### PR TITLE
Update kamada_kawai_spring_layout.hpp

### DIFF
--- a/include/boost/graph/kamada_kawai_spring_layout.hpp
+++ b/include/boost/graph/kamada_kawai_spring_layout.hpp
@@ -106,7 +106,7 @@ namespace boost {
     template <>
     struct linear_solver<3> {
       template <typename Vec>
-      static Vec solve(double mat[2][2], Vec rhs) {
+      static Vec solve(double mat[3][3], Vec rhs) {
         double denom = mat[0][0] * (mat[1][1] * mat[2][2] - mat[2][1] * mat[1][2])
                      - mat[1][0] * (mat[0][1] * mat[2][2] - mat[2][1] * mat[0][2])
                      + mat[2][0] * (mat[0][1] * mat[1][2] - mat[1][1] * mat[0][2]);


### PR DESCRIPTION
//There was a bug in line 109 
matrix size should be 3x3 else it will give segmentation fault (index out of range).