### PR TITLE
Fix some minor documentation annoyances

### DIFF
--- a/doc/adjacency_list.html
+++ b/doc/adjacency_list.html
@@ -474,9 +474,9 @@ The type used for dealing with the number of vertices in the graph.
 
 <hr>
 
-<tt>graph_traits&lt;adjacency_list&gt;::edge_size_type</tt><br>
+<tt>graph_traits&lt;adjacency_list&gt;::edges_size_type</tt><br>
 and<br>
-<tt>adjacency_list_traits&lt;OutEdgeList, VertexList, Directed_list, EdgeList&gt;::edge_size_type</tt><br>
+<tt>adjacency_list_traits&lt;OutEdgeList, VertexList, Directed_list, EdgeList&gt;::edges_size_type</tt><br>
 <br><br>
 The type used for dealing with the number of edges in the graph.
 

--- a/doc/filtered_graph.html
+++ b/doc/filtered_graph.html
@@ -257,7 +257,7 @@ The type used for dealing with the number of vertices in the graph.
 
 <hr>
 
-<tt>graph_traits&lt;filtered_graph&gt;::edge_size_type</tt>
+<tt>graph_traits&lt;filtered_graph&gt;::edges_size_type</tt>
 <br><br>
 The type used for dealing with the number of edges in the graph.
 

--- a/doc/graph_traits.html
+++ b/doc/graph_traits.html
@@ -218,7 +218,7 @@ vertices in the graph.
 
 <tr>
 <td><tt>
-edge_size_type
+edges_size_type
 </tt></td>
 <td>
 The unsigned integer type used for representing the number of

--- a/doc/push_relabel_max_flow.html
+++ b/doc/push_relabel_max_flow.html
@@ -77,7 +77,7 @@ The time complexity is <i>O(V<sup>3</sup>)</i>.
 <H3>Where Defined</H3>
 
 <P>
-<a href="../../../boost/graph/push_relabel_max_flow.hpp"><TT>boost/graph/preflow_push_max_flow.hpp</TT></a>
+<a href="../../../boost/graph/push_relabel_max_flow.hpp"><TT>boost/graph/push_relabel_max_flow.hpp</TT></a>
 
 <P>
 

--- a/doc/reverse_graph.html
+++ b/doc/reverse_graph.html
@@ -190,7 +190,7 @@ The type used for dealing with the number of vertices in the graph.
 
 <hr>
 
-<tt>graph_traits&lt;reverse_graph&gt;::edge_size_type</tt>
+<tt>graph_traits&lt;reverse_graph&gt;::edges_size_type</tt>
 <br><br>
 The type used for dealing with the number of edges in the graph.
 


### PR DESCRIPTION
- the graph trait's edge size type is `edges_size_type` (pl.) and not `edge_size_type`
- the push relabel algorithm is defined in header `push_relabel.hpp` and not `preflow_push.hpp`