### PR TITLE
bc_clustering: Remove an unused typedef.

### DIFF
--- a/include/boost/graph/bc_clustering.hpp
+++ b/include/boost/graph/bc_clustering.hpp
@@ -114,8 +114,6 @@ betweenness_centrality_clustering(MutableGraph& g, Done done,
     centrality_type;
   typedef typename graph_traits<MutableGraph>::edge_iterator edge_iterator;
   typedef typename graph_traits<MutableGraph>::edge_descriptor edge_descriptor;
-  typedef typename graph_traits<MutableGraph>::vertices_size_type
-    vertices_size_type;
 
   if (has_no_edges(g)) return;
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/boostorg/graph/66)
<!-- Reviewable:end -->
