### PR TITLE
Add a .clang-format file.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,16 @@
+BasedOnStyle: WebKit
+Standard: Cpp11
+AlignAfterOpenBracket: false
+AlignEscapedNewlinesLeft: true
+AlwaysBreakAfterDefinitionReturnType: None
+BreakBeforeBraces: Allman
+BreakConstructorInitializersBeforeComma: false
+ColumnLimit: 80
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 0
+IndentCaseLabels: false
+SortIncludes: false
+AlignTrailingComments: false
+
+SpacesInAngles: true
+


### PR DESCRIPTION
So we can at least make the examples use a more consistent code style.

Run clang-format like so:
$ clang-format -i *.cpp
and use git diff to see what has changed.

This will strip trailing whitespace too. You can ignore that by
using git diff -w

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/boostorg/graph/68)

<!-- Reviewable:end -->
