### PR TITLE
Qualify calling of as_const.

### DIFF
--- a/test/test_properties.hpp
+++ b/test/test_properties.hpp
@@ -21,7 +21,7 @@ void test_graph_bundle(Graph& g, boost::mpl::true_) {
   GraphBundle& b2 = get_property(g);
   ignore(b1); ignore(b2);
 
-  GraphBundle const& cb1 = as_const(g)[graph_bundle];
+  GraphBundle const& cb1 = ::as_const(g)[graph_bundle];
   GraphBundle const& cb2 = get_property(g);
   ignore(cb1); ignore(cb2);
 }


### PR DESCRIPTION
It is ambiguous with upcoming standardized `std::as_const`.

see [teeks99-09f-win2012R2-64on64 - graph - test_graphs / msvc-14.0](http://www.boost.org/development/tests/develop/developer/output/teeks99-09f-win2012R2-64on64-boost-bin-v2-libs-graph-test-test_graphs-test-msvc-14-0-dbg-adrs-mdl-64-thrd-mlt.html) and [Flast-FreeBSD11 - graph - test_graphs / clang-linux-3.8~gnu++1z](http://www.boost.org/development/tests/develop/developer/output/Flast-FreeBSD11-boost-bin-v2-libs-graph-test-test_graphs-test-clang-linux-3-8~gnu++1z-debug.html).