### PR TITLE
Add degree to reverse_graph

### DIFF
--- a/include/boost/graph/reverse_graph.hpp
+++ b/include/boost/graph/reverse_graph.hpp
@@ -322,6 +322,13 @@ target(const detail::reverse_graph_edge_descriptor<Edge>& e, const reverse_graph
     return source(e.underlying_descx, g.m_g);
 }
 
+template <class BidirectionalGraph, class GRef>
+inline typename graph_traits<BidirectionalGraph>::degree_size_type
+degree(const typename graph_traits<BidirectionalGraph>::vertex_descriptor u,
+          const reverse_graph<BidirectionalGraph,GRef>& g)
+{
+    return degree(u, g.m_g);
+}
 
 namespace detail {
 

--- a/test/reverse_graph_cc.cpp
+++ b/test/reverse_graph_cc.cpp
@@ -25,6 +25,7 @@ int main(int,char*[])
     > AdjList;
     typedef reverse_graph<AdjList> Graph;
     BOOST_CONCEPT_ASSERT(( VertexListGraphConcept<Graph> ));
+    BOOST_CONCEPT_ASSERT(( BidirectionalGraphConcept<Graph> ));
     typedef graph_traits<Graph>::vertex_descriptor Vertex;
     typedef graph_traits<Graph>::edge_descriptor Edge;
     BOOST_CONCEPT_ASSERT(( ReadablePropertyGraphConcept<Graph, Vertex, vertex_color_t> ));
@@ -43,6 +44,7 @@ int main(int,char*[])
     > AdjList;
     typedef reverse_graph<AdjList,AdjList&> Graph;
     BOOST_CONCEPT_ASSERT(( VertexListGraphConcept<Graph> ));
+    BOOST_CONCEPT_ASSERT(( BidirectionalGraphConcept<Graph> ));
     typedef graph_traits<Graph>::vertex_descriptor Vertex;
     typedef graph_traits<Graph>::edge_descriptor Edge;
     BOOST_CONCEPT_ASSERT(( PropertyGraphConcept<Graph, Vertex, vertex_color_t> ));


### PR DESCRIPTION
degree is required for BidirectionalGraphConcept.
Also adds the concept check to the reverse_graph unit test.
