### PR TITLE
use graph_traits to access *_category types of a Graph

### DIFF
--- a/include/boost/graph/copy.hpp
+++ b/include/boost/graph/copy.hpp
@@ -248,8 +248,8 @@ namespace boost {
 
     template <class Graph>
     struct choose_graph_copy {
-      typedef typename Graph::traversal_category Trv;
-      typedef typename Graph::directed_category Dr;
+      typedef typename graph_traits<Graph>::traversal_category Trv;
+      typedef typename graph_traits<Graph>::directed_category Dr;
       enum { algo = 
              (is_convertible<Trv, vertex_list_graph_tag>::value
               && is_convertible<Trv, edge_list_graph_tag>::value)


### PR DESCRIPTION
`Graph` does not necessarily contain the categories. some of my code fails to compile because of this.