### PR TITLE
Update attribute delimiter for read_graphviz

### DIFF
--- a/src/read_graphviz_new.cpp
+++ b/src/read_graphviz_new.cpp
@@ -726,8 +726,8 @@ namespace read_graphviz_detail {
             }
             default: error("Wanted identifier as name of attribute");
           }
-          if (peek().type == token::comma) {get(); continue;}
-          break;
+          if (peek().type == token::comma || peek().type == token::semicolon) get();
+          else if(peek().type == token::right_bracket) break;
         }
         if (peek().type == token::right_bracket) get(); else error("Wanted right bracket to end attribute list");
         if (peek().type != token::left_bracket) break;


### PR DESCRIPTION
Support semicolon and nothing as ending of attributes, in addition to comma. See http://graphviz.org/content/dot-language.
