### PR TITLE
random.hpp: weighted_random_out_edge(): Add missing return.

### DIFF
--- a/include/boost/graph/random.hpp
+++ b/include/boost/graph/random.hpp
@@ -103,6 +103,7 @@ namespace boost {
       }
     }
     BOOST_ASSERT (false); // Should not get here
+    return typename graph_traits<Graph>::edge_descriptor();
   }
 
   namespace detail {


### PR DESCRIPTION
This should avoid a compiler warning. For instance:
http://beta.boost.org/development/tests/develop/output/GLIS-homo-impi-graph-intel-linux-warnings.html#cycle_ratio_tests