### PR TITLE
Make it clearer that when tree_edge is called

### DIFF
--- a/doc/breadth_first_search.html
+++ b/doc/breadth_first_search.html
@@ -270,7 +270,8 @@ The time complexity is <i>O(E + V)</i>.
 
 <li><b><tt>vis.tree_edge(e, g)</tt></b> is invoked (in addition to
   <tt>examine_edge()</tt>) if the edge is a tree edge. The
-  target vertex of edge <tt>e</tt> is discovered at this time.
+  target vertex of edge <tt>e</tt> is discovered at this time after this
+  function is called.
 
 <li><b><tt>vis.discover_vertex(u, g)</tt></b> is invoked the first time the
   algorithm encounters vertex <i>u</i>. All vertices closer to the

--- a/doc/depth_first_search.html
+++ b/doc/depth_first_search.html
@@ -261,7 +261,8 @@ The time complexity is <i>O(E + V)</i>.
 
 <li><b><tt>vis.tree_edge(e, g)</tt></b> is invoked on each edge as it
   becomes a member of the edges that form the search tree. If you
-  wish to record predecessors, do so at this event point.
+  wish to record predecessors, do so at this event point. The target
+  vertex is discovered after this function is called.
   
 <li><b><tt>vis.back_edge(e, g)</tt></b> is invoked on the back edges in
   the graph.


### PR DESCRIPTION
tree_edge function is called before the target vertex is discovered, so users should be acknoledged that at this moment, the target's color is still white.

---

There may be a more proper way to fix the document, but I think the original version is confusing, as the target is actually still white.