### PR TITLE
avoid closed_plus in dijkstra_shortest_path

### DIFF
--- a/include/boost/graph/dijkstra_shortest_paths.hpp
+++ b/include/boost/graph/dijkstra_shortest_paths.hpp
@@ -129,7 +129,7 @@ namespace boost {
 
       template <class Edge, class Graph>
       void tree_edge(Edge e, Graph& g) {
-        bool decreased = relax(e, g, m_weight, m_predecessor, m_distance,
+        bool decreased = relax_target(e, g, m_weight, m_predecessor, m_distance,
                                m_combine, m_compare);
         if (decreased)
           m_vis.edge_relaxed(e, g);
@@ -140,7 +140,7 @@ namespace boost {
       void gray_target(Edge e, Graph& g) {
         D old_distance = get(m_distance, target(e, g));
 
-        bool decreased = relax(e, g, m_weight, m_predecessor, m_distance,
+        bool decreased = relax_target(e, g, m_weight, m_predecessor, m_distance,
                                m_combine, m_compare);
         if (decreased) {
           dijkstra_queue_update(m_Q, target(e, g), old_distance);
@@ -564,7 +564,7 @@ namespace boost {
          choose_param(get_param(params, distance_compare_t()),
                       std::less<D>()),
          choose_param(get_param(params, distance_combine_t()),
-                      closed_plus<D>(inf)),
+                      std::plus<D>()),
          inf,
          choose_param(get_param(params, distance_zero_t()),
                       D()),

--- a/include/boost/graph/relax.hpp
+++ b/include/boost/graph/relax.hpp
@@ -76,6 +76,37 @@ namespace boost {
       } else
         return false;
     }
+
+    template <class Graph, class WeightMap,
+            class PredecessorMap, class DistanceMap,
+            class BinaryFunction, class BinaryPredicate>
+    bool relax_target(typename graph_traits<Graph>::edge_descriptor e,
+                      const Graph& g, const WeightMap& w,
+                      PredecessorMap& p, DistanceMap& d,
+                      const BinaryFunction& combine, const BinaryPredicate& compare)
+    {
+      typedef typename graph_traits<Graph>::vertex_descriptor Vertex;
+      typedef typename property_traits<DistanceMap>::value_type D;
+      typedef typename property_traits<WeightMap>::value_type W;
+      const Vertex u = source(e, g);
+      const Vertex v = target(e, g);
+      const D d_u = get(d, u);
+      const D d_v = get(d, v);
+      const W& w_e = get(w, e);
+
+      // The seemingly redundant comparisons after the distance puts are to
+      // ensure that extra floating-point precision in x87 registers does not
+      // lead to relax() returning true when the distance did not actually
+      // change.
+      if (compare(combine(d_u, w_e), d_v)) {
+        put(d, v, combine(d_u, w_e));
+        if (compare(get(d, v), d_v)) {
+          put(p, v, u);
+          return true;
+        }
+      }
+      return false;
+    }
     
     template <class Graph, class WeightMap, 
       class PredecessorMap, class DistanceMap>


### PR DESCRIPTION
dijkstra_shortest_path requires boost::closed_plus because of redundant checks in the relax function. By using a new relax_target() function it avoids combining weights with infinite distances and std::plus can be used.