### PR TITLE
Compile the SGB examples.

### DIFF
--- a/example/roget_components.cpp
+++ b/example/roget_components.cpp
@@ -7,7 +7,8 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 //=======================================================================
 
-#include <stdio.h>
+#include <cstdio>
+#include <cstring>
 #include <iostream>
 #include <boost/graph/stanford_graph.hpp>
 #include <boost/graph/strong_components.hpp>

--- a/example/topo-sort-with-sgb.cpp
+++ b/example/topo-sort-with-sgb.cpp
@@ -8,8 +8,8 @@
 #include <vector>
 #include <string>
 #include <iostream>
-#include <boost/graph/topological_sort.hpp>
 #include <boost/graph/stanford_graph.hpp>
+#include <boost/graph/topological_sort.hpp>
 
 int
 main()

--- a/include/boost/graph/stanford_graph.hpp
+++ b/include/boost/graph/stanford_graph.hpp
@@ -46,6 +46,8 @@ extern "C" {
 #include <gb_books.h> /* graphs based on literature */
 #include <gb_econ.h> /* graphs based on economic data */
 #include <gb_games.h> /* graphs based on football scores */
+#undef ap /* avoid name clash with BGL parameter */
+        // ap ==> Vertex::u.I
 #include <gb_gates.h> /* graphs based on logic circuits */
 #undef val /* avoid name clash with g++ headerfile stl_tempbuf.h */
         // val ==> Vertex::x.I
@@ -92,6 +94,9 @@ namespace boost {
     typedef directed_tag directed_category;
     typedef sgb_traversal_tag traversal_category;
     typedef allow_parallel_edge_tag edge_parallel_category;
+    /** Return a null descriptor */
+    static vertex_descriptor null_vertex()
+    { return NULL; }
   };
   template <> struct graph_traits<sgb_const_graph_ptr> {
     typedef Vertex* vertex_descriptor;
@@ -107,6 +112,9 @@ namespace boost {
     typedef directed_tag directed_category;
     typedef sgb_traversal_tag traversal_category;
     typedef allow_parallel_edge_tag edge_parallel_category;
+    /** Return a null descriptor */
+    static vertex_descriptor null_vertex()
+    { return NULL; }
   };
 }
 


### PR DESCRIPTION
System: (K)Ubuntu 16.04 LTS
Compiler: g++ (Ubuntu 5.4.0-6ubuntu1~16.04.4) 5.4.0 20160609

Try to `g++ -c --std=c++14` the four BGL–SGB examples `girth.cpp`, `miles_span.cpp`, `roget_components.cpp`, and `topo-sort-with-sgb.cpp`. This leads to numerous errors.

## Applied fixes

1. **SGB 2002-01-30** changed the “Associated Press scores” from `ap0` and `ap1` to `ap`. This preprocessor macro (sic!) collides with numerous function parameters in `named_function_params.hpp`. `#undef`ining the macro doesn't break the BGL–SGB examples.

2. `girth.cpp` fails because of a missing `null_vertex()` function. Added to the header templates.

3. `roget_components.cpp` invokes `strncmp()` from the C library. `#include` added.

4. `topo-sort-with-sgb.cpp` hickups because of a missing `vertices()` function. Following `roget_components.cpp` and putting the collective SGB header up front fixes this.

## Results

With my local installation of the [Stanford GraphBase](https://github.com/ascherer/sgb/tree/local), all four **example** programs compile and link fine with the commandline (from the `example/` subdirectory)
```
for example in girth miles_span roget_components topo-sort-with-sgb
do
    g++ --std=c++14 -I../include -I/usr/include/sgb $example.cpp -o $example -lgb -L/usr/lib/sgb
done
```
The resulting executables produce the expected outputs.