### PR TITLE
Fixes bug #10449 (copy constructor of directed_graph is broken)

### DIFF
--- a/include/boost/graph/directed_graph.hpp
+++ b/include/boost/graph/directed_graph.hpp
@@ -92,7 +92,7 @@ public:
     { }
 
     directed_graph(directed_graph const& x)
-        : m_graph(x), m_num_vertices(x.m_num_vertices), m_num_edges(x.m_num_edges)
+        : m_graph(x.m_graph), m_num_vertices(x.m_num_vertices), m_num_edges(x.m_num_edges)
         , m_max_vertex_index(x.m_max_vertex_index), m_max_edge_index(x.m_max_edge_index)
     { }
 


### PR DESCRIPTION
Without this patch it is not possible to call the copy constructor of directed_graph.
I.e. the following code will not compile without the fix:

    boost::directed_graph<> d;
    boost::directed_graph<> d2(d);