### PR TITLE
Fix MSVC14 compile break

### DIFF
--- a/include/boost/graph/detail/array_binary_tree.hpp
+++ b/include/boost/graph/detail/array_binary_tree.hpp
@@ -63,6 +63,9 @@ public:
       inline iterator& operator++() { ++i; return *this; }
       inline iterator operator++(int)
         { iterator t = *this; ++(*this); return t; }
+      inline iterator& operator--() { --i; return *this; }
+      inline iterator operator--(int)
+        { iterator t = *this; --(*this); return t; }
       inline bool operator==(const iterator& x) const { return i == x.i; }
       inline bool operator!=(const iterator& x) const
         { return !(*this == x); }


### PR DESCRIPTION
array_binary_tree_node::children_type::iterator pretends to be a bidirectional iterator but does not define operator--, which results in compile breaks with Visual C++ 2015:
http://www.boost.org/development/tests/develop/developer/output/teeks99-08f-win2012R2-64on64-boost-bin-v2-libs-graph-test-dijkstra_heap_performance-test-msvc-14-0-debug-threading-multi.html