### PR TITLE
Add Travis-ci as the continuous integration service for Boost.Graph

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@
 #
 # Mael Valais, 2016
 # This travis file has been inspired from boostorg/geometry/circle.yml.
-# 
-# This file is intended to make use of travis-ci, a continuous integration 
+#
+# This file is intended to make use of travis-ci, a continuous integration
 # service. The purpose is to build and run the tests on the graph module
 # on every push, and be able to know if those commits are "clean" or if
 # they break the build.
@@ -19,16 +19,20 @@
 #    - develop
 #    - test
 
-language: c
+language: cpp
 compiler: gcc
 
 env:
   global:
     - BOOST_BRANCH=$([[ "$TRAVIS_BRANCH" = "master" ]] && echo master || echo develop)
     - BOOST=boost-local # must be different from graph/boost dir name
+addons:
+  apt:
+    sources: ubuntu-toolchain-r-test
+    packages: g++-4.8
 
 before_install:
-  # clone boost repository
+  # Clone boost repository
   - cd
   - mkdir $BOOST && cd $BOOST
   - git init .
@@ -43,7 +47,7 @@ before_install:
   - git submodule foreach "git reset --quiet --hard; git clean -fxd"
   - git reset --hard; git clean -fxd
   - git status
-    
+
   # replace the content of the library with the currently tested repo
   - cd && pwd && ls
   - rm -rf $BOOST/libs/graph
@@ -58,4 +62,4 @@ before_install:
 # This part is meant for unit tests
 script:
   - cd $HOME/$BOOST/libs/graph/test
-  - ../../../b2 cxxflags="-std=c++11"
+  - ../../../b2 toolset=gcc-4.8 cxxflags=-std=c++11

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,61 @@
+# Use, modification, and distribution are
+# subject to the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#
+# Mael Valais, 2016
+# This travis file has been inspired from boostorg/geometry/circle.yml.
+# 
+# This file is intended to make use of travis-ci, a continuous integration 
+# service. The purpose is to build and run the tests on the graph module
+# on every push, and be able to know if those commits are "clean" or if
+# they break the build.
+#
+
+# I think that we shouldn't restrict on branches: PRs must also be tested
+# So for now, I disabled the "only on branches" feature
+#branches:
+#  only:
+#    - master
+#    - develop
+#    - test
+
+language: c
+compiler: gcc
+
+env:
+  global:
+    - BOOST_BRANCH=$([[ "$TRAVIS_BRANCH" = "master" ]] && echo master || echo develop)
+    - BOOST=boost-local # must be different from graph/boost dir name
+
+before_install:
+  # clone boost repository
+  - cd
+  - mkdir $BOOST && cd $BOOST
+  - git init .
+  - git remote add --no-tags -t $BOOST_BRANCH origin https://github.com/boostorg/boost.git
+  - git fetch --depth=1
+  - git checkout $BOOST_BRANCH
+  - git submodule update --init --merge
+  - git remote set-branches --add origin $BOOST_BRANCH
+  - git pull --recurse-submodules
+  - git submodule update --init
+  - git checkout $BOOST_BRANCH
+  - git submodule foreach "git reset --quiet --hard; git clean -fxd"
+  - git reset --hard; git clean -fxd
+  - git status
+    
+  # replace the content of the library with the currently tested repo
+  - cd && pwd && ls
+  - rm -rf $BOOST/libs/graph
+  - cd $TRAVIS_BUILD_DIR && cd ..
+  - mv graph $HOME/$BOOST/libs/
+
+  # build b2 and create headers
+  - cd && cd $BOOST
+  - ./bootstrap.sh
+  - ./b2 headers
+
+# This part is meant for unit tests
+script:
+  - cd $HOME/$BOOST/libs/graph/test
+  - ../../../b2

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,4 +58,4 @@ before_install:
 # This part is meant for unit tests
 script:
   - cd $HOME/$BOOST/libs/graph/test
-  - ../../../b2
+  - ../../../b2 cxxflags="-std=c++11"


### PR DESCRIPTION
I thought it would be a great idea to have the test running from a
"neutral entity" instead of having to checkout the pull request and

```
cd libs/graph/test && ../../../b2
```

I saw that many other boostorg submodules had their own CI system:
- compute relies on travis-ci
- geometry uses circleci

The major difference between circleci and travis-ci is the multi-threading supported by circleci. Both are free for open-source project (as of 2016/04/26). I chose travis-ci because I know how to configure it.

As for geometry, we could also use coveralls.io to display the test covering reports and improve the quality/coverage of tests on boostorg/graph.

**IMPORTANT: a member of boostorg will have to add the repo boostorg/graph into travis-ci for it to work.**

I tested this file against [my fork](https://github.com/maelvalais/graph/). Here is the [travis-ci part](https://travis-ci.org/maelvalais/graph/). It works great!

The only slight issue is that it takes ~10min to build and test, but it's totally fine.

Here is what displays when opening a PR:

[![capture d ecran 2016-05-03 a 10 36 16](https://cloud.githubusercontent.com/assets/2195781/14978845/eaf15ee4-111e-11e6-94b9-9601e430182c.png)](https://github.com/maelvalais/graph/pull/1)
![capture d ecran 2016-05-03 a 11 04 55](https://cloud.githubusercontent.com/assets/2195781/14978865/0b321946-111f-11e6-9a41-991f0bf793c3.png)
