### PR TITLE
Fix compilation with gcc 4.4 in C++11 mode

### DIFF
--- a/include/boost/graph/detail/adjacency_list.hpp
+++ b/include/boost/graph/detail/adjacency_list.hpp
@@ -308,9 +308,9 @@ namespace boost {
         m_property = std::move(x.m_property);
         return *this;
       }
-      self& operator=(self& x) {
+      self& operator=(self const& x) {
         Base::operator=(static_cast< Base const& >(x));
-        m_property = std::move(x.m_property);
+        m_property = std::move(const_cast<self&>(x).m_property);
         return *this;
       }
 #else


### PR DESCRIPTION
Add constructor and assignment operator implementations for gcc 4.4 since it does not support defaulted move constructors and assignment. The operators are also used for gcc 4.5 for good measure (I cannot test it but gcc 4.6 does not need this workaround).

Also the workaround is used for MSVC as well. The previous MSVC branch was incorrect since it did not invoke base class constructors and assignment.

See the "[1.56.0] Release candidates available" discussion on the ML for the original compilation error.
