### PR TITLE
Fix missing #include causing compilation errors

### DIFF
--- a/include/boost/graph/detail/edge.hpp
+++ b/include/boost/graph/detail/edge.hpp
@@ -13,6 +13,8 @@
 
 #include <iosfwd>
 
+#include <boost/functional/hash.hpp>
+
 namespace boost {
 
   namespace  detail {


### PR DESCRIPTION
I had trouble compiling this simple program and traced it down to a missing include.
The error occurs in both, boost 1.56.0 and the current develop branch.

```
#include <boost/graph/adjacency_matrix.hpp>

int main(void) {
}
```
