### PR TITLE
Conditionally replace deprecated/removed C++98 std::bind1st by std::b…

### DIFF
--- a/include/boost/graph/astar_search.hpp
+++ b/include/boost/graph/astar_search.hpp
@@ -46,11 +46,12 @@ namespace boost {
 
 
   template <class Graph, class CostType>
-  class astar_heuristic : public std::unary_function<
-    typename graph_traits<Graph>::vertex_descriptor, CostType>
+  class astar_heuristic
   {
   public:
     typedef typename graph_traits<Graph>::vertex_descriptor Vertex;
+    typedef Vertex argument_type;
+    typedef CostType result_type;
     astar_heuristic() {}
     CostType operator()(Vertex u) { return static_cast<CostType>(0); }
   };

--- a/include/boost/graph/detail/adjacency_list.hpp
+++ b/include/boost/graph/detail/adjacency_list.hpp
@@ -289,7 +289,11 @@ namespace boost {
       // invalidation for add_edge() with EdgeList=vecS. Instead we
       // hold a pointer to the property. std::auto_ptr is not
       // a perfect fit for the job, but it is darn close.
+#ifdef BOOST_NO_AUTO_PTR
+      std::unique_ptr<Property> m_property;
+#else
       std::auto_ptr<Property> m_property;
+#endif
     };
 #else
     template <class Vertex, class Property>

--- a/include/boost/graph/detail/geodesic.hpp
+++ b/include/boost/graph/detail/geodesic.hpp
@@ -82,8 +82,11 @@ namespace detail {
     // Similar to std::plus<T>, but maximizes parameters
     // rather than adding them.
     template <typename T>
-    struct maximize : public std::binary_function<T, T, T>
+    struct maximize
     {
+        typedef T result_type;
+        typedef T first_argument_type;
+        typedef T second_argument_type;
         T operator ()(T x, T y) const
         { BOOST_USING_STD_MAX(); return max BOOST_PREVENT_MACRO_SUBSTITUTION (x, y); }
     };
@@ -93,11 +96,10 @@ namespace detail {
     // types, but should be specialized for those types that have
     // discrete notions of reciprocals.
     template <typename T>
-    struct reciprocal : public std::unary_function<T, T>
+    struct reciprocal
     {
-        typedef std::unary_function<T, T> function_type;
-        typedef typename function_type::result_type result_type;
-        typedef typename function_type::argument_type argument_type;
+        typedef T result_type;
+        typedef T argument_type;
         T operator ()(T t)
         { return T(1) / t; }
     };

--- a/include/boost/graph/transitive_closure.hpp
+++ b/include/boost/graph/transitive_closure.hpp
@@ -41,8 +41,9 @@ namespace boost
   {
     template < typename TheContainer, typename ST = std::size_t,
       typename VT = typename TheContainer::value_type >
-      struct subscript_t:public std::unary_function < ST, VT >
+      struct subscript_t
     {
+      typedef ST& argument_type;
       typedef VT& result_type;
 
       subscript_t(TheContainer & c):container(&c)

--- a/test/graph.cpp
+++ b/test/graph.cpp
@@ -64,6 +64,8 @@ bool check_vertex_cleared(Graph& g, Vertex v, ID id)
         found = ai;
         break;
       }
+#elif defined(BOOST_NO_CXX98_BINDERS)
+    found = std::find_if(ai, aiend, std::bind(cmp,v,std::placeholders::_1));
 #else
     found = std::find_if(ai, aiend, std::bind1st(cmp,v));
 #endif

--- a/test/isomorphism.cpp
+++ b/test/isomorphism.cpp
@@ -33,6 +33,7 @@
 
 using namespace boost;
 
+#ifndef BOOST_NO_CXX98_RANDOM_SHUFFLE
 template <typename Generator>
 struct random_functor {
   random_functor(Generator& g) : g(g) { }
@@ -44,6 +45,7 @@ struct random_functor {
   }
   Generator& g;
 };
+#endif
 
 template<typename Graph1, typename Graph2>
 void randomly_permute_graph(const Graph1& g1, Graph2& g2)
@@ -57,12 +59,18 @@ void randomly_permute_graph(const Graph1& g1, Graph2& g2)
   typedef typename graph_traits<Graph1>::edge_iterator edge_iterator;
 
   boost::mt19937 gen;
+#ifndef BOOST_NO_CXX98_RANDOM_SHUFFLE
   random_functor<boost::mt19937> rand_fun(gen);
+#endif
 
   // Decide new order
   std::vector<vertex1> orig_vertices;
   std::copy(vertices(g1).first, vertices(g1).second, std::back_inserter(orig_vertices));
+#ifndef BOOST_NO_CXX98_RANDOM_SHUFFLE
   std::random_shuffle(orig_vertices.begin(), orig_vertices.end(), rand_fun);
+#else
+  std::shuffle(orig_vertices.begin(), orig_vertices.end(), gen);
+#endif
   std::map<vertex1, vertex2> vertex_map;
 
   for (std::size_t i = 0; i < num_vertices(g1); ++i) {

--- a/test/vf2_sub_graph_iso_test.cpp
+++ b/test/vf2_sub_graph_iso_test.cpp
@@ -33,7 +33,7 @@
 
 using namespace boost;
 
-
+#ifndef BOOST_NO_CXX98_RANDOM_SHUFFLE
 template <typename Generator>
 struct random_functor {
   random_functor(Generator& g) : g(g) { }
@@ -45,7 +45,7 @@ struct random_functor {
   }
   Generator& g;
 };
-
+#endif
 
 template<typename Graph1, typename Graph2>
 void randomly_permute_graph(Graph1& g1, const Graph2& g2) {
@@ -58,12 +58,18 @@ void randomly_permute_graph(Graph1& g1, const Graph2& g2) {
   typedef typename graph_traits<Graph2>::edge_iterator edge_iterator;
   
   boost::mt19937 gen;
+#ifndef BOOST_NO_CXX98_RANDOM_SHUFFLE
   random_functor<boost::mt19937> rand_fun(gen);
+#endif
   
   // Decide new order
   std::vector<vertex2> orig_vertices;
   std::copy(vertices(g2).first, vertices(g2).second, std::back_inserter(orig_vertices));
+#ifndef BOOST_NO_CXX98_RANDOM_SHUFFLE
   std::random_shuffle(orig_vertices.begin(), orig_vertices.end(), rand_fun);
+#else
+  std::shuffle(orig_vertices.begin(), orig_vertices.end(), gen);
+#endif
   std::map<vertex2, vertex1> vertex_map;
   
   std::size_t i = 0;


### PR DESCRIPTION
…ind, std::auto_ptr by std::unique_ptr, and std::random_shuffle by std::shuffle. Inline typedefs from C++98 function adapters.

Signed-off-by: Daniela Engert <dani@ngrt.de>