### PR TITLE
Fix compiler error with release builds on VS2015

### DIFF
--- a/include/boost/graph/named_function_params.hpp
+++ b/include/boost/graph/named_function_params.hpp
@@ -228,6 +228,7 @@ BOOST_BGL_DECLARE_NAMED_PARAMS
   };
 
   struct param_not_found {};
+  static param_not_found g_param_not_found;
 
   template <typename Tag, typename Args>
   struct get_param_type: 
@@ -237,7 +238,7 @@ BOOST_BGL_DECLARE_NAMED_PARAMS
   inline
   const typename lookup_named_param_def<Tag, Args, param_not_found>::type&
   get_param(const Args& p, Tag) {
-    return lookup_named_param_def<Tag, Args, param_not_found>::get(p, param_not_found());
+    return lookup_named_param_def<Tag, Args, param_not_found>::get(p, g_param_not_found);
   }
 
   template <class P, class Default> 


### PR DESCRIPTION
When using MSVC compiler optimization, using `param_not_found()` causes compiler error [C4172][1]: returning address of local variable or temporary


[1]: https://msdn.microsoft.com/en-us/library/d0ws2xs1.aspx