### PR TITLE
C std headers

### DIFF
--- a/example/astar-cities.cpp
+++ b/example/astar-cities.cpp
@@ -21,7 +21,7 @@
 #include <list>
 #include <iostream>
 #include <fstream>
-#include <math.h>    // for sqrt
+#include <cmath>    // for sqrt
 
 using namespace boost;
 using namespace std;
@@ -111,7 +111,7 @@ private:
 
 int main(int argc, char **argv)
 {
-  
+
   // specify some types
   typedef adjacency_list<listS, vecS, undirectedS, no_property,
     property<edge_weight_t, cost> > mygraph_t;
@@ -119,7 +119,7 @@ int main(int argc, char **argv)
   typedef mygraph_t::vertex_descriptor vertex;
   typedef mygraph_t::edge_descriptor edge_descriptor;
   typedef std::pair<int, int> edge;
-  
+
   // specify data
   enum nodes {
     Troy, LakePlacid, Plattsburgh, Massena, Watertown, Utica,
@@ -156,8 +156,8 @@ int main(int argc, char **argv)
     96, 134, 143, 65, 115, 133, 117, 116, 74, 56,
     84, 73, 69, 70, 116, 147, 173, 183, 74, 71, 124
   };
-  
-  
+
+
   // create graph
   mygraph_t g(N);
   WeightMap weightmap = get(edge_weight, g);
@@ -167,17 +167,17 @@ int main(int argc, char **argv)
                                        edge_array[j].second, g);
     weightmap[e] = weights[j];
   }
-  
-  
+
+
   // pick random start/goal
   boost::mt19937 gen(time(0));
   vertex start = random_vertex(g, gen);
   vertex goal = random_vertex(g, gen);
-  
-  
+
+
   cout << "Start vertex: " << name[start] << endl;
   cout << "Goal vertex: " << name[goal] << endl;
-  
+
   ofstream dotfile;
   dotfile.open("test-astar-cities.dot");
   write_graphviz(dotfile, g,
@@ -185,8 +185,8 @@ int main(int argc, char **argv)
                   (name, locations, 73.46, 78.86, 40.67, 44.93,
                    480, 400),
                  time_writer<WeightMap>(weightmap));
-  
-  
+
+
   vector<mygraph_t::vertex_descriptor> p(num_vertices(g));
   vector<cost> d(num_vertices(g));
   try {
@@ -198,8 +198,8 @@ int main(int argc, char **argv)
        predecessor_map(make_iterator_property_map(p.begin(), get(vertex_index, g))).
        distance_map(make_iterator_property_map(d.begin(), get(vertex_index, g))).
        visitor(astar_goal_visitor<vertex>(goal)));
-  
-  
+
+
   } catch(found_goal fg) { // found a path to the goal
     list<vertex> shortest_path;
     for(vertex v = goal;; v = p[v]) {
@@ -216,9 +216,9 @@ int main(int argc, char **argv)
     cout << endl << "Total travel time: " << d[goal] << endl;
     return 0;
   }
-  
+
   cout << "Didn't find a path from " << name[start] << "to"
        << name[goal] << "!" << endl;
   return 0;
-  
+
 }

--- a/example/bucket_sorter.cpp
+++ b/example/bucket_sorter.cpp
@@ -10,7 +10,7 @@
 #include <vector>
 #include <iostream>
 
-#include <stdlib.h>
+#include <cstdlib>
 #include <boost/pending/bucket_sorter.hpp>
 
 template <class Integral>
@@ -27,7 +27,7 @@ struct trivial_id {
 int main() {
   using namespace std;
   using boost::bucket_sorter;
-  
+
   const std::size_t N = 10;
 
   vector<std::size_t> bucket(N);
@@ -38,13 +38,13 @@ int main() {
   }
 
   typedef trivial_id<int> ID;
-  typedef bucket_sorter<std::size_t, int, 
+  typedef bucket_sorter<std::size_t, int,
     vector<std::size_t>::iterator, ID> BS;
   BS my_bucket_sorter(N, N, bucket.begin());
 
   for (std::size_t ii=0; ii<N; ii++)
     my_bucket_sorter.push(ii);
-    
+
   std::size_t j;
   for (j=0; j<N; j++) {
     cout << "The bucket " << j;

--- a/example/dfs.cpp
+++ b/example/dfs.cpp
@@ -7,13 +7,12 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 //=======================================================================
 #include <boost/config.hpp>
-#include <assert.h>
+#include <cassert>
 #include <iostream>
 
 #include <vector>
 #include <algorithm>
 #include <utility>
-
 
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/depth_first_search.hpp>
@@ -75,12 +74,12 @@ struct edge_categorizer : public dfs_visitor<VisitorList> {
          << " --> " <<  target(e, G) << endl;
     Base::forward_or_cross_edge(e, G);
   }
-  template <class Edge, class Graph> 
-  void finish_edge(Edge e, Graph& G) { 
-    cout << "Finish edge: " << source(e, G) << 
-      " --> " <<  target(e, G) << endl; 
-    Base::finish_edge(e, G); 
-  } 
+  template <class Edge, class Graph>
+  void finish_edge(Edge e, Graph& G) {
+    cout << "Finish edge: " << source(e, G) <<
+      " --> " <<  target(e, G) << endl;
+    Base::finish_edge(e, G);
+  }
 };
 template <class VisitorList>
 edge_categorizer<VisitorList>
@@ -88,14 +87,14 @@ categorize_edges(const VisitorList& v) {
   return edge_categorizer<VisitorList>(v);
 }
 
-int 
+int
 main(int , char* [])
 {
 
   using namespace boost;
-  
+
   typedef adjacency_list<> Graph;
-  
+
   Graph G(5);
   add_edge(0, 2, G);
   add_edge(1, 1, G);
@@ -110,7 +109,7 @@ main(int , char* [])
   typedef graph_traits<Graph>::vertex_descriptor Vertex;
   typedef graph_traits<Graph>::vertices_size_type size_type;
 
-  std::vector<size_type> d(num_vertices(G));  
+  std::vector<size_type> d(num_vertices(G));
   std::vector<size_type> f(num_vertices(G));
   int t = 0;
   depth_first_search(G, visitor(categorize_edges(
@@ -123,4 +122,3 @@ main(int , char* [])
 
   return 0;
 }
-

--- a/example/dfs_parenthesis.cpp
+++ b/example/dfs_parenthesis.cpp
@@ -12,7 +12,7 @@
 //  (0(2(3(4(11)4)3)2)0)
 
 #include <boost/config.hpp>
-#include <assert.h>
+#include <cassert>
 #include <iostream>
 
 #include <vector>
@@ -43,19 +43,19 @@ struct close_paren : public base_visitor<close_paren> {
 };
 
 
-int 
+int
 main(int, char*[])
 {
 
   using namespace boost;
-  
+
   typedef adjacency_list<> Graph;
   typedef std::pair<int,int> E;
   E edge_array[] = { E(0, 2),
                 E(1, 1), E(1, 3),
                 E(2, 1), E(2, 3),
                 E(3, 1), E(3, 4),
-                E(4, 0), E(4, 1) };  
+                E(4, 0), E(4, 1) };
 #if defined(BOOST_MSVC) && BOOST_MSVC <= 1300
   Graph G(5);
   for (std::size_t j = 0; j < sizeof(edge_array) / sizeof(E); ++j)
@@ -66,11 +66,10 @@ main(int, char*[])
 
   typedef boost::graph_traits<Graph>::vertex_descriptor Vertex;
   typedef boost::graph_traits<Graph>::vertices_size_type size_type;
-  
+
   std::cout << "DFS parenthesis:" << std::endl;
-  depth_first_search(G, visitor(make_dfs_visitor(std::make_pair(open_paren(), 
+  depth_first_search(G, visitor(make_dfs_visitor(std::make_pair(open_paren(),
                                                         close_paren()))));
   std::cout << std::endl;
   return 0;
 }
-

--- a/example/file_dependencies.cpp
+++ b/example/file_dependencies.cpp
@@ -32,7 +32,7 @@
 #include <iostream>
 #include <iterator>
 #include <algorithm>
-#include <time.h>
+#include <ctime>
 
 #include <boost/utility.hpp>
 #include <boost/graph/adjacency_list.hpp>
@@ -44,9 +44,9 @@
 using namespace std;
 using namespace boost;
 
-enum files_e { dax_h, yow_h, boz_h, zow_h, foo_cpp, 
+enum files_e { dax_h, yow_h, boz_h, zow_h, foo_cpp,
                foo_o, bar_cpp, bar_o, libfoobar_a,
-               zig_cpp, zig_o, zag_cpp, zag_o, 
+               zig_cpp, zig_o, zag_cpp, zag_o,
                  libzigzag_a, killerapp, N };
 const char* name[] = { "dax.h", "yow.h", "boz.h", "zow.h", "foo.cpp",
                        "foo.o", "bar.cpp", "bar.o", "libfoobar.a",
@@ -64,7 +64,7 @@ struct print_visitor : public bfs_visitor<> {
 
 struct cycle_detector : public dfs_visitor<>
 {
-  cycle_detector(bool& has_cycle) 
+  cycle_detector(bool& has_cycle)
     : m_has_cycle(has_cycle) { }
 
   template <class Edge, class Graph>
@@ -84,7 +84,7 @@ int main(int,char*[])
     Edge(dax_h, foo_cpp), Edge(dax_h, bar_cpp), Edge(dax_h, yow_h),
     Edge(yow_h, bar_cpp), Edge(yow_h, zag_cpp),
     Edge(boz_h, bar_cpp), Edge(boz_h, zig_cpp), Edge(boz_h, zag_cpp),
-    Edge(zow_h, foo_cpp), 
+    Edge(zow_h, foo_cpp),
     Edge(foo_cpp, foo_o),
     Edge(foo_o, libfoobar_a),
     Edge(bar_cpp, bar_o),
@@ -121,19 +121,19 @@ int main(int,char*[])
     topological_sort(g, std::front_inserter(make_order));
     cout << "make ordering: ";
     for (i = make_order.begin();
-         i != make_order.end(); ++i) 
+         i != make_order.end(); ++i)
       cout << name[*i] << " ";
-  
+
     cout << endl << endl;
 
     // Parallel compilation ordering
     std::vector<int> time(N, 0);
-    for (i = make_order.begin(); i != make_order.end(); ++i) {    
+    for (i = make_order.begin(); i != make_order.end(); ++i) {
       // Walk through the in_edges an calculate the maximum time.
       if (in_degree (*i, g) > 0) {
         Graph::in_edge_iterator j, j_end;
         int maxdist=0;
-        // Through the order from topological sort, we are sure that every 
+        // Through the order from topological sort, we are sure that every
         // time we are using here is already initialized.
         for (boost::tie(j, j_end) = in_edges(*i, g); j != j_end; ++j)
           maxdist=(std::max)(time[source(*j, g)], maxdist);

--- a/example/iohb.h
+++ b/example/iohb.h
@@ -1,4 +1,4 @@
-//  (C) Copyright Jeremy Siek 2004 
+//  (C) Copyright Jeremy Siek 2004
 //  Distributed under the Boost Software License, Version 1.0. (See
 //  accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
@@ -6,55 +6,55 @@
 #ifndef IOHB_H
 #define IOHB_H
 
-#include<stdio.h>
-#include<stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-int readHB_info(const char* filename, int* M, int* N, int* nz, char** Type, 
+int readHB_info(const char* filename, int* M, int* N, int* nz, char** Type,
                                                       int* Nrhs);
 
-int readHB_header(FILE* in_file, char* Title, char* Key, char* Type, 
+int readHB_header(FILE* in_file, char* Title, char* Key, char* Type,
                     int* Nrow, int* Ncol, int* Nnzero, int* Nrhs,
-                    char* Ptrfmt, char* Indfmt, char* Valfmt, char* Rhsfmt, 
-                    int* Ptrcrd, int* Indcrd, int* Valcrd, int* Rhscrd, 
+                    char* Ptrfmt, char* Indfmt, char* Valfmt, char* Rhsfmt,
+                    int* Ptrcrd, int* Indcrd, int* Valcrd, int* Rhscrd,
                     char *Rhstype);
 
-int readHB_mat_double(const char* filename, int colptr[], int rowind[], 
+int readHB_mat_double(const char* filename, int colptr[], int rowind[],
                                                                  double val[]);
 
-int readHB_newmat_double(const char* filename, int* M, int* N, int* nonzeros, 
+int readHB_newmat_double(const char* filename, int* M, int* N, int* nonzeros,
                          int** colptr, int** rowind, double** val);
 
 int readHB_aux_double(const char* filename, const char AuxType, double b[]);
 
 int readHB_newaux_double(const char* filename, const char AuxType, double** b);
 
-int writeHB_mat_double(const char* filename, int M, int N, 
-                        int nz, const int colptr[], const int rowind[], 
-                        const double val[], int Nrhs, const double rhs[], 
+int writeHB_mat_double(const char* filename, int M, int N,
+                        int nz, const int colptr[], const int rowind[],
+                        const double val[], int Nrhs, const double rhs[],
                         const double guess[], const double exact[],
-                        const char* Title, const char* Key, const char* Type, 
+                        const char* Title, const char* Key, const char* Type,
                         char* Ptrfmt, char* Indfmt, char* Valfmt, char* Rhsfmt,
                         const char* Rhstype);
 
-int readHB_mat_char(const char* filename, int colptr[], int rowind[], 
+int readHB_mat_char(const char* filename, int colptr[], int rowind[],
                                            char val[], char* Valfmt);
 
-int readHB_newmat_char(const char* filename, int* M, int* N, int* nonzeros, int** colptr, 
+int readHB_newmat_char(const char* filename, int* M, int* N, int* nonzeros, int** colptr,
                           int** rowind, char** val, char** Valfmt);
 
 int readHB_aux_char(const char* filename, const char AuxType, char b[]);
 
 int readHB_newaux_char(const char* filename, const char AuxType, char** b, char** Rhsfmt);
 
-int writeHB_mat_char(const char* filename, int M, int N, 
-                        int nz, const int colptr[], const int rowind[], 
-                        const char val[], int Nrhs, const char rhs[], 
-                        const char guess[], const char exact[], 
-                        const char* Title, const char* Key, const char* Type, 
+int writeHB_mat_char(const char* filename, int M, int N,
+                        int nz, const int colptr[], const int rowind[],
+                        const char val[], int Nrhs, const char rhs[],
+                        const char guess[], const char exact[],
+                        const char* Title, const char* Key, const char* Type,
                         char* Ptrfmt, char* Indfmt, char* Valfmt, char* Rhsfmt,
                         const char* Rhstype);
 

--- a/example/knights-tour.cpp
+++ b/example/knights-tour.cpp
@@ -1,12 +1,12 @@
 //=======================================================================
-// Copyright 2001 Jeremy G. Siek, Andrew Lumsdaine, Lie-Quan Lee, 
+// Copyright 2001 Jeremy G. Siek, Andrew Lumsdaine, Lie-Quan Lee,
 //
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 //=======================================================================
 #include <boost/config.hpp>
-#include <stdlib.h>
+#include <cstdlib>
 #include <iostream>
 #include <stack>
 #include <queue>

--- a/example/roget_components.cpp
+++ b/example/roget_components.cpp
@@ -7,7 +7,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 //=======================================================================
 
-#include <stdio.h>
+#include <cstdio>
 #include <iostream>
 #include <boost/graph/stanford_graph.hpp>
 #include <boost/graph/strong_components.hpp>
@@ -56,10 +56,10 @@ int main(int argc, char* argv[])
   //   a separate field for marking colors, so we use the w field.
 
   std::vector<int> comp(num_vertices(g));
-  property_map<Graph*, vertex_index_t>::type 
+  property_map<Graph*, vertex_index_t>::type
     index_map = get(vertex_index, g);
 
-  property_map<Graph*, v_property<vertex_t> >::type 
+  property_map<Graph*, v_property<vertex_t> >::type
     root = get(v_property<vertex_t>(), g);
 
   int num_comp = strong_components

--- a/include/boost/graph/graph_utility.hpp
+++ b/include/boost/graph/graph_utility.hpp
@@ -11,10 +11,10 @@
 #ifndef BOOST_GRAPH_UTILITY_HPP
 #define BOOST_GRAPH_UTILITY_HPP
 
-#include <stdlib.h>
+#include <cstdlib>
 #include <iostream>
 #include <algorithm>
-#include <assert.h>
+#include <cassert>
 #include <boost/config.hpp>
 #include <boost/tuple/tuple.hpp>
 
@@ -38,7 +38,7 @@ namespace boost {
   // Provide an undirected graph interface alternative to the
   // the source() and target() edge functions.
   template <class UndirectedGraph>
-  inline 
+  inline
   std::pair<typename graph_traits<UndirectedGraph>::vertex_descriptor,
             typename graph_traits<UndirectedGraph>::vertex_descriptor>
   incident(typename graph_traits<UndirectedGraph>::edge_descriptor e,
@@ -50,7 +50,7 @@ namespace boost {
   // Provide an undirected graph interface alternative
   // to the out_edges() function.
   template <class Graph>
-  inline 
+  inline
   std::pair<typename graph_traits<Graph>::out_edge_iterator,
             typename graph_traits<Graph>::out_edge_iterator>
   incident_edges(typename graph_traits<Graph>::vertex_descriptor u,
@@ -93,7 +93,7 @@ namespace boost {
   incident_from(Vertex u, const Graph& g) {
     return incident_from_predicate<Vertex, Graph>(u, g);
   }
-  
+
   template <typename Vertex, typename Graph>
   struct incident_to_predicate {
     incident_to_predicate(Vertex u, const Graph& g)
@@ -127,7 +127,7 @@ namespace boost {
   incident_on(Vertex u, const Graph& g) {
     return incident_on_predicate<Vertex, Graph>(u, g);
   }
-  
+
   template <typename Vertex, typename Graph>
   struct connects_predicate {
     connects_predicate(Vertex u, Vertex v, const Graph& g)
@@ -237,21 +237,21 @@ namespace boost {
   template <class Graph, class Vertex>
   bool is_adj_dispatch(Graph& g, Vertex a, Vertex b, bidirectional_tag)
   {
-    typename graph_traits<Graph>::adjacency_iterator vi, viend, 
+    typename graph_traits<Graph>::adjacency_iterator vi, viend,
       adj_found;
     boost::tie(vi, viend) = adjacent_vertices(a, g);
     adj_found = std::find(vi, viend, b);
     if (adj_found == viend)
-      return false;  
+      return false;
 
-    typename graph_traits<Graph>::out_edge_iterator oi, oiend, 
+    typename graph_traits<Graph>::out_edge_iterator oi, oiend,
       out_found;
     boost::tie(oi, oiend) = out_edges(a, g);
     out_found = std::find_if(oi, oiend, incident_to(b, g));
     if (out_found == oiend)
       return false;
 
-    typename graph_traits<Graph>::in_edge_iterator ii, iiend, 
+    typename graph_traits<Graph>::in_edge_iterator ii, iiend,
       in_found;
     boost::tie(ii, iiend) = in_edges(b, g);
     in_found = std::find_if(ii, iiend, incident_from(a, g));
@@ -269,7 +269,7 @@ namespace boost {
     if ( found == viend )
       return false;
 
-    typename graph_traits<Graph>::out_edge_iterator oi, oiend, 
+    typename graph_traits<Graph>::out_edge_iterator oi, oiend,
       out_found;
     boost::tie(oi, oiend) = out_edges(a, g);
 
@@ -323,7 +323,7 @@ namespace boost {
   inline bool is_descendant
   (typename property_traits<ParentMap>::value_type x,
    typename property_traits<ParentMap>::value_type y,
-   ParentMap parent) 
+   ParentMap parent)
   {
     if (get(parent, x) == x) // x is the root of the tree
       return false;
@@ -354,12 +354,12 @@ namespace boost {
   {
     typedef typename property_traits<VertexColorMap>::value_type ColorValue;
     typedef color_traits<ColorValue> Color;
-    typename graph_traits<VertexListGraph>::vertex_iterator 
+    typename graph_traits<VertexListGraph>::vertex_iterator
       ui, ui_end, vi, vi_end, ci, ci_end;
     for (boost::tie(ui, ui_end) = vertices(g); ui != ui_end; ++ui)
       for (boost::tie(vi, vi_end) = vertices(g); vi != vi_end; ++vi)
         if (*ui != *vi) {
-          for (boost::tie(ci, ci_end) = vertices(g); ci != ci_end; ++ci) 
+          for (boost::tie(ci, ci_end) = vertices(g); ci != ci_end; ++ci)
             put(color, *ci, Color::white());
           if (! is_reachable(*ui, *vi, g, color))
             return false;
@@ -377,33 +377,33 @@ namespace boost {
 
 
   template <class T1, class T2>
-  std::pair<T1,T2> 
-  make_list(const T1& t1, const T2& t2) 
+  std::pair<T1,T2>
+  make_list(const T1& t1, const T2& t2)
     { return std::make_pair(t1, t2); }
 
   template <class T1, class T2, class T3>
-  std::pair<T1,std::pair<T2,T3> > 
+  std::pair<T1,std::pair<T2,T3> >
   make_list(const T1& t1, const T2& t2, const T3& t3)
     { return std::make_pair(t1, std::make_pair(t2, t3)); }
 
   template <class T1, class T2, class T3, class T4>
-  std::pair<T1,std::pair<T2,std::pair<T3,T4> > > 
+  std::pair<T1,std::pair<T2,std::pair<T3,T4> > >
   make_list(const T1& t1, const T2& t2, const T3& t3, const T4& t4)
     { return std::make_pair(t1, std::make_pair(t2, std::make_pair(t3, t4))); }
 
   template <class T1, class T2, class T3, class T4, class T5>
-  std::pair<T1,std::pair<T2,std::pair<T3,std::pair<T4,T5> > > > 
+  std::pair<T1,std::pair<T2,std::pair<T3,std::pair<T4,T5> > > >
   make_list(const T1& t1, const T2& t2, const T3& t3, const T4& t4, const T5& t5)
     { return std::make_pair(t1, std::make_pair(t2, std::make_pair(t3, std::make_pair(t4, t5)))); }
 
   namespace graph {
-    
+
     // Functor for remove_parallel_edges: edge property of the removed edge is added to the remaining
     template <typename EdgeProperty>
     struct add_removed_edge_property
     {
       add_removed_edge_property(EdgeProperty ep) : ep(ep) {}
-      
+
       template <typename Edge>
       void operator() (Edge stay, Edge away)
       {
@@ -419,7 +419,7 @@ namespace boost {
     {
       typedef add_removed_edge_property<typename property_map<Graph, edge_capacity_t>::type> base;
       add_removed_edge_capacity(Graph& g) : base(get(edge_capacity, g)) {}
-    };    
+    };
 
     template <typename Graph>
     bool has_no_vertices(const Graph& g) {
@@ -469,7 +469,7 @@ namespace boost {
   (const PropertyMapFirst property_map1,
    const PropertyMapSecond property_map2,
    const Graph& graph) {
-  
+
     BGL_FORALL_VERTICES_T(vertex, graph, Graph) {
       if (get(property_map1, vertex) !=
           get(property_map2, vertex)) {

--- a/include/boost/graph/graphviz.hpp
+++ b/include/boost/graph/graphviz.hpp
@@ -15,7 +15,7 @@
 #include <map>
 #include <iostream>
 #include <fstream>
-#include <stdio.h> // for FILE
+#include <cstdio> // for FILE
 #include <boost/property_map/property_map.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/graph/graph_traits.hpp>
@@ -473,7 +473,7 @@ namespace boost {
   // Library has not existed for a while
   extern void read_graphviz(const std::string& file, GraphvizDigraph& g);
   extern void read_graphviz(FILE* file, GraphvizDigraph& g);
-  
+
   extern void read_graphviz(const std::string& file, GraphvizGraph& g);
   extern void read_graphviz(FILE* file, GraphvizGraph& g);
 #endif

--- a/include/boost/graph/rmat_graph_generator.hpp
+++ b/include/boost/graph/rmat_graph_generator.hpp
@@ -9,7 +9,7 @@
 #ifndef BOOST_GRAPH_RMAT_GENERATOR_HPP
 #define BOOST_GRAPH_RMAT_GENERATOR_HPP
 
-#include <math.h>
+#include <cmath>
 #include <iterator>
 #include <utility>
 #include <vector>

--- a/include/boost/pending/mutable_queue.hpp
+++ b/include/boost/pending/mutable_queue.hpp
@@ -114,14 +114,6 @@ namespace boost {
 
     void clear() { c.clear(); }
 
-#if 0
-        // dwa 2003/7/11 - I don't know what compiler is supposed to
-        // be able to compile this, but is_heap is not standard!!
-    bool test() {
-      return std::is_heap(c.begin(), c.end(), Comp());
-    }
-#endif
-
    protected:
     IndexArray index_array;
     Compare comp;

--- a/test/astar_search_test.cpp
+++ b/test/astar_search_test.cpp
@@ -19,8 +19,8 @@
 #include <vector>
 #include <list>
 #include <iostream>
-#include <math.h>    // for sqrt
-#include <time.h>
+#include <cmath>    // for sqrt
+#include <ctime>
 
 using namespace boost;
 using namespace std;
@@ -115,7 +115,7 @@ private:
 
 int main(int, char **)
 {
-  
+
   // specify some types
   typedef adjacency_list<listS, vecS, undirectedS, no_property,
     property<edge_weight_t, cost> > mygraph_t;
@@ -123,7 +123,7 @@ int main(int, char **)
   typedef mygraph_t::vertex_descriptor vertex;
   typedef mygraph_t::edge_descriptor edge_descriptor;
   typedef std::pair<int, int> edge;
-  
+
   // specify data
   enum nodes {
     Troy, LakePlacid, Plattsburgh, Massena, Watertown, Utica,
@@ -160,8 +160,8 @@ int main(int, char **)
     my_float(96), my_float(134), my_float(143), my_float(65), my_float(115), my_float(133), my_float(117), my_float(116), my_float(74), my_float(56),
     my_float(84), my_float(73), my_float(69), my_float(70), my_float(116), my_float(147), my_float(173), my_float(183), my_float(74), my_float(71), my_float(124)
   };
-  
-  
+
+
   // create graph
   mygraph_t g(N);
   WeightMap weightmap = get(edge_weight, g);
@@ -171,17 +171,17 @@ int main(int, char **)
                                        edge_array[j].second, g);
     weightmap[e] = weights[j];
   }
-  
-  
+
+
   // pick random start/goal
   boost::minstd_rand gen(time(0));
   vertex start = gen() % num_vertices(g);
   vertex goal = gen() % num_vertices(g);
-  
-  
+
+
   cout << "Start vertex: " << name[start] << endl;
   cout << "Goal vertex: " << name[goal] << endl;
-  
+
   vector<mygraph_t::vertex_descriptor> p(num_vertices(g));
   vector<cost> d(num_vertices(g));
 
@@ -197,8 +197,8 @@ int main(int, char **)
        predecessor_map(make_iterator_property_map(p.begin(), idx)).
        distance_map(make_iterator_property_map(d.begin(), idx)).
        visitor(astar_goal_visitor<vertex>(goal)).distance_inf(my_float((std::numeric_limits<float>::max)())));
-  
-  
+
+
   } catch(found_goal fg) { // found a path to the goal
     list<vertex> shortest_path;
     for(vertex v = goal;; v = p[v]) {
@@ -215,9 +215,9 @@ int main(int, char **)
     cout << endl << "Total travel time: " << d[goal] << endl;
     return 0;
   }
-  
+
   cout << "Didn't find a path from " << name[start] << "to"
        << name[goal] << "!" << endl;
   return 0;
-  
+
 }

--- a/test/core_numbers_test.cpp
+++ b/test/core_numbers_test.cpp
@@ -8,7 +8,7 @@
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/core_numbers.hpp>
 #include <boost/property_map/property_map.hpp>
-#include <stdio.h>
+#include <cstdio>
 
 using namespace boost;
 

--- a/test/dfs.cpp
+++ b/test/dfs.cpp
@@ -9,7 +9,7 @@
 
 #include <boost/config.hpp>
 #include <boost/test/minimal.hpp>
-#include <stdlib.h>
+#include <cstdlib>
 
 #include <boost/graph/depth_first_search.hpp>
 #include <boost/graph/adjacency_list.hpp>
@@ -125,7 +125,7 @@ struct dfs_test
         // Get vertex index map
         typedef typename boost::property_map<Graph, boost::vertex_index_t>::const_type idx_type;
         idx_type idx = get(boost::vertex_index, g);
-        
+
         typedef
           boost::iterator_property_map<typename std::vector<vertex_descriptor>::iterator, idx_type>
           parent_pm_type;
@@ -189,4 +189,3 @@ int test_main(int argc, char* argv[])
 
   return 0;
 }
-

--- a/test/isomorphism.cpp
+++ b/test/isomorphism.cpp
@@ -20,7 +20,7 @@
 #include <map>
 #include <algorithm>
 #include <cstdlib>
-#include <time.h> // clock used without std:: qualifier?
+#include <ctime> // clock used without std:: qualifier?
 #include <boost/test/minimal.hpp>
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/isomorphism.hpp>

--- a/test/undirected_dfs.cpp
+++ b/test/undirected_dfs.cpp
@@ -9,7 +9,7 @@
 
 #include <boost/config.hpp>
 #include <boost/test/minimal.hpp>
-#include <stdlib.h>
+#include <cstdlib>
 
 #include <boost/graph/undirected_dfs.hpp>
 #include <boost/graph/adjacency_list.hpp>
@@ -133,7 +133,7 @@ struct dfs_test
         // Get vertex index map
         typedef typename boost::property_map<Graph, boost::vertex_index_t>::const_type idx_type;
         idx_type idx = get(boost::vertex_index, g);
-        
+
         typedef
           boost::iterator_property_map<typename std::vector<vertex_descriptor>::iterator, idx_type>
           parent_pm_type;
@@ -199,4 +199,3 @@ int test_main(int argc, char* argv[])
 
   return 0;
 }
-

--- a/test/vf2_sub_graph_iso_test.cpp
+++ b/test/vf2_sub_graph_iso_test.cpp
@@ -10,14 +10,14 @@
 //=======================================================================
 
 // Revision History:
-//   8 April 2013: Fixed a typo in random_functor. (Flavio De Lorenzi) 
+//   8 April 2013: Fixed a typo in random_functor. (Flavio De Lorenzi)
 
 #include <iostream>
 #include <fstream>
 #include <map>
 #include <algorithm>
 #include <cstdlib>
-#include <time.h> 
+#include <ctime>
 #include <boost/test/minimal.hpp>
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/vf2_sub_graph_iso.hpp>
@@ -51,23 +51,23 @@ template<typename Graph1, typename Graph2>
 void randomly_permute_graph(Graph1& g1, const Graph2& g2) {
   BOOST_REQUIRE(num_vertices(g1) <= num_vertices(g2));
   BOOST_REQUIRE(num_edges(g1) == 0);
-  
+
   typedef typename graph_traits<Graph1>::vertex_descriptor vertex1;
   typedef typename graph_traits<Graph2>::vertex_descriptor vertex2;
   typedef typename graph_traits<Graph1>::vertex_iterator vertex_iterator;
   typedef typename graph_traits<Graph2>::edge_iterator edge_iterator;
-  
+
   boost::mt19937 gen;
   random_functor<boost::mt19937> rand_fun(gen);
-  
+
   // Decide new order
   std::vector<vertex2> orig_vertices;
   std::copy(vertices(g2).first, vertices(g2).second, std::back_inserter(orig_vertices));
   std::random_shuffle(orig_vertices.begin(), orig_vertices.end(), rand_fun);
   std::map<vertex2, vertex1> vertex_map;
-  
+
   std::size_t i = 0;
-  for (vertex_iterator vi = vertices(g1).first; 
+  for (vertex_iterator vi = vertices(g1).first;
        vi != vertices(g1).second; ++i, ++vi) {
     vertex_map[orig_vertices[i]] = *vi;
     put(vertex_name_t(), g1, *vi, get(vertex_name_t(), g2, orig_vertices[i]));
@@ -83,7 +83,7 @@ void randomly_permute_graph(Graph1& g1, const Graph2& g2) {
 
 
 template<typename Graph>
-void generate_random_digraph(Graph& g, double edge_probability, 
+void generate_random_digraph(Graph& g, double edge_probability,
                              int max_parallel_edges, double parallel_edge_probability,
                              int max_edge_name, int max_vertex_name) {
 
@@ -110,7 +110,7 @@ void generate_random_digraph(Graph& g, double edge_probability,
       }
     }
   }
-  
+
   {
     boost::uniform_int<int> dist_int(0, max_edge_name);
     boost::variate_generator<boost::mt19937&, boost::uniform_int<int> >
@@ -122,7 +122,7 @@ void generate_random_digraph(Graph& g, double edge_probability,
     boost::uniform_int<int> dist_int(0, max_vertex_name);
     boost::variate_generator<boost::mt19937&, boost::uniform_int<int> >
       random_int_dist(random_gen, dist_int);
-    
+
     randomize_property<edge_name_t>(g, random_int_dist);
   }
 
@@ -134,34 +134,34 @@ template <typename Graph1,
           typename EdgeEquivalencePredicate,
           typename VertexEquivalencePredicate>
 struct test_callback {
-  
-  test_callback(const Graph1& graph1, const Graph2& graph2, 
-                EdgeEquivalencePredicate edge_comp, 
-                VertexEquivalencePredicate vertex_comp, bool output) 
+
+  test_callback(const Graph1& graph1, const Graph2& graph2,
+                EdgeEquivalencePredicate edge_comp,
+                VertexEquivalencePredicate vertex_comp, bool output)
     : graph1_(graph1), graph2_(graph2), edge_comp_(edge_comp), vertex_comp_(vertex_comp),
       output_(output) {}
-  
+
   template <typename CorrespondenceMap1To2,
             typename CorrespondenceMap2To1>
   bool operator()(CorrespondenceMap1To2 f, CorrespondenceMap2To1) {
-    
+
     bool verified;
     BOOST_CHECK(verified = verify_vf2_subgraph_iso(graph1_, graph2_, f, edge_comp_, vertex_comp_));
-  
+
     // Output (sub)graph isomorphism map
     if (!verified || output_) {
       std::cout << "Verfied: " << std::boolalpha << verified << std::endl;
       std::cout << "Num vertices: " << num_vertices(graph1_) << ' ' << num_vertices(graph2_) << std::endl;
-      BGL_FORALL_VERTICES_T(v, graph1_, Graph1) 
-        std::cout << '(' << get(vertex_index_t(), graph1_, v) << ", " 
+      BGL_FORALL_VERTICES_T(v, graph1_, Graph1)
+        std::cout << '(' << get(vertex_index_t(), graph1_, v) << ", "
                   << get(vertex_index_t(), graph2_, get(f, v)) << ") ";
-    
+
       std::cout << std::endl;
     }
-    
+
     return true;
   }
- 
+
 private:
   const Graph1& graph1_;
   const Graph2& graph2_;
@@ -171,16 +171,16 @@ private:
 };
 
 
-void test_vf2_sub_graph_iso(int n1, int n2, double edge_probability, 
+void test_vf2_sub_graph_iso(int n1, int n2, double edge_probability,
                             int max_parallel_edges, double parallel_edge_probability,
                             int max_edge_name, int max_vertex_name, bool output) {
 
   typedef property<edge_name_t, int> edge_property;
   typedef property<vertex_name_t, int, property<vertex_index_t, int> > vertex_property;
-  
+
   typedef adjacency_list<listS, listS, bidirectionalS, vertex_property, edge_property> graph1;
   typedef adjacency_list<vecS, vecS, bidirectionalS, vertex_property, edge_property> graph2;
-  
+
   graph1 g1(n1);
   graph2 g2(n2);
   generate_random_digraph(g2, edge_probability, max_parallel_edges, parallel_edge_probability,
@@ -197,23 +197,23 @@ void test_vf2_sub_graph_iso(int n1, int n2, double edge_probability,
   // Create vertex and edge predicates
   typedef property_map<graph1, vertex_name_t>::type vertex_name_map1;
   typedef property_map<graph2, vertex_name_t>::type vertex_name_map2;
-  
+
   typedef property_map_equivalent<vertex_name_map1, vertex_name_map2> vertex_predicate;
   vertex_predicate vertex_comp =
     make_property_map_equivalent(get(vertex_name, g1), get(vertex_name, g2));
-  
+
   typedef property_map<graph1, edge_name_t>::type edge_name_map1;
   typedef property_map<graph2, edge_name_t>::type edge_name_map2;
-  
+
   typedef property_map_equivalent<edge_name_map1, edge_name_map2> edge_predicate;
   edge_predicate edge_comp =
     make_property_map_equivalent(get(edge_name, g1), get(edge_name, g2));
-  
-  
+
+
   std::clock_t start = std::clock();
-  
+
   // Create callback
-  test_callback<graph1, graph2, edge_predicate, vertex_predicate> 
+  test_callback<graph1, graph2, edge_predicate, vertex_predicate>
     callback(g1, g2, edge_comp, vertex_comp, output);
 
   std::cout << std::endl;
@@ -227,17 +227,17 @@ void test_vf2_sub_graph_iso(int n1, int n2, double edge_probability,
     std::cout << std::endl;
     BOOST_CHECK(vf2_graph_iso(g1, g2, callback, vertex_order_by_mult(g1),
                               edges_equivalent(edge_comp).vertices_equivalent(vertex_comp)));
-    
+
     std::clock_t end2 = std::clock();
     std::cout << "vf2_graph_iso: elapsed time (clock cycles): " << (end2 - end1) << std::endl;
   }
-  
+
   if (output) {
     std::fstream file_graph1("graph1.dot", std::fstream::out);
     write_graphviz(file_graph1, g1,
                    make_label_writer(get(boost::vertex_name, g1)),
                    make_label_writer(get(boost::edge_name, g1)));
-    
+
     std::fstream file_graph2("graph2.dot", std::fstream::out);
     write_graphviz(file_graph2, g2,
                    make_label_writer(get(boost::vertex_name, g2)),
@@ -255,42 +255,42 @@ int test_main(int argc, char* argv[]) {
   int max_edge_name = 5;
   int max_vertex_name = 5;
   bool output = false;
-  
+
   if (argc > 1) {
     num_vertices_g1 = boost::lexical_cast<int>(argv[1]);
   }
-  
+
   if (argc > 2) {
     num_vertices_g2 = boost::lexical_cast<int>(argv[2]);
   }
-  
+
   if (argc > 3) {
     edge_probability = boost::lexical_cast<double>(argv[3]);
   }
-  
+
   if (argc > 4) {
     max_parallel_edges = boost::lexical_cast<int>(argv[4]);
   }
-  
+
   if (argc > 5) {
     parallel_edge_probability = boost::lexical_cast<double>(argv[5]);
   }
-  
+
   if (argc > 6) {
     max_edge_name = boost::lexical_cast<int>(argv[6]);
   }
-  
+
   if (argc > 7) {
     max_vertex_name = boost::lexical_cast<int>(argv[7]);
   }
-  
+
   if (argc > 8) {
     output = boost::lexical_cast<bool>(argv[8]);
   }
 
-  test_vf2_sub_graph_iso(num_vertices_g1, num_vertices_g2, edge_probability, 
-                         max_parallel_edges, parallel_edge_probability, 
+  test_vf2_sub_graph_iso(num_vertices_g1, num_vertices_g2, edge_probability,
+                         max_parallel_edges, parallel_edge_probability,
                          max_edge_name, max_vertex_name, output);
-  
+
   return 0;
 }


### PR DESCRIPTION
The function in 17e0154 is not compiled (the C++11 dictates that this signature is valid standard C++, but probably wasn't standard in 2003 when the comment was written.

I replaced a number of imports so they match the style in the C++ standard, e.g., <stdlib.h> => <cstdlib>, and since my editor deletes trailing whitespace, affected files, I also cleaned this up. 

include/boost/pending/fibonacci_heap.hpp has this snippet, but I'm uncertain whether <math.h> can also be changed into <cmath>

    #if defined(__sgi) && !defined(__GNUC__)
    # include <math.h>
    #else