### PR TITLE
fix comments about boost::detail::vector_matrix

### DIFF
--- a/include/boost/graph/exterior_property.hpp
+++ b/include/boost/graph/exterior_property.hpp
@@ -14,8 +14,7 @@
 namespace boost {
 namespace detail {
     // The vector matrix provides a little abstraction over vector
-    // types that makes matrices easier to work with. Note that it's
-    // non-copyable, meaning you should be passing it by value.
+    // types that makes matrices easier to work with.
     template <typename Value>
     struct vector_matrix
     {
@@ -28,7 +27,7 @@ namespace detail {
         typedef container_type* pointer;
         typedef typename matrix_type::size_type size_type;
 
-        // Instantiate the matrix over n elements (creates an nxn matrix).
+        // Instantiate the matrix over n elements (creates an n by n matrix).
         // The graph has to be passed in order to ensure the index maps
         // are constructed correctly when returning indexible elements.
         inline vector_matrix(size_type n)


### PR DESCRIPTION
`vector_matrix` does not seem non-copyable, and a non-copyable object should be passed by _reference_ or _move_ but not _value_.
Anyway, this comment is confusing.