### PR TITLE
Fix #11374 and #8791: issues with bundled properties and `find_flow_cost`

### DIFF
--- a/include/boost/graph/find_flow_cost.hpp
+++ b/include/boost/graph/find_flow_cost.hpp
@@ -14,9 +14,9 @@
 namespace boost {
 
 template<class Graph, class Capacity, class ResidualCapacity, class Weight>
-typename property_traits<typename property_map < Graph, edge_capacity_t >::type>::value_type
+typename property_traits<Weight>::value_type
 find_flow_cost(const Graph & g, Capacity capacity, ResidualCapacity residual_capacity, Weight weight) {
-    typedef typename property_traits<typename property_map<Graph, edge_weight_t>::const_type>::value_type Cost;
+    typedef typename property_traits<Weight>::value_type Cost;
 
     Cost cost = 0;
     BGL_FORALL_EDGES_T(e, g, Graph) {

--- a/include/boost/graph/find_flow_cost.hpp
+++ b/include/boost/graph/find_flow_cost.hpp
@@ -28,7 +28,7 @@ find_flow_cost(const Graph & g, Capacity capacity, ResidualCapacity residual_cap
 }
 
 template <class Graph, class P, class T, class R> 
-typename property_traits<typename property_map < Graph, edge_capacity_t >::type>::value_type
+typename detail::edge_capacity_value<Graph, P, T, R>::type
 find_flow_cost(const Graph & g,
                const bgl_named_params<P, T, R>& params) {
     return find_flow_cost(g,

--- a/include/boost/graph/named_function_params.hpp
+++ b/include/boost/graph/named_function_params.hpp
@@ -326,6 +326,14 @@ BOOST_BGL_DECLARE_NAMED_PARAMS
       typedef typename detail::choose_impl_result<boost::mpl::true_, Graph, typename get_param_type<edge_capacity_t, Params>::type, edge_capacity_t>::type CapacityEdgeMap;
       typedef typename property_traits<CapacityEdgeMap>::value_type type;
     };
+    // used in the max-flow algorithms
+    template <class Graph, class P, class T, class R>
+    struct edge_weight_value
+    {
+      typedef bgl_named_params<P, T, R> Params;
+      typedef typename detail::choose_impl_result<boost::mpl::true_, Graph, typename get_param_type<edge_weight_t, Params>::type, edge_weight_t>::type WeightMap;
+      typedef typename property_traits<WeightMap>::value_type type;
+    };
 
   }
 

--- a/include/boost/graph/named_function_params.hpp
+++ b/include/boost/graph/named_function_params.hpp
@@ -323,7 +323,7 @@ BOOST_BGL_DECLARE_NAMED_PARAMS
     struct edge_capacity_value
     {
       typedef bgl_named_params<P, T, R> Params;
-      typedef typename detail::choose_impl_result<boost::mpl::true_, Graph, typename get_param_type<Params, edge_capacity_t>::type, edge_capacity_t>::type CapacityEdgeMap;
+      typedef typename detail::choose_impl_result<boost::mpl::true_, Graph, typename get_param_type<edge_capacity_t, Params>::type, edge_capacity_t>::type CapacityEdgeMap;
       typedef typename property_traits<CapacityEdgeMap>::value_type type;
     };
 


### PR DESCRIPTION
I talked about that problem on [stackoverflow](http://stackoverflow.com/questions/30621255/using-named-parameters-and-bundled-properties-with-edmonds-karp-max-flow). This PR solves two different tickets because the cause was almost the same (bundled properties had not been tested thoroughly).  
Here are the tickets: 
- Issue [#11374](https://svn.boost.org/trac/boost/ticket/11374): `find_flow_cost()` won't work with bundled properties
- Issue [#8791](https://svn.boost.org/trac/boost/ticket/8791): no "flow" function (e.g. `edmonds_arp_max_flow()`) won't work with named parameters

I apologize for having mixed those two issues in one PR ; they were really "close" to each other... And I should have opened a new issue for the #8791 but it turned out that I didn't.

