### PR TITLE
Support for edge multiplicities in brandes_betweenness_centrality

### DIFF
--- a/doc/betweenness_centrality.html
+++ b/doc/betweenness_centrality.html
@@ -59,7 +59,8 @@ brandes_betweenness_centrality(const Graph&amp; g, CentralityMap centrality_map,
 
 template&lt;typename Graph, typename CentralityMap, typename EdgeCentralityMap,
          typename IncomingMap, typename DistanceMap, typename DependencyMap, 
-         typename PathCountMap, typename VertexIndexMap, typename WeightMap&gt;    
+         typename PathCountMap, typename VertexIndexMap, typename WeightMap,
+         typename MultiplicityMap&gt;
 void 
 brandes_betweenness_centrality(const Graph&amp; g, CentralityMap centrality_map,
                                EdgeCentralityMap edge_centrality,
@@ -289,7 +290,7 @@ IN: <tt>weight_map(WeightMap weight_map)</tt>
   The weight or ``length'' of each edge in the graph. The weights
   must all be non-negative, and the algorithm will throw a
   <a href="./exception.html#negative_edge"><tt>negative_edge</tt></a> 
-  exception is one of the edges is negative.
+  exception if one of the edges is negative.
   The type <tt>WeightMap</tt> must be a model of
   <a href="../../property_map/doc/ReadablePropertyMap.html">Readable Property Map</a>. The edge descriptor type of
   the graph needs to be usable as the key type for the weight
@@ -303,8 +304,8 @@ IN: <tt>multiplicity_map(MultiplicityMap multiplicity_map)</tt>
 <blockquote>
   The multiplicity of each edge in the graph. The multiplicities
   must all be positive, and the algorithm will throw a
-  <a href="./exception.html#negative_edge"><tt>negative_edge</tt></a> 
-  exception is one of the edges is non-positive.
+  <a href="./exception.html#nonpositive_edge"><tt>nonpositive_edge</tt></a> 
+  exception if one of the edges is non-positive.
   The type <tt>MultiplicityMap</tt> must be a model of
   <a href="../../property_map/doc/ReadablePropertyMap.html">Readable Property Map</a>. The edge descriptor type of
   the graph needs to be usable as the key type for the multiplicity

--- a/doc/betweenness_centrality.html
+++ b/doc/betweenness_centrality.html
@@ -57,6 +57,19 @@ brandes_betweenness_centrality(const Graph&amp; g, CentralityMap centrality_map,
                                VertexIndexMap vertex_index,
                                WeightMap weight_map);
 
+template&lt;typename Graph, typename CentralityMap, typename EdgeCentralityMap,
+         typename IncomingMap, typename DistanceMap, typename DependencyMap, 
+         typename PathCountMap, typename VertexIndexMap, typename WeightMap&gt;    
+void 
+brandes_betweenness_centrality(const Graph&amp; g, CentralityMap centrality_map,
+                               EdgeCentralityMap edge_centrality,
+                               IncomingMap incoming, 
+                               DistanceMap distance,  DependencyMap dependency,
+                               PathCountMap path_count,      
+                               VertexIndexMap vertex_index,
+                               WeightMap weight_map,
+                               MultiplicityMap multiplicity_map);
+
 <em>// helper functions</em>
 template&lt;typename Graph, typename CentralityMap&gt;
 void 
@@ -271,7 +284,7 @@ IN: <tt>vertex_index_map(VertexIndexMap vertex_index)</tt>
   <b>Python</b>: Unsupported parameter.
 </blockquote>
 
-IN: <tt>weight_map(WeightMap w_map)</tt>   
+IN: <tt>weight_map(WeightMap weight_map)</tt>   
 <blockquote>
   The weight or ``length'' of each edge in the graph. The weights
   must all be non-negative, and the algorithm will throw a
@@ -284,6 +297,21 @@ IN: <tt>weight_map(WeightMap w_map)</tt>
   the same as the value type of the distance map.<br>
   <b>Default:</b> All edge weights are assumed to be equivalent.
   <b>Python</b>: If supplied, must be an <tt>edge_double_map</tt> for the graph.
+</blockquote>
+
+IN: <tt>multiplicity_map(MultiplicityMap multiplicity_map)</tt>   
+<blockquote>
+  The multiplicity of each edge in the graph. The multiplicities
+  must all be positive, and the algorithm will throw a
+  <a href="./exception.html#negative_edge"><tt>negative_edge</tt></a> 
+  exception is one of the edges is non-positive.
+  The type <tt>MultiplicityMap</tt> must be a model of
+  <a href="../../property_map/doc/ReadablePropertyMap.html">Readable Property Map</a>. The edge descriptor type of
+  the graph needs to be usable as the key type for the multiplicity
+  map. The value type for this map must be
+  the same as the value type of the distance map.<br>
+  <b>Default:</b> All edge multiplicities are assumed to be one.
+  <b>Python</b>: Unsupported parameter.
 </blockquote>
 
 <h3>Complexity</h3> 

--- a/doc/exception.html
+++ b/doc/exception.html
@@ -34,7 +34,10 @@ appropriate exception.
   struct <a name="not_a_dag">not_a_dag</a> : public bad_graph {
     not_a_dag();
   };
-  struct <a name="negative_edge">negative_edge</a> : public bad_graph {
+  struct <a name="nonpositive_edge">nonpositive_edge</a> : public bad_graph {
+    negative_edge();
+  };
+  struct <a name="negative_edge">negative_edge</a> : public nonpositive_edge {
     negative_edge();
   };
   struct <a name="negative_cycle">negative_cycle</a> : public bad_graph {

--- a/include/boost/graph/betweenness_centrality.hpp
+++ b/include/boost/graph/betweenness_centrality.hpp
@@ -344,13 +344,10 @@ namespace detail { namespace graph {
     }
   }
 
-  template<typename PropertyMap, typename Graph>
-  inline boost::static_property_map<typename property_traits<PropertyMap>::value_type,
-                                    typename graph_traits<Graph>::edge_descriptor>
-  make_static_one_property(const Graph& g) {
-    typedef typename graph_traits<Graph>::edge_descriptor edge_descriptor;
-    typedef typename property_traits<PropertyMap>::value_type property_type;
-    return boost::make_static_property_map<edge_descriptor, property_type>(property_type(1));
+  template<typename Number>
+  inline Number
+  one() {
+    return Number(1);
   }
 
   template<typename Graph, typename CentralityMap, typename EdgeCentralityMap,
@@ -369,12 +366,9 @@ namespace detail { namespace graph {
                                       ShortestPaths shortest_paths)
   {
     // default constant multiplicity of one
-    typedef typename graph_traits<Graph>::edge_descriptor edge_descriptor;
     typedef typename property_traits<PathCountMap>::value_type multiplicity_type;
-    typedef static_property_map<multiplicity_type, edge_descriptor> MultiplicityMap;
-
-    MultiplicityMap multiplicity_map =
-        detail::graph::make_static_one_property<MultiplicityMap>(g);
+    typedef static_property_map<multiplicity_type> MultiplicityMap;
+    MultiplicityMap multiplicity_map(detail::graph::one<multiplicity_type>());
 
     brandes_betweenness_centrality_impl(g, centrality, edge_centrality_map,
                                         incoming, distance, dependency,
@@ -478,12 +472,9 @@ brandes_betweenness_centrality(const Graph& g,
                                BOOST_GRAPH_ENABLE_IF_MODELS_PARM(Graph,vertex_list_graph_tag))
 {
   // default constant multiplicity of one
-  typedef typename graph_traits<Graph>::edge_descriptor edge_descriptor;
   typedef typename property_traits<PathCountMap>::value_type multiplicity_type;
-  typedef static_property_map<multiplicity_type, edge_descriptor> MultiplicityMap;
-
-  MultiplicityMap multiplicity_map =
-      detail::graph::make_static_one_property<MultiplicityMap>(g);
+  typedef static_property_map<multiplicity_type> MultiplicityMap;
+  MultiplicityMap multiplicity_map(detail::graph::one<multiplicity_type>());
 
   detail::graph::brandes_unweighted_shortest_paths<MultiplicityMap>
     shortest_paths(multiplicity_map);
@@ -513,12 +504,9 @@ brandes_betweenness_centrality(const Graph& g,
                                BOOST_GRAPH_ENABLE_IF_MODELS_PARM(Graph,vertex_list_graph_tag))
 {
   // default constant multiplicity of one
-  typedef typename graph_traits<Graph>::edge_descriptor edge_descriptor;
   typedef typename property_traits<PathCountMap>::value_type multiplicity_type;
-  typedef static_property_map<multiplicity_type, edge_descriptor> MultiplicityMap;
-
-  MultiplicityMap multiplicity_map =
-      detail::graph::make_static_one_property<MultiplicityMap>(g);
+  typedef static_property_map<multiplicity_type> MultiplicityMap;
+  MultiplicityMap multiplicity_map(detail::graph::one<multiplicity_type>());
 
   brandes_betweenness_centrality(g, centrality, edge_centrality_map,
                                  incoming, distance, dependency, path_count,
@@ -654,16 +642,12 @@ namespace detail { namespace graph {
         WeightMap weight_map, param_not_found)
     {
       // default constant multiplicity of one
-      typedef typename graph_traits<Graph>::edge_descriptor edge_descriptor;
-      typedef typename mpl::if_c<(is_same<CentralityMap, 
-                                          dummy_property_map>::value),
-                                           EdgeCentralityMap, 
-                                  CentralityMap>::type a_centrality_map;
+      typedef typename mpl::if_<is_same<CentralityMap, dummy_property_map>,
+                                EdgeCentralityMap, CentralityMap>::type
+                                a_centrality_map;
       typedef typename property_traits<a_centrality_map>::value_type multiplicity_type;
-      typedef static_property_map<multiplicity_type, edge_descriptor> MultiplicityMap;
-
-      MultiplicityMap multiplicity_map =
-          detail::graph::make_static_one_property<MultiplicityMap>(g);
+      typedef static_property_map<multiplicity_type> MultiplicityMap;
+      MultiplicityMap multiplicity_map(detail::graph::one<multiplicity_type>());
 
       brandes_betweenness_centrality_dispatch2(g, centrality, edge_centrality_map,
                                                weight_map, multiplicity_map,

--- a/include/boost/graph/betweenness_centrality.hpp
+++ b/include/boost/graph/betweenness_centrality.hpp
@@ -483,7 +483,7 @@ brandes_betweenness_centrality(const Graph& g,
   typedef static_property_map<multiplicity_type, edge_descriptor> MultiplicityMap;
 
   MultiplicityMap multiplicity_map =
-      detail::graph::make_static_one_property<multiplicity_type>(g);
+      detail::graph::make_static_one_property<MultiplicityMap>(g);
 
   detail::graph::brandes_unweighted_shortest_paths<MultiplicityMap>
     shortest_paths(multiplicity_map);

--- a/include/boost/graph/betweenness_centrality.hpp
+++ b/include/boost/graph/betweenness_centrality.hpp
@@ -344,12 +344,6 @@ namespace detail { namespace graph {
     }
   }
 
-  template<typename Number>
-  inline Number
-  one() {
-    return Number(1);
-  }
-
   template<typename Graph, typename CentralityMap, typename EdgeCentralityMap,
            typename IncomingMap, typename DistanceMap, 
            typename DependencyMap, typename PathCountMap,
@@ -368,7 +362,7 @@ namespace detail { namespace graph {
     // default constant multiplicity of one
     typedef typename property_traits<PathCountMap>::value_type multiplicity_type;
     typedef static_property_map<multiplicity_type> MultiplicityMap;
-    MultiplicityMap multiplicity_map(detail::graph::one<multiplicity_type>());
+    MultiplicityMap multiplicity_map(multiplicity_type(1));
 
     brandes_betweenness_centrality_impl(g, centrality, edge_centrality_map,
                                         incoming, distance, dependency,
@@ -474,7 +468,7 @@ brandes_betweenness_centrality(const Graph& g,
   // default constant multiplicity of one
   typedef typename property_traits<PathCountMap>::value_type multiplicity_type;
   typedef static_property_map<multiplicity_type> MultiplicityMap;
-  MultiplicityMap multiplicity_map(detail::graph::one<multiplicity_type>());
+  MultiplicityMap multiplicity_map(multiplicity_type(1));
 
   detail::graph::brandes_unweighted_shortest_paths<MultiplicityMap>
     shortest_paths(multiplicity_map);
@@ -506,7 +500,7 @@ brandes_betweenness_centrality(const Graph& g,
   // default constant multiplicity of one
   typedef typename property_traits<PathCountMap>::value_type multiplicity_type;
   typedef static_property_map<multiplicity_type> MultiplicityMap;
-  MultiplicityMap multiplicity_map(detail::graph::one<multiplicity_type>());
+  MultiplicityMap multiplicity_map(multiplicity_type(1));
 
   brandes_betweenness_centrality(g, centrality, edge_centrality_map,
                                  incoming, distance, dependency, path_count,
@@ -647,7 +641,7 @@ namespace detail { namespace graph {
                                 a_centrality_map;
       typedef typename property_traits<a_centrality_map>::value_type multiplicity_type;
       typedef static_property_map<multiplicity_type> MultiplicityMap;
-      MultiplicityMap multiplicity_map(detail::graph::one<multiplicity_type>());
+      MultiplicityMap multiplicity_map(multiplicity_type(1));
 
       brandes_betweenness_centrality_dispatch2(g, centrality, edge_centrality_map,
                                                weight_map, multiplicity_map,

--- a/include/boost/graph/exception.hpp
+++ b/include/boost/graph/exception.hpp
@@ -26,9 +26,18 @@ namespace boost {
         { }
     };
 
-    struct negative_edge : public bad_graph {
+    struct nonpositive_edge : public bad_graph {
+        nonpositive_edge()
+            : bad_graph("The graph may not contain an edge with non-positive weight.")
+        { }
+      protected:
+        nonpositive_edge(const std::string& what_arg)
+            : bad_graph(what_arg) { }
+    };
+
+    struct negative_edge : public nonpositive_edge {
         negative_edge()
-            : bad_graph("The graph may not contain an edge with negative weight.")
+            : nonpositive_edge("The graph may not contain an edge with negative weight.")
         { }
     };
 

--- a/include/boost/graph/named_function_params.hpp
+++ b/include/boost/graph/named_function_params.hpp
@@ -28,6 +28,7 @@
 namespace boost {
 
   struct parity_map_t { };
+  struct edge_multiplicity_t { };
   struct vertex_assignment_map_t { };
   struct distance_compare_t { };
   struct distance_combine_t { };
@@ -76,6 +77,7 @@ namespace boost {
     BOOST_BGL_ONE_PARAM_CREF(edge_color_map, edge_color) \
     BOOST_BGL_ONE_PARAM_CREF(capacity_map, edge_capacity) \
     BOOST_BGL_ONE_PARAM_CREF(residual_capacity_map, edge_residual_capacity) \
+    BOOST_BGL_ONE_PARAM_CREF(multiplicity_map, edge_multiplicity) \
     BOOST_BGL_ONE_PARAM_CREF(reverse_edge_map, edge_reverse) \
     BOOST_BGL_ONE_PARAM_CREF(discover_time_map, vertex_discover_time) \
     BOOST_BGL_ONE_PARAM_CREF(lowpoint_map, vertex_lowpoint) \

--- a/quickbook/reference/betweenness_centrality.qbk
+++ b/quickbook/reference/betweenness_centrality.qbk
@@ -182,4 +182,20 @@ interface.
                                    VertexIndexMap vertex_index,
                                    WeightMap weight_map)
 
+    template<typename Graph, typename CentralityMap, typename EdgeCentralityMap,
+             typename IncomingMap, typename DistanceMap, typename DependencyMap,
+             typename PathCountMap, typename VertexIndexMap, typename WeightMap,
+             typename MultiplicityMap>
+    void
+    brandes_betweenness_centrality(const Graph& g,
+                                   CentralityMap centrality,
+                                   EdgeCentralityMap edge_centrality,
+                                   IncomingMap incoming,
+                                   DistanceMap distance,
+                                   DependencyMap dependency,
+                                   PathCountMap path_count,
+                                   VertexIndexMap vertex_index,
+                                   WeightMap weight_map,
+                                   MultiplicityMap multiplicity_map)
+
 [endsect]


### PR DESCRIPTION
[Ticket #9935](https://svn.boost.org/trac/boost/ticket/9935)
Implemented support for edges multiplicities in betweenness calculation. As explained in the ticket, the algorithm variation is taken from Ulrik Brandes' paper [On variants of shortest-path betweenness centrality and their generic computation](http://www.inf.uni-konstanz.de/algo/publications/b-vspbc-08.pdf), section 3.8, algorithm 11. Please note that this paper has a mistake on this algorithm, as explained in [Brandes' publications web page](http://www.inf.uni-konstanz.de/~brandes/publications/) - this patch implements the corrected algorithm.
Note this implementation uses `static_property_map` and `make_static_property_map`, which are currently in the develop branch of the property_map library.

**Note:** This PR cause compilation error when using `non_distributed_betweenness` centrality from graph-parallel. [PR #2 in that library](https://github.com/boostorg/graph_parallel/pull/2) fix these errors, while adding the multiplicity feature to that version of the algorithm.
