### PR TITLE
Fix #11374 and #12038: issues with `find_flow_cost()`, bundled properties and named parameters

### DIFF
--- a/include/boost/graph/find_flow_cost.hpp
+++ b/include/boost/graph/find_flow_cost.hpp
@@ -14,9 +14,9 @@
 namespace boost {
 
 template<class Graph, class Capacity, class ResidualCapacity, class Weight>
-typename property_traits<typename property_map < Graph, edge_capacity_t >::type>::value_type
+typename property_traits<Weight>::value_type
 find_flow_cost(const Graph & g, Capacity capacity, ResidualCapacity residual_capacity, Weight weight) {
-    typedef typename property_traits<typename property_map<Graph, edge_weight_t>::const_type>::value_type Cost;
+    typedef typename property_traits<Weight>::value_type Cost;
 
     Cost cost = 0;
     BGL_FORALL_EDGES_T(e, g, Graph) {

--- a/include/boost/graph/find_flow_cost.hpp
+++ b/include/boost/graph/find_flow_cost.hpp
@@ -28,7 +28,7 @@ find_flow_cost(const Graph & g, Capacity capacity, ResidualCapacity residual_cap
 }
 
 template <class Graph, class P, class T, class R> 
-typename property_traits<typename property_map < Graph, edge_capacity_t >::type>::value_type
+typename detail::edge_weight_value<Graph, P, T, R>::type
 find_flow_cost(const Graph & g,
                const bgl_named_params<P, T, R>& params) {
     return find_flow_cost(g,

--- a/include/boost/graph/named_function_params.hpp
+++ b/include/boost/graph/named_function_params.hpp
@@ -326,6 +326,14 @@ BOOST_BGL_DECLARE_NAMED_PARAMS
       typedef typename detail::choose_impl_result<boost::mpl::true_, Graph, typename get_param_type<edge_capacity_t, Params>::type, edge_capacity_t>::type CapacityEdgeMap;
       typedef typename property_traits<CapacityEdgeMap>::value_type type;
     };
+    // used in the max-flow algorithms
+    template <class Graph, class P, class T, class R>
+    struct edge_weight_value
+    {
+      typedef bgl_named_params<P, T, R> Params;
+      typedef typename detail::choose_impl_result<boost::mpl::true_, Graph, typename get_param_type<edge_weight_t, Params>::type, edge_weight_t>::type WeightMap;
+      typedef typename property_traits<WeightMap>::value_type type;
+    };
 
   }
 

--- a/include/boost/graph/named_function_params.hpp
+++ b/include/boost/graph/named_function_params.hpp
@@ -323,7 +323,7 @@ BOOST_BGL_DECLARE_NAMED_PARAMS
     struct edge_capacity_value
     {
       typedef bgl_named_params<P, T, R> Params;
-      typedef typename detail::choose_impl_result<boost::mpl::true_, Graph, typename get_param_type<Params, edge_capacity_t>::type, edge_capacity_t>::type CapacityEdgeMap;
+      typedef typename detail::choose_impl_result<boost::mpl::true_, Graph, typename get_param_type<edge_capacity_t, Params>::type, edge_capacity_t>::type CapacityEdgeMap;
       typedef typename property_traits<CapacityEdgeMap>::value_type type;
     };
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -136,6 +136,7 @@ test-suite graph_test :
     [ run cycle_canceling_test.cpp ../../test/build//boost_unit_test_framework/<link>static ]
     [ run strong_components_test.cpp ]
     [ run find_flow_cost_bundled_properties_and_named_params_test.cpp ../../test/build//boost_unit_test_framework/<link>static ]
+	[ run max_flow_algorithms_bundled_properties_and_named_params.cpp ../../test/build//boost_unit_test_framework/<link>static ]
     ;
 
 # Run SDB tests only when -sSDB= is set.

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -136,7 +136,7 @@ test-suite graph_test :
     [ run cycle_canceling_test.cpp ../../test/build//boost_unit_test_framework/<link>static ]
     [ run strong_components_test.cpp ]
     [ run find_flow_cost_bundled_properties_and_named_params_test.cpp ../../test/build//boost_unit_test_framework/<link>static ]
-	[ run max_flow_algorithms_bundled_properties_and_named_params.cpp ../../test/build//boost_unit_test_framework/<link>static ]
+    [ run max_flow_algorithms_bundled_properties_and_named_params.cpp ../../test/build//boost_unit_test_framework/<link>static ]
     ;
 
 # Run SDB tests only when -sSDB= is set.

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -135,6 +135,7 @@ test-suite graph_test :
     [ run successive_shortest_path_nonnegative_weights_test.cpp ../../test/build//boost_unit_test_framework/<link>static ]
     [ run cycle_canceling_test.cpp ../../test/build//boost_unit_test_framework/<link>static ]
     [ run strong_components_test.cpp ]
+    [ run find_flow_cost_bundled_properties_and_named_params_test.cpp ../../test/build//boost_unit_test_framework/<link>static ]
     ;
 
 # Run SDB tests only when -sSDB= is set.

--- a/test/find_flow_cost_bundled_properties_and_named_params_test.cpp
+++ b/test/find_flow_cost_bundled_properties_and_named_params_test.cpp
@@ -7,73 +7,73 @@
 
 typedef boost::adjacency_list_traits<boost::vecS,boost::vecS,boost::directedS> traits;
 struct edge_t {
-	double capacity;
-	float cost;
-	float residual_capacity;
-	traits::edge_descriptor reversed_edge;
+  double capacity;
+  float cost;
+  float residual_capacity;
+  traits::edge_descriptor reversed_edge;
 };
 struct node_t {
-	traits::edge_descriptor predecessor;
-	int dist;
-	int dist_prev;
-	boost::vertex_index_t id;
+  traits::edge_descriptor predecessor;
+  int dist;
+  int dist_prev;
+  boost::vertex_index_t id;
 };
 typedef boost::adjacency_list<boost::listS, boost::vecS, boost::directedS, node_t, edge_t > Graph;
 
 // Unit test written in order to fails (at compile time) if the find_flow_cost()
 // is not properly handling bundled properties
-BOOST_AUTO_TEST_CASE(using_bundled_properties_with_find_max_flow_test) 
+BOOST_AUTO_TEST_CASE(using_bundled_properties_with_find_max_flow_test)
 {
-	Graph g;
-	traits::vertex_descriptor s,t;
+  Graph g;
+  traits::vertex_descriptor s,t;
 
-	boost::property_map<Graph,double edge_t::* >::type capacity = get(&edge_t::capacity, g);
-	boost::property_map<Graph,float edge_t::* >::type cost = get(&edge_t::cost, g);
-	boost::property_map<Graph,float edge_t::* >::type residual_capacity = get(&edge_t::residual_capacity, g);
-	boost::property_map<Graph,traits::edge_descriptor edge_t::* >::type rev = get(&edge_t::reversed_edge, g);
-	boost::property_map<Graph,traits::edge_descriptor node_t::* >::type pred = get(&node_t::predecessor, g);
-	boost::property_map<Graph,boost::vertex_index_t>::type vertex_indices = get(boost::vertex_index, g);	
-	boost::property_map<Graph,int node_t::* >::type dist = get(&node_t::dist, g);
-	boost::property_map<Graph,int node_t::* >::type dist_prev = get(&node_t::dist_prev, g);
-	
+  boost::property_map<Graph,double edge_t::* >::type capacity = get(&edge_t::capacity, g);
+  boost::property_map<Graph,float edge_t::* >::type cost = get(&edge_t::cost, g);
+  boost::property_map<Graph,float edge_t::* >::type residual_capacity = get(&edge_t::residual_capacity, g);
+  boost::property_map<Graph,traits::edge_descriptor edge_t::* >::type rev = get(&edge_t::reversed_edge, g);
+  boost::property_map<Graph,traits::edge_descriptor node_t::* >::type pred = get(&node_t::predecessor, g);
+  boost::property_map<Graph,boost::vertex_index_t>::type vertex_indices = get(boost::vertex_index, g);
+  boost::property_map<Graph,int node_t::* >::type dist = get(&node_t::dist, g);
+  boost::property_map<Graph,int node_t::* >::type dist_prev = get(&node_t::dist_prev, g);
 
-	boost::SampleGraph::getSampleGraph(g,s,t,capacity,residual_capacity,cost,rev);
-	
-    boost::successive_shortest_path_nonnegative_weights(g,s,t,
-			capacity,residual_capacity,cost,rev,vertex_indices,
-			pred,dist,dist_prev);
 
-	// The "bundled properties" version (producing errors)	
-	int flow_cost = boost::find_flow_cost(g,capacity,residual_capacity,cost);
-	BOOST_CHECK_EQUAL(flow_cost, 29);
+  boost::SampleGraph::getSampleGraph(g,s,t,capacity,residual_capacity,cost,rev);
+
+  boost::successive_shortest_path_nonnegative_weights(g,s,t,
+      capacity,residual_capacity,cost,rev,vertex_indices,
+      pred,dist,dist_prev);
+
+  // The "bundled properties" version (producing errors)
+  int flow_cost = boost::find_flow_cost(g,capacity,residual_capacity,cost);
+  BOOST_CHECK_EQUAL(flow_cost, 29);
 }
 
 // Unit test written in order to fails (at compile time) if the find_flow_cost()
 // is not properly handling bundled properties
-BOOST_AUTO_TEST_CASE(using_named_params_and_bundled_properties_with_find_max_flow_test) 
+BOOST_AUTO_TEST_CASE(using_named_params_and_bundled_properties_with_find_max_flow_test)
 {
-	Graph g;
-	traits::vertex_descriptor s,t;
+  Graph g;
+  traits::vertex_descriptor s,t;
 
-	boost::property_map<Graph,double edge_t::* >::type capacity = get(&edge_t::capacity, g);
-	boost::property_map<Graph,float edge_t::* >::type cost = get(&edge_t::cost, g);
-	boost::property_map<Graph,float edge_t::* >::type residual_capacity = get(&edge_t::residual_capacity, g);
-	boost::property_map<Graph,traits::edge_descriptor edge_t::* >::type rev = get(&edge_t::reversed_edge, g);
-	boost::property_map<Graph,traits::edge_descriptor node_t::* >::type pred = get(&node_t::predecessor, g);
-	boost::property_map<Graph,boost::vertex_index_t>::type vertex_indices = get(boost::vertex_index, g);	
-	boost::property_map<Graph,int node_t::* >::type dist = get(&node_t::dist, g);
-	boost::property_map<Graph,int node_t::* >::type dist_prev = get(&node_t::dist_prev, g);
-	
-	boost::SampleGraph::getSampleGraph(g,s,t,capacity,residual_capacity,cost,rev);
-	
-    boost::successive_shortest_path_nonnegative_weights(g,s,t,
-			capacity,residual_capacity,cost,rev,vertex_indices,
-			pred,dist,dist_prev);
+  boost::property_map<Graph,double edge_t::* >::type capacity = get(&edge_t::capacity, g);
+  boost::property_map<Graph,float edge_t::* >::type cost = get(&edge_t::cost, g);
+  boost::property_map<Graph,float edge_t::* >::type residual_capacity = get(&edge_t::residual_capacity, g);
+  boost::property_map<Graph,traits::edge_descriptor edge_t::* >::type rev = get(&edge_t::reversed_edge, g);
+  boost::property_map<Graph,traits::edge_descriptor node_t::* >::type pred = get(&node_t::predecessor, g);
+  boost::property_map<Graph,boost::vertex_index_t>::type vertex_indices = get(boost::vertex_index, g);
+  boost::property_map<Graph,int node_t::* >::type dist = get(&node_t::dist, g);
+  boost::property_map<Graph,int node_t::* >::type dist_prev = get(&node_t::dist_prev, g);
 
-	// The  "named parameters" version (with "bundled properties"; producing errors)	
-	int flow_cost = boost::find_flow_cost(g,
-			boost::capacity_map(capacity)
-			.residual_capacity_map(residual_capacity)
-			.weight_map(cost));
-	BOOST_CHECK_EQUAL(flow_cost, 29);
+  boost::SampleGraph::getSampleGraph(g,s,t,capacity,residual_capacity,cost,rev);
+
+  boost::successive_shortest_path_nonnegative_weights(g,s,t,
+    capacity,residual_capacity,cost,rev,vertex_indices,
+    pred,dist,dist_prev);
+
+  // The  "named parameters" version (with "bundled properties"; producing errors)
+  int flow_cost = boost::find_flow_cost(g,
+    boost::capacity_map(capacity)
+    .residual_capacity_map(residual_capacity)
+    .weight_map(cost));
+  BOOST_CHECK_EQUAL(flow_cost, 29);
 }

--- a/test/find_flow_cost_bundled_properties_and_named_params_test.cpp
+++ b/test/find_flow_cost_bundled_properties_and_named_params_test.cpp
@@ -1,0 +1,79 @@
+#define BOOST_TEST_MODULE find_flow_cost_bundled_properties_and_named_params_test
+
+#include <boost/test/unit_test.hpp>
+#include <boost/graph/successive_shortest_path_nonnegative_weights.hpp>
+#include <boost/graph/find_flow_cost.hpp>
+#include "min_cost_max_flow_utils.hpp"
+
+typedef boost::adjacency_list_traits<boost::vecS,boost::vecS,boost::directedS> traits;
+struct edge_t {
+	double capacity;
+	float cost;
+	float residual_capacity;
+	traits::edge_descriptor reversed_edge;
+};
+struct node_t {
+	traits::edge_descriptor predecessor;
+	int dist;
+	int dist_prev;
+	boost::vertex_index_t id;
+};
+typedef boost::adjacency_list<boost::listS, boost::vecS, boost::directedS, node_t, edge_t > Graph;
+
+// Unit test written in order to fails (at compile time) if the find_flow_cost()
+// is not properly handling bundled properties
+BOOST_AUTO_TEST_CASE(using_bundled_properties_with_find_max_flow_test) 
+{
+	Graph g;
+	traits::vertex_descriptor s,t;
+
+	boost::property_map<Graph,double edge_t::* >::type capacity = get(&edge_t::capacity, g);
+	boost::property_map<Graph,float edge_t::* >::type cost = get(&edge_t::cost, g);
+	boost::property_map<Graph,float edge_t::* >::type residual_capacity = get(&edge_t::residual_capacity, g);
+	boost::property_map<Graph,traits::edge_descriptor edge_t::* >::type rev = get(&edge_t::reversed_edge, g);
+	boost::property_map<Graph,traits::edge_descriptor node_t::* >::type pred = get(&node_t::predecessor, g);
+	boost::property_map<Graph,boost::vertex_index_t>::type vertex_indices = get(boost::vertex_index, g);	
+	boost::property_map<Graph,int node_t::* >::type dist = get(&node_t::dist, g);
+	boost::property_map<Graph,int node_t::* >::type dist_prev = get(&node_t::dist_prev, g);
+	
+
+	boost::SampleGraph::getSampleGraph(g,s,t,capacity,residual_capacity,cost,rev);
+	
+    boost::successive_shortest_path_nonnegative_weights(g,s,t,
+			capacity,residual_capacity,cost,rev,vertex_indices,
+			pred,dist,dist_prev);
+
+	// The "bundled properties" version (producing errors)	
+	int flow_cost = boost::find_flow_cost(g,capacity,residual_capacity,cost);
+	BOOST_CHECK_EQUAL(flow_cost, 29);
+}
+
+// Unit test written in order to fails (at compile time) if the find_flow_cost()
+// is not properly handling bundled properties
+BOOST_AUTO_TEST_CASE(using_named_params_and_bundled_properties_with_find_max_flow_test) 
+{
+	Graph g;
+	traits::vertex_descriptor s,t;
+
+	boost::property_map<Graph,double edge_t::* >::type capacity = get(&edge_t::capacity, g);
+	boost::property_map<Graph,float edge_t::* >::type cost = get(&edge_t::cost, g);
+	boost::property_map<Graph,float edge_t::* >::type residual_capacity = get(&edge_t::residual_capacity, g);
+	boost::property_map<Graph,traits::edge_descriptor edge_t::* >::type rev = get(&edge_t::reversed_edge, g);
+	boost::property_map<Graph,traits::edge_descriptor node_t::* >::type pred = get(&node_t::predecessor, g);
+	boost::property_map<Graph,boost::vertex_index_t>::type vertex_indices = get(boost::vertex_index, g);	
+	boost::property_map<Graph,int node_t::* >::type dist = get(&node_t::dist, g);
+	boost::property_map<Graph,int node_t::* >::type dist_prev = get(&node_t::dist_prev, g);
+	
+	boost::SampleGraph::getSampleGraph(g,s,t,capacity,residual_capacity,cost,rev);
+	
+    boost::successive_shortest_path_nonnegative_weights(g,s,t,
+			capacity,residual_capacity,cost,rev,vertex_indices,
+			pred,dist,dist_prev);
+
+	// The  "named parameters" version (with "bundled properties"; producing errors)	
+	int flow_cost = boost::find_flow_cost(g,
+			boost::capacity_map(capacity)
+			.residual_capacity_map(residual_capacity)
+			.weight_map(cost));
+	BOOST_CHECK_EQUAL(flow_cost, 29);
+}

--- a/test/max_flow_algorithms_bundled_properties_and_named_params.cpp
+++ b/test/max_flow_algorithms_bundled_properties_and_named_params.cpp
@@ -8,42 +8,42 @@
 
 typedef boost::adjacency_list_traits<boost::vecS,boost::vecS,boost::directedS> traits;
 struct edge_t {
-	double capacity;
-	float cost;
-	float residual_capacity;
-	traits::edge_descriptor reversed_edge;
+  double capacity;
+  float cost;
+  float residual_capacity;
+  traits::edge_descriptor reversed_edge;
 };
 struct node_t {
-	traits::edge_descriptor predecessor;
-	int dist;
-	int dist_prev;
-	boost::vertex_index_t id;
-	boost::default_color_type color;
+  traits::edge_descriptor predecessor;
+  int dist;
+  int dist_prev;
+  boost::vertex_index_t id;
+  boost::default_color_type color;
 };
 typedef boost::adjacency_list<boost::listS, boost::vecS, boost::directedS, node_t, edge_t > Graph;
 
-BOOST_AUTO_TEST_CASE(using_named_parameters_and_bundled_params_on_edmonds_karp_max_flow_test) 
+BOOST_AUTO_TEST_CASE(using_named_parameters_and_bundled_params_on_edmonds_karp_max_flow_test)
 {
-	Graph g;
-	traits::vertex_descriptor s,t;
+  Graph g;
+  traits::vertex_descriptor s,t;
 
-	boost::property_map<Graph,double edge_t::* >::type capacity = get(&edge_t::capacity, g);
-	boost::property_map<Graph,float edge_t::* >::type cost = get(&edge_t::cost, g);
-	boost::property_map<Graph,float edge_t::* >::type residual_capacity = get(&edge_t::residual_capacity, g);
-	boost::property_map<Graph,traits::edge_descriptor edge_t::* >::type rev = get(&edge_t::reversed_edge, g);
-	boost::property_map<Graph,traits::edge_descriptor node_t::* >::type pred = get(&node_t::predecessor, g);
-	boost::property_map<Graph,boost::default_color_type node_t::* >::type col = get(&node_t::color, g);
+  boost::property_map<Graph,double edge_t::* >::type capacity = get(&edge_t::capacity, g);
+  boost::property_map<Graph,float edge_t::* >::type cost = get(&edge_t::cost, g);
+  boost::property_map<Graph,float edge_t::* >::type residual_capacity = get(&edge_t::residual_capacity, g);
+  boost::property_map<Graph,traits::edge_descriptor edge_t::* >::type rev = get(&edge_t::reversed_edge, g);
+  boost::property_map<Graph,traits::edge_descriptor node_t::* >::type pred = get(&node_t::predecessor, g);
+  boost::property_map<Graph,boost::default_color_type node_t::* >::type col = get(&node_t::color, g);
 
-	boost::SampleGraph::getSampleGraph(g,s,t,capacity,residual_capacity,cost,rev);
+  boost::SampleGraph::getSampleGraph(g,s,t,capacity,residual_capacity,cost,rev);
 
-	// The "named parameter version" (producing errors)
-	// I chose to show the error with edmonds_karp_max_flow().
-	int flow_value = edmonds_karp_max_flow(g, s, t,
-			boost::capacity_map(capacity)
-			.residual_capacity_map(residual_capacity)
-			.reverse_edge_map(rev)
-			.color_map(col)
-			.predecessor_map(pred));
+  // The "named parameter version" (producing errors)
+  // I chose to show the error with edmonds_karp_max_flow().
+  int flow_value = edmonds_karp_max_flow(g, s, t,
+    boost::capacity_map(capacity)
+    .residual_capacity_map(residual_capacity)
+    .reverse_edge_map(rev)
+    .color_map(col)
+    .predecessor_map(pred));
 
-	BOOST_CHECK_EQUAL(flow_value,4);
+  BOOST_CHECK_EQUAL(flow_value,4);
 }

--- a/test/max_flow_algorithms_bundled_properties_and_named_params.cpp
+++ b/test/max_flow_algorithms_bundled_properties_and_named_params.cpp
@@ -1,0 +1,49 @@
+#define BOOST_TEST_MODULE max_flow_algorithms_named_parameters_and_bundled_params_test
+
+#include <boost/graph/adjacency_list.hpp>
+#include <boost/test/unit_test.hpp>
+#include <boost/graph/edmonds_karp_max_flow.hpp>
+
+#include "min_cost_max_flow_utils.hpp"
+
+typedef boost::adjacency_list_traits<boost::vecS,boost::vecS,boost::directedS> traits;
+struct edge_t {
+	double capacity;
+	float cost;
+	float residual_capacity;
+	traits::edge_descriptor reversed_edge;
+};
+struct node_t {
+	traits::edge_descriptor predecessor;
+	int dist;
+	int dist_prev;
+	boost::vertex_index_t id;
+	boost::default_color_type color;
+};
+typedef boost::adjacency_list<boost::listS, boost::vecS, boost::directedS, node_t, edge_t > Graph;
+
+BOOST_AUTO_TEST_CASE(using_named_parameters_and_bundled_params_on_edmonds_karp_max_flow_test) 
+{
+	Graph g;
+	traits::vertex_descriptor s,t;
+
+	boost::property_map<Graph,double edge_t::* >::type capacity = get(&edge_t::capacity, g);
+	boost::property_map<Graph,float edge_t::* >::type cost = get(&edge_t::cost, g);
+	boost::property_map<Graph,float edge_t::* >::type residual_capacity = get(&edge_t::residual_capacity, g);
+	boost::property_map<Graph,traits::edge_descriptor edge_t::* >::type rev = get(&edge_t::reversed_edge, g);
+	boost::property_map<Graph,traits::edge_descriptor node_t::* >::type pred = get(&node_t::predecessor, g);
+	boost::property_map<Graph,boost::default_color_type node_t::* >::type col = get(&node_t::color, g);
+
+	boost::SampleGraph::getSampleGraph(g,s,t,capacity,residual_capacity,cost,rev);
+
+	// The "named parameter version" (producing errors)
+	// I chose to show the error with edmonds_karp_max_flow().
+	int flow_value = edmonds_karp_max_flow(g, s, t,
+			boost::capacity_map(capacity)
+			.residual_capacity_map(residual_capacity)
+			.reverse_edge_map(rev)
+			.color_map(col)
+			.predecessor_map(pred));
+
+	BOOST_CHECK_EQUAL(flow_value,4);
+}

--- a/test/min_cost_max_flow_utils.hpp
+++ b/test/min_cost_max_flow_utils.hpp
@@ -34,7 +34,7 @@ struct SampleGraph {
     typedef boost::graph_traits<Graph>::vertices_size_type size_type;
     typedef Traits::vertex_descriptor vertex_descriptor;
     
-	template <class Graph, class Weight, class Capacity, class Reversed, class ResidualCapacity>
+    template <class Graph, class Weight, class Capacity, class Reversed, class ResidualCapacity>
     class EdgeAdder {
     public:
       EdgeAdder(Graph& g, Weight& w, Capacity& c, Reversed& rev
@@ -69,18 +69,18 @@ struct SampleGraph {
     };
 
 
-	static void getSampleGraph(Graph &g, vertex_descriptor & s, vertex_descriptor & t) {
-		Capacity  capacity = get(edge_capacity, g);
-		Reversed rev = get(edge_reverse, g);
-		ResidualCapacity residual_capacity = get(edge_residual_capacity, g); 
-		Weight weight = get(edge_weight, g);
-		getSampleGraph(g,s,t,capacity,residual_capacity,weight,rev);
-	}
+    static void getSampleGraph(Graph &g, vertex_descriptor & s, vertex_descriptor & t) {
+        Capacity  capacity = get(edge_capacity, g);
+        Reversed rev = get(edge_reverse, g);
+        ResidualCapacity residual_capacity = get(edge_residual_capacity, g); 
+        Weight weight = get(edge_weight, g);
+        getSampleGraph(g,s,t,capacity,residual_capacity,weight,rev);
+    }
 
-	template <class Graph, class Weight, class Capacity, class Reversed, class ResidualCapacity>
+    template <class Graph, class Weight, class Capacity, class Reversed, class ResidualCapacity>
     static void 
-	getSampleGraph(Graph &g, vertex_descriptor & s, vertex_descriptor & t, 
-			Capacity capacity, ResidualCapacity residual_capacity, Weight weight, Reversed rev) {
+    getSampleGraph(Graph &g, vertex_descriptor & s, vertex_descriptor & t, 
+            Capacity capacity, ResidualCapacity residual_capacity, Weight weight, Reversed rev) {
         size_type N(6);
 
         for(size_type i = 0; i < N; ++i){

--- a/test/min_cost_max_flow_utils.hpp
+++ b/test/min_cost_max_flow_utils.hpp
@@ -34,6 +34,7 @@ struct SampleGraph {
     typedef boost::graph_traits<Graph>::vertices_size_type size_type;
     typedef Traits::vertex_descriptor vertex_descriptor;
     
+	template <class Graph, class Weight, class Capacity, class Reversed, class ResidualCapacity>
     class EdgeAdder {
     public:
       EdgeAdder(Graph& g, Weight& w, Capacity& c, Reversed& rev
@@ -67,22 +68,29 @@ struct SampleGraph {
       Reversed & m_rev;
     };
 
-    static void getSampleGraph(Graph &g, vertex_descriptor & s, vertex_descriptor & t) {
+
+	static void getSampleGraph(Graph &g, vertex_descriptor & s, vertex_descriptor & t) {
+		Capacity  capacity = get(edge_capacity, g);
+		Reversed rev = get(edge_reverse, g);
+		ResidualCapacity residual_capacity = get(edge_residual_capacity, g); 
+		Weight weight = get(edge_weight, g);
+		getSampleGraph(g,s,t,capacity,residual_capacity,weight,rev);
+	}
+
+	template <class Graph, class Weight, class Capacity, class Reversed, class ResidualCapacity>
+    static void 
+	getSampleGraph(Graph &g, vertex_descriptor & s, vertex_descriptor & t, 
+			Capacity capacity, ResidualCapacity residual_capacity, Weight weight, Reversed rev) {
         size_type N(6);
-        typedef property_map < Graph, edge_reverse_t >::type Reversed;
 
         for(size_type i = 0; i < N; ++i){
             add_vertex(g);
         }
-        Capacity  capacity = get(edge_capacity, g);
-        Reversed rev = get(edge_reverse, g);
-        ResidualCapacity residual_capacity = get(edge_residual_capacity, g); 
-        Weight weight = get(edge_weight, g);
 
         s = 0;
         t = 5;
 
-        EdgeAdder ea(g, weight, capacity, rev, residual_capacity);
+        EdgeAdder<Graph, Weight, Capacity, Reversed, ResidualCapacity> ea(g, weight, capacity, rev, residual_capacity);
 
         ea.addEdge(0, 1, 4 ,2);
         ea.addEdge(0, 2, 2 ,2);
@@ -113,7 +121,7 @@ struct SampleGraph {
         s = 0;
         t = 4;
 
-        EdgeAdder ea(g, weight, capacity, rev, residual_capacity);
+        EdgeAdder<Graph, Weight, Capacity, Reversed, ResidualCapacity> ea(g, weight, capacity, rev, residual_capacity);
 
         ea.addEdge(0, 1, 4 ,2);
         ea.addEdge(0, 2, 2 ,2);


### PR DESCRIPTION
I talked about that problem on [stackoverflow](http://stackoverflow.com/questions/30621255/using-named-parameters-and-bundled-properties-with-edmonds-karp-max-flow). This PR solves two different tickets because the cause was almost the same (bundled properties had not been tested thoroughly).  
Here are the tickets: 
- Issue [#11374](https://svn.boost.org/trac/boost/ticket/11374): `find_flow_cost()` won't work with bundled properties in conjonction to named parameters
- Issue [#12038](https://svn.boost.org/trac/boost/ticket/12038): every max-flow function (e.g. `edmonds_karp_max_flow()`) won't work with named parameters 

I apologize for having mixed those two issues in one PR ; I did try to separate them, but the last one (bundled properties and named parameters with `find_flow_cost()`) needed the two other commits.


