### PR TITLE
VF2, fix assumption that index maps are default constructible.

### DIFF
--- a/include/boost/graph/vf2_sub_graph_iso.hpp
+++ b/include/boost/graph/vf2_sub_graph_iso.hpp
@@ -113,16 +113,13 @@ namespace boost {
                  IndexMapThis index_map_this, IndexMapOther index_map_other)
         : graph_this_(graph_this), graph_other_(graph_other), 
           index_map_this_(index_map_this), index_map_other_(index_map_other), 
+          core_vec_(num_vertices(graph_this_), graph_traits<GraphOther>::null_vertex()),
+          core_(core_vec_.begin(), index_map_this_),
+          in_vec_(num_vertices(graph_this_), 0),
+          out_vec_(num_vertices(graph_this_), 0),
+          in_(in_vec_.begin(), index_map_this_),
+          out_(out_vec_.begin(), index_map_this_),
           term_in_count_(0), term_out_count_(0), term_both_count_(0), core_count_(0) {
-
-        core_vec_.resize(num_vertices(graph_this_), graph_traits<GraphOther>::null_vertex());
-        core_ = make_iterator_property_map(core_vec_.begin(), index_map_this_);
-
-        in_vec_.resize(num_vertices(graph_this_), 0);
-        in_ = make_iterator_property_map(in_vec_.begin(), index_map_this_);
-
-        out_vec_.resize(num_vertices(graph_this_), 0);
-        out_ = make_iterator_property_map(out_vec_.begin(), index_map_this_);
       }
 
       // Adds a vertex pair to the state of graph graph_this

--- a/test/vf2_sub_graph_iso_test.cpp
+++ b/test/vf2_sub_graph_iso_test.cpp
@@ -170,6 +170,23 @@ private:
   bool output_;
 };
 
+// we pretend this is something more complicated which calculates indices somehow
+template<typename G>
+struct IndirectIndexMap {
+  typedef std::size_t value_type;
+  typedef value_type reference;
+  typedef typename boost::graph_traits<G>::vertex_descriptor key_type;
+  typedef boost::readable_property_map_tag category;
+  explicit IndirectIndexMap(const G &g) : g(g) {}
+public:
+  const G &g;
+};
+
+template<typename G>
+std::size_t get(const IndirectIndexMap<G> &map, typename boost::graph_traits<G>::vertex_descriptor v) {
+  // we pretend this is something more complicated which calculates indices somehow
+  return get(vertex_index_t(), map.g, v);
+}
 
 void test_vf2_sub_graph_iso(int n1, int n2, double edge_probability, 
                             int max_parallel_edges, double parallel_edge_probability,
@@ -219,6 +236,11 @@ void test_vf2_sub_graph_iso(int n1, int n2, double edge_probability,
   std::cout << std::endl;
   BOOST_CHECK(vf2_subgraph_iso(g1, g2, callback, vertex_order_by_mult(g1),
                                edges_equivalent(edge_comp).vertices_equivalent(vertex_comp)));
+  BOOST_CHECK(vf2_subgraph_iso(g1, g2, callback,
+                               IndirectIndexMap<graph1>(g1),
+                               IndirectIndexMap<graph2>(g2),
+                               vertex_order_by_mult(g1),
+                               edge_comp, vertex_comp));
 
   std::clock_t end1 = std::clock();
   std::cout << "vf2_subgraph_iso: elapsed time (clock cycles): " << (end1 - start) << std::endl;


### PR DESCRIPTION
The fix moves construction of some internal data structures into the relevant initialization list. The added test case triggers the issue in the previous revisions.
