### PR TITLE
Remove any support for slist, which is a deprecated gcc extension.

### DIFF
--- a/include/boost/graph/adjacency_list.hpp
+++ b/include/boost/graph/adjacency_list.hpp
@@ -20,14 +20,6 @@
 
 #include <boost/unordered_set.hpp>
 
-#if !defined BOOST_NO_SLIST
-#  ifdef BOOST_SLIST_HEADER
-#    include BOOST_SLIST_HEADER
-#  else
-#    include <slist>
-#  endif
-#endif
-
 #include <boost/scoped_ptr.hpp>
 
 #include <boost/graph/graph_traits.hpp>
@@ -52,10 +44,6 @@ namespace boost {
   // to map the selectors to the container type used to implement the
   // graph.
 
-#if !defined BOOST_NO_SLIST
-  struct slistS {};
-#endif
-
   struct vecS  { };
   struct listS { };
   struct setS { };
@@ -74,12 +62,7 @@ namespace boost {
   struct container_gen<listS, ValueType> {
     typedef std::list<ValueType> type;
   };
-#if !defined BOOST_NO_SLIST
-  template <class ValueType>
-  struct container_gen<slistS, ValueType> {
-    typedef BOOST_STD_EXTENSION_NAMESPACE::slist<ValueType> type;
-  };
-#endif
+
   template <class ValueType>
   struct container_gen<vecS, ValueType> {
     typedef std::vector<ValueType> type;
@@ -135,12 +118,6 @@ namespace boost {
   template <>
   struct parallel_edge_traits<listS> {
     typedef allow_parallel_edge_tag type; };
-
-#if !defined BOOST_NO_SLIST
-  template <>
-  struct parallel_edge_traits<slistS> {
-    typedef allow_parallel_edge_tag type; };
-#endif
 
   template <>
   struct parallel_edge_traits<setS> {

--- a/include/boost/graph/graph_utility.hpp
+++ b/include/boost/graph/graph_utility.hpp
@@ -18,14 +18,6 @@
 #include <boost/config.hpp>
 #include <boost/tuple/tuple.hpp>
 
-#if !defined BOOST_NO_SLIST
-#  ifdef BOOST_SLIST_HEADER
-#    include BOOST_SLIST_HEADER
-#  else
-#    include <slist>
-#  endif
-#endif
-
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/properties.hpp>
 #include <boost/pending/container_traits.hpp>

--- a/include/boost/pending/container_traits.hpp
+++ b/include/boost/pending/container_traits.hpp
@@ -23,14 +23,6 @@
 #include <boost/unordered_set.hpp>
 #include <boost/unordered_map.hpp>
 
-#if !defined BOOST_NO_SLIST
-#  ifdef BOOST_SLIST_HEADER
-#    include BOOST_SLIST_HEADER
-#  else
-#    include <slist>
-#  endif
-#endif
-
 #ifndef BOOST_NO_CXX11_HDR_UNORDERED_SET
 #include <unordered_set>
 #endif
@@ -148,27 +140,6 @@ namespace boost { namespace graph_detail {
     typedef list_tag category;
     typedef stable_tag iterator_stability;
   };
-
-
-  // std::slist
-#ifndef BOOST_NO_SLIST
-  template <class T, class Alloc>
-  struct container_traits<BOOST_STD_EXTENSION_NAMESPACE::slist<T,Alloc> > {
-    typedef front_insertion_sequence_tag category;
-    typedef stable_tag iterator_stability;
-  };
-  template <class T, class Alloc>
-  front_insertion_sequence_tag container_category(
-  const BOOST_STD_EXTENSION_NAMESPACE::slist<T,Alloc>&
-  )
-    { return front_insertion_sequence_tag(); }
-
-  template <class T, class Alloc>
-  stable_tag iterator_stability(
-  const BOOST_STD_EXTENSION_NAMESPACE::slist<T,Alloc>&)
-    { return stable_tag(); }
-#endif
-
 
   // std::set
   struct set_tag :


### PR DESCRIPTION
Maybe this was useful once, but nobody should still be using the deprecated gcc extension std::slist now. Trying to support it clutters the code and can lead to warnings such as this:
https://svn.boost.org/trac/boost/ticket/12048#comment:3

slist seems to have been deprecated by gcc for a long time, so any BGL API that used it was implicitly deprecated too. So removing it now seems fine.

We might want to add support for std::forward_list as a replacement for slist.
