### PR TITLE
[subgraph.hpp] add_vertex(u_global, g) on a subgraph does not recursi…

### DIFF
--- a/include/boost/graph/subgraph.hpp
+++ b/include/boost/graph/subgraph.hpp
@@ -366,6 +366,35 @@ struct graph_bundle_type<subgraph<Graph> >
 //===========================================================================
 // Functions special to the Subgraph Class
 
+
+namespace detail {
+    
+    template <typename G>
+    typename subgraph<G>::vertex_descriptor
+    add_vertex_recur_up(typename subgraph<G>::vertex_descriptor u_global,
+                subgraph<G>& g)
+    {
+        if (!g.is_root()) {
+            if (!g.find_vertex(u_global).second) {
+                add_vertex_recur_up(u_global, g.parent());
+
+                typename subgraph<G>::vertex_descriptor u_local;
+                u_local = add_vertex(g.m_graph);
+                g.m_global_vertex.push_back(u_global);
+                g.m_local_vertex[u_global] = u_local;
+
+                return u_local;
+            } else {
+                return g.find_vertex(u_global).first;
+            }
+        } else {
+            return u_global;
+        }
+    }
+    
+} // namespace detail
+
+
 template <typename G>
 typename subgraph<G>::vertex_descriptor
 add_vertex(typename subgraph<G>::vertex_descriptor u_global,
@@ -375,7 +404,7 @@ add_vertex(typename subgraph<G>::vertex_descriptor u_global,
     typename subgraph<G>::vertex_descriptor u_local, v_global;
     typename subgraph<G>::edge_descriptor e_global;
 
-    u_local = add_vertex(g.m_graph);
+    u_local = detail::add_vertex_recur_up(u_global, g);
     g.m_global_vertex.push_back(u_global);
     g.m_local_vertex[u_global] = u_local;
 

--- a/include/boost/graph/subgraph.hpp
+++ b/include/boost/graph/subgraph.hpp
@@ -405,8 +405,6 @@ add_vertex(typename subgraph<G>::vertex_descriptor u_global,
     typename subgraph<G>::edge_descriptor e_global;
 
     u_local = detail::add_vertex_recur_up(u_global, g);
-    g.m_global_vertex.push_back(u_global);
-    g.m_local_vertex[u_global] = u_local;
 
     subgraph<G>& r = g.root();
 

--- a/include/boost/graph/subgraph.hpp
+++ b/include/boost/graph/subgraph.hpp
@@ -379,7 +379,7 @@ add_vertex(typename subgraph<G>::vertex_descriptor u_global,
         boost::tie(u_local, exists_local) = g.find_vertex(u_global);
 
         if (!exists_local) {
-            typename subgraph<G>::vertex_descriptor u_local, v_global;
+            typename subgraph<G>::vertex_descriptor v_global;
             typename subgraph<G>::edge_descriptor e_global;
             // call recursion for parent subgraph
             add_vertex(u_global, g.parent());

--- a/include/boost/graph/subgraph.hpp
+++ b/include/boost/graph/subgraph.hpp
@@ -366,78 +366,61 @@ struct graph_bundle_type<subgraph<Graph> >
 //===========================================================================
 // Functions special to the Subgraph Class
 
-
-namespace detail {
-    
-    template <typename G>
-    typename subgraph<G>::vertex_descriptor
-    add_vertex_recur_up(typename subgraph<G>::vertex_descriptor u_global,
-                subgraph<G>& g)
-    {
-        if (!g.is_root()) {
-            if (!g.find_vertex(u_global).second) {
-                typename subgraph<G>::vertex_descriptor u_local, v_global;
-                typename subgraph<G>::edge_descriptor e_global;
-                
-                add_vertex_recur_up(u_global, g.parent());
-                
-                u_local = add_vertex(g.m_graph);
-                g.m_global_vertex.push_back(u_global);
-                g.m_local_vertex[u_global] = u_local;
-                
-                subgraph<G>& r = g.root();
-
-                // remember edge global and local maps
-                {
-                    typename subgraph<G>::out_edge_iterator ei, ei_end;
-                    for (boost::tie(ei, ei_end) = out_edges(u_global, r);
-                        ei != ei_end; ++ei) {
-                        e_global = *ei;
-                        v_global = target(e_global, r);
-                        if (g.find_vertex(v_global).second == true)
-                        g.local_add_edge(u_local, g.global_to_local(v_global), e_global);
-                    }
-                }
-                if (is_directed(g)) { // not necessary for undirected graph
-                    typename subgraph<G>::vertex_iterator vi, vi_end;
-                    typename subgraph<G>::out_edge_iterator ei, ei_end;
-                    for(boost::tie(vi, vi_end) = vertices(r); vi != vi_end; ++vi) {
-                        v_global = *vi;
-                        if (v_global == u_global)
-                            continue; // don't insert self loops twice!
-                        if (!g.find_vertex(v_global).second)
-                            continue; // not a subgraph vertex => try next one
-                        for(boost::tie(ei, ei_end) = out_edges(*vi, r); ei != ei_end; ++ei) {
-                            e_global = *ei;
-                            if(target(e_global, r) == u_global) {
-                                g.local_add_edge(g.global_to_local(v_global), u_local, e_global);
-                            }
-                        }
-                    }
-                }
-                return u_local;
-            } else {
-                return g.find_vertex(u_global).first;
-            }
-        } else {
-            return u_global;
-        }
-    }
-    
-} // namespace detail
-
-
 template <typename G>
 typename subgraph<G>::vertex_descriptor
 add_vertex(typename subgraph<G>::vertex_descriptor u_global,
            subgraph<G>& g)
 {
-    BOOST_ASSERT(!g.is_root());
-    typename subgraph<G>::vertex_descriptor u_local;
-    
-    u_local = detail::add_vertex_recur_up(u_global, g);
+    if (g.is_root()) {
+        return u_global;
+    } else {
+        typename subgraph<G>::vertex_descriptor u_local;
+        bool exists_local;
+        boost::tie(u_local, exists) = g.find_vertex(u_global);
 
-    return u_local;
+        if (!exists_local) {
+            typename subgraph<G>::vertex_descriptor u_local, v_global;
+            typename subgraph<G>::edge_descriptor e_global;
+            // call recursion for parent subgraph
+            add_vertex(u_global, g.parent());
+            
+            u_local = add_vertex(g.m_graph);
+            g.m_global_vertex.push_back(u_global);
+            g.m_local_vertex[u_global] = u_local;
+            
+            subgraph<G>& r = g.root();
+
+            // remember edge global and local maps
+            {
+                typename subgraph<G>::out_edge_iterator ei, ei_end;
+                for (boost::tie(ei, ei_end) = out_edges(u_global, r);
+                    ei != ei_end; ++ei) {
+                    e_global = *ei;
+                    v_global = target(e_global, r);
+                    if (g.find_vertex(v_global).second == true)
+                    g.local_add_edge(u_local, g.global_to_local(v_global), e_global);
+                }
+            }
+            if (is_directed(g)) { // not necessary for undirected graph
+                typename subgraph<G>::vertex_iterator vi, vi_end;
+                typename subgraph<G>::out_edge_iterator ei, ei_end;
+                for(boost::tie(vi, vi_end) = vertices(r); vi != vi_end; ++vi) {
+                    v_global = *vi;
+                    if (v_global == u_global)
+                        continue; // don't insert self loops twice!
+                    if (!g.find_vertex(v_global).second)
+                        continue; // not a subgraph vertex => try next one
+                    for(boost::tie(ei, ei_end) = out_edges(*vi, r); ei != ei_end; ++ei) {
+                        e_global = *ei;
+                        if(target(e_global, r) == u_global) {
+                            g.local_add_edge(g.global_to_local(v_global), u_local, e_global);
+                        }
+                    }
+                }
+            }
+        }
+        return u_local;
+    }
 }
 
 // NOTE: Descriptors are local unless otherwise noted.

--- a/include/boost/graph/subgraph.hpp
+++ b/include/boost/graph/subgraph.hpp
@@ -376,7 +376,7 @@ add_vertex(typename subgraph<G>::vertex_descriptor u_global,
     } else {
         typename subgraph<G>::vertex_descriptor u_local;
         bool exists_local;
-        boost::tie(u_local, exists) = g.find_vertex(u_global);
+        boost::tie(u_local, exists_local) = g.find_vertex(u_global);
 
         if (!exists_local) {
             typename subgraph<G>::vertex_descriptor u_local, v_global;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -74,6 +74,7 @@ test-suite graph_test :
     # TODO: Merge these into a single test framework.
     [ run subgraph.cpp ../../test/build//boost_test_exec_monitor ]
     [ run subgraph_bundled.cpp ]
+    [ run subgraph_add.cpp ../../test/build//boost_unit_test_framework/<link>static : $(TEST_DIR) ]
     [ run subgraph_props.cpp ]
 
     [ run isomorphism.cpp ../../test/build//boost_test_exec_monitor ]

--- a/test/subgraph_add.cpp
+++ b/test/subgraph_add.cpp
@@ -1,0 +1,272 @@
+/* This file is a boost.test unit test and provides tests the internal dependency graph
+ *
+ * Created on: 06.10.2015
+ * Author: Stefan Hammer <s.hammer@univie.ac.at>
+ * License: Boost Software License, Version 1.0. (See
+ *   accompanying file LICENSE_1_0.txt or copy at
+ *   http://www.boost.org/LICENSE_1_0.txt)
+ *
+ * 
+ */
+
+#define BOOST_TEST_MODULE subgraph_add
+
+// std lib includes
+#include <iostream>
+
+// include boost components
+#include <boost/test/unit_test.hpp>
+#include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/iteration_macros.hpp>
+
+// include header
+#include <boost/graph/subgraph.hpp>
+
+using namespace boost;
+
+BOOST_AUTO_TEST_CASE(simpleGraph) {
+
+    BOOST_TEST_MESSAGE("simple subgraph");
+
+    typedef subgraph< adjacency_list< vecS, vecS, directedS,
+        no_property, property< edge_index_t, int > > > Graph;
+
+    const int N = 6;
+    Graph G0(N);
+
+    enum { A, B, C, D, E, F};  // for conveniently refering to vertices in G0
+
+    Graph& G1 = G0.create_subgraph();
+    Graph& G2 = G1.create_subgraph();
+    
+    BOOST_CHECK(&G1.parent() == &G0);
+    BOOST_CHECK(&G2.parent() == &G1);
+    
+    enum { A1, B1, C1 }; // for conveniently refering to vertices in G1
+    enum { A2, B2, C2 };     // for conveniently refering to vertices in G2
+    
+    add_vertex(C, G1); // global vertex C becomes local A1 for G1
+    add_vertex(E, G1); // global vertex E becomes local B1 for G1
+    add_vertex(F, G1); // global vertex F becomes local C1 for G1
+
+    add_vertex(C, G2); // global vertex C becomes local A2 for G2
+    add_vertex(E, G2); // global vertex E becomes local B2 for G2
+    
+    BOOST_CHECK(num_vertices(G0) == 6);
+    BOOST_CHECK(num_vertices(G1) == 3);
+    std::cerr << num_vertices(G1) << std::endl;
+    BOOST_CHECK(num_vertices(G2) == 2);
+    
+    // add edges to root graph
+    add_edge(A, B, G0);
+    add_edge(B, C, G0);
+    add_edge(B, D, G0);
+    add_edge(E, F, G0);
+    
+    BOOST_CHECK(num_edges(G0) == 4);
+    BOOST_CHECK(num_edges(G1) == 1);
+    BOOST_CHECK(num_edges(G2) == 0);
+    
+    // add edges to G1
+    add_edge(A1, B1, G1);
+    BOOST_CHECK(num_edges(G0) == 5);
+    BOOST_CHECK(num_edges(G1) == 2);
+    BOOST_CHECK(num_edges(G2) == 1);
+    // num_vertices stays the same
+    BOOST_CHECK(num_vertices(G0) == 6);
+    BOOST_CHECK(num_vertices(G1) == 3);
+    BOOST_CHECK(num_vertices(G2) == 2);
+}
+
+BOOST_AUTO_TEST_CASE(addVertices) {
+
+    BOOST_TEST_MESSAGE("subgraph add edges");
+
+    typedef subgraph< adjacency_list< vecS, vecS, directedS,
+        no_property, property< edge_index_t, int > > > Graph;
+    typedef Graph::vertex_descriptor Vertex;
+
+    const int N = 3;
+    Graph G0(N);
+    Graph& G1 = G0.create_subgraph();
+    Graph& G2 = G1.create_subgraph();
+    
+    BOOST_CHECK(&G1.parent() == &G0);
+    BOOST_CHECK(&G2.parent() == &G1);
+    
+    // add vertices to G2
+    Vertex n1 = add_vertex(0, G2);
+    Vertex n2 = add_vertex(1, G2);
+    // check if the global vertex 2 is equal to the returned local vertex
+    if (G2.find_vertex(0).second) {
+        BOOST_CHECK(G2.find_vertex(0).first == n1);
+    } else {
+        BOOST_ERROR( "vertex not found!" );
+    }
+    if (G2.find_vertex(1).second) {
+        BOOST_CHECK(G2.find_vertex(1).first == n2);
+    } else {
+        BOOST_ERROR( "vertex not found!" );
+    }
+    // and check if this vertex is also present in G1
+    if (G1.find_vertex(0).second) {
+        BOOST_CHECK(G1.local_to_global(G1.find_vertex(0).first) == 0);
+    } else {
+        BOOST_ERROR( "vertex not found!" );
+    }
+    if (G1.find_vertex(0).second) {
+        BOOST_CHECK(G1.local_to_global(G1.find_vertex(1).first) == 1);
+    } else {
+        BOOST_ERROR( "vertex not found!" );
+    }
+    
+    // num_vertices stays the same
+    BOOST_CHECK(num_vertices(G0) == 3);
+    BOOST_CHECK(num_vertices(G1) == 2);
+    BOOST_CHECK(num_vertices(G2) == 2);
+    
+    // add vertices to G1
+    Vertex n3 = add_vertex(2, G1);
+    // check if the global vertex 2 is equal to the returned local vertex
+    if (G1.find_vertex(2).second) {
+        BOOST_CHECK(G1.find_vertex(2).first == n3);
+    } else {
+        BOOST_ERROR( "vertex not found!" );
+    }
+    // num_vertices stays the same
+    BOOST_CHECK(num_vertices(G0) == 3);
+    BOOST_CHECK(num_vertices(G1) == 3);
+    BOOST_CHECK(num_vertices(G2) == 2);
+    
+    // add vertices to G1
+    Vertex n4 = add_vertex(G1);
+    
+    // check if the new local vertex is also in the global graph
+    BOOST_CHECK(G0.find_vertex(G1.local_to_global(n4)).second);
+    // check if the new local vertex is not in the subgraphs
+    BOOST_CHECK(!G2.find_vertex(n4).second);
+    
+    // num_vertices stays the same
+    BOOST_CHECK(num_vertices(G0) == 4);
+    BOOST_CHECK(num_vertices(G1) == 4);
+    BOOST_CHECK(num_vertices(G2) == 2);
+    
+    // add vertices to G0
+    Vertex n5 = add_vertex(G0);
+    
+    // check if the new local vertex is not in the subgraphs
+    BOOST_CHECK(!G1.find_vertex(n5).second);
+    BOOST_CHECK(!G2.find_vertex(n5).second);
+    
+    // num_vertices stays the same
+    BOOST_CHECK(num_vertices(G0) == 5);
+    BOOST_CHECK(num_vertices(G1) == 4);
+    BOOST_CHECK(num_vertices(G2) == 2);
+    
+    std::cerr << "All G0 vertices: " << std::endl;
+    BGL_FORALL_VERTICES_T(v, G0, Graph) {
+        std::cerr << G0.local_to_global(v) << std::endl;
+    }
+    std::cerr << "All G1 vertices: " << std::endl;
+    BGL_FORALL_VERTICES_T(v, G1, Graph) {
+        std::cerr << G1.local_to_global(v) << std::endl;
+    }
+    std::cerr << "All G2 vertices: " << std::endl;
+    BGL_FORALL_VERTICES_T(v, G2, Graph) {
+        std::cerr << G2.local_to_global(v) << std::endl;
+    }
+}
+
+BOOST_AUTO_TEST_CASE(addEdge) {
+
+    BOOST_TEST_MESSAGE("subgraph add edges");
+
+    typedef subgraph< adjacency_list< vecS, vecS, directedS,
+        no_property, property< edge_index_t, int > > > Graph;
+    typedef Graph::vertex_descriptor Vertex;
+
+    const int N = 3;
+    Graph G0(N);
+    Graph& G1 = G0.create_subgraph();
+    Graph& G2 = G1.create_subgraph();
+    
+    BOOST_CHECK(&G1.parent() == &G0);
+    BOOST_CHECK(&G2.parent() == &G1);
+    
+    // add vertices
+    add_vertex(0, G2);
+    add_vertex(1, G2);
+    BOOST_CHECK(num_vertices(G1) == 2);
+    BOOST_CHECK(num_vertices(G2) == 2);
+    
+    // add edge to G0 which needs propagation
+    add_edge(0, 1, G0);
+    
+    BOOST_CHECK(num_edges(G0) == 1);
+    BOOST_CHECK(num_edges(G1) == 1);
+    BOOST_CHECK(num_edges(G2) == 1);
+    // num_vertices stays the same
+    BOOST_CHECK(num_vertices(G0) == 3);
+    BOOST_CHECK(num_vertices(G1) == 2);
+    BOOST_CHECK(num_vertices(G2) == 2);
+    
+    // add edge to G0 without propagation
+    add_edge(1, 2, G0);
+    
+    BOOST_CHECK(num_edges(G0) == 2);
+    BOOST_CHECK(num_edges(G1) == 1);
+    BOOST_CHECK(num_edges(G2) == 1);
+    // num_vertices stays the same
+    BOOST_CHECK(num_vertices(G0) == 3);
+    BOOST_CHECK(num_vertices(G1) == 2);
+    BOOST_CHECK(num_vertices(G2) == 2);
+    
+    // add vertex 2 to G2/G1 with edge propagation
+    Vertex n = add_vertex(2, G2);
+    BOOST_CHECK(G2.local_to_global(n) == 2);
+    
+    BOOST_CHECK(num_edges(G0) == 2);
+    BOOST_CHECK(num_edges(G1) == 2);
+    BOOST_CHECK(num_edges(G2) == 2);
+    // num_vertices stays the same
+    BOOST_CHECK(num_vertices(G0) == 3);
+    BOOST_CHECK(num_vertices(G1) == 3);
+    BOOST_CHECK(num_vertices(G2) == 3);
+    
+    // add edge to G2 with propagation upwards
+    add_edge(0, 2, G2);
+    
+    BOOST_CHECK(num_edges(G0) == 3);
+    BOOST_CHECK(num_edges(G1) == 3);
+    BOOST_CHECK(num_edges(G2) == 3);
+    // num_vertices stays the same
+    BOOST_CHECK(num_vertices(G0) == 3);
+    BOOST_CHECK(num_vertices(G1) == 3);
+    BOOST_CHECK(num_vertices(G2) == 3);
+    
+    std::cerr << "All G0 vertices: " << std::endl;
+    BGL_FORALL_VERTICES_T(v, G0, Graph) {
+        std::cerr << G0.local_to_global(v) << std::endl;
+    }
+    std::cerr << "All G1 vertices: " << std::endl;
+    BGL_FORALL_VERTICES_T(v, G1, Graph) {
+        std::cerr << G1.local_to_global(v) << std::endl;
+    }
+    std::cerr << "All G2 vertices: " << std::endl;
+    BGL_FORALL_VERTICES_T(v, G2, Graph) {
+        std::cerr << G2.local_to_global(v) << std::endl;
+    }
+    std::cerr << "All G0 edges: " << std::endl;
+    BGL_FORALL_EDGES_T(e, G0, Graph) {
+        std::cerr << source(e, G0) << "->" << target(e, G0) << std::endl;
+    }
+    std::cerr << "All G1 edges: " << std::endl;
+    BGL_FORALL_EDGES_T(e, G1, Graph) {
+        std::cerr << source(e, G1) << "->" << target(e, G1) << std::endl;
+    }
+    std::cerr << "All G2 edges: " << std::endl;
+    BGL_FORALL_EDGES_T(e, G2, Graph) {
+        std::cerr << source(e, G2) << "->" << target(e, G2) << std::endl;
+    }
+}
+


### PR DESCRIPTION
…vely add to parent subgraphs

Hello,
One of the invariants of an induced subgraph is:
- If vertex u is in subgraph g, then u must be in g.parent().

This is true if you call add_vertex(g) on a subgraph to create a new vertex.
If you however choose to add a already existing global vertex to the subgraph, this addition is not propagated to the parents of this subgraph.

 I assume this is a bug and fixed it. 
Bug Ticket can be found here: https://svn.boost.org/trac/boost/ticket/11714
Thanks, Stefan 
