### PR TITLE
Allow use of grid_graph without "using namespace boost"

### DIFF
--- a/example/grid_graph_example.cpp
+++ b/example/grid_graph_example.cpp
@@ -36,7 +36,7 @@ int main(int argc, char* argv[]) {
 
     // The two indicies should always be equal
     std::cout << "Index of vertex " << v_index << " is " <<
-      get(boost::vertex_index, graph, vertex(v_index, graph)) << std::endl;
+      boost::get(boost::vertex_index, graph, vertex(v_index, graph)) << std::endl;
 
   }
 
@@ -46,7 +46,7 @@ int main(int argc, char* argv[]) {
 
     // The two indicies should always be equal
     std::cout << "Index of edge " << e_index << " is " <<
-      get(boost::edge_index, graph, edge_at(e_index, graph)) << std::endl;
+      boost::get(boost::edge_index, graph, edge_at(e_index, graph)) << std::endl;
 
   }
 

--- a/example/grid_graph_example.cpp
+++ b/example/grid_graph_example.cpp
@@ -32,17 +32,17 @@ int main(int argc, char* argv[]) {
 
   // Do a round-trip test of the vertex index functions
   for (Traits::vertices_size_type v_index = 0;
-       v_index < num_vertices(graph); ++v_index) {
+       v_index < boost::num_vertices(graph); ++v_index) {
 
     // The two indicies should always be equal
     std::cout << "Index of vertex " << v_index << " is " <<
-      boost::get(boost::vertex_index, graph, vertex(v_index, graph)) << std::endl;
+      boost::get(boost::vertex_index, graph, boost::vertex(v_index, graph)) << std::endl;
 
   }
 
   // Do a round-trip test of the edge index functions
   for (Traits::edges_size_type e_index = 0;
-       e_index < num_edges(graph); ++e_index) {
+       e_index < boost::num_edges(graph); ++e_index) {
 
     // The two indicies should always be equal
     std::cout << "Index of edge " << e_index << " is " <<
@@ -63,7 +63,7 @@ int main(int argc, char* argv[]) {
     (graph.wrapped(2) ? "W" : "U") << std::endl; // prints "W, U, W"
 
   // Start with the first vertex in the graph
-  Traits::vertex_descriptor first_vertex = vertex(0, graph);
+  Traits::vertex_descriptor first_vertex = boost::vertex(0, graph);
   print_vertex(first_vertex); // prints "(0, 0, 0)"
 
   // Print the next vertex in dimension 0

--- a/include/boost/graph/grid_graph.hpp
+++ b/include/boost/graph/grid_graph.hpp
@@ -63,16 +63,20 @@ namespace boost {
       return (m_graph->index_of(key));
     }
 
-    friend inline Index
-    get(const grid_graph_index_map<Graph, Descriptor, Index>& index_map,
-        const typename grid_graph_index_map<Graph, Descriptor, Index>::key_type& key)
-    {
-      return (index_map[key]);
-    }
 
   protected:
     const Graph* m_graph;
   };
+
+  template <typename Graph,
+            typename Descriptor,
+            typename Index>
+  inline Index
+  get(const grid_graph_index_map<Graph, Descriptor, Index>& index_map,
+      const typename grid_graph_index_map<Graph, Descriptor, Index>::key_type& key)
+  {
+    return (index_map[key]);
+  }
 
   template<BOOST_GRID_GRAPH_TEMPLATE_PARAMS>
   struct property_map<BOOST_GRID_GRAPH_TYPE, vertex_index_t> {
@@ -109,13 +113,15 @@ namespace boost {
       return (value_type(key.second, key.first));
     }
 
-    friend inline Descriptor
-    get(const grid_graph_reverse_edge_map<Descriptor>& rev_map,
-        const typename grid_graph_reverse_edge_map<Descriptor>::key_type& key)
-    {
-      return (rev_map[key]);
-    }
   };
+
+  template <typename Descriptor>
+  inline Descriptor
+  get(const grid_graph_reverse_edge_map<Descriptor>& rev_map,
+      const typename grid_graph_reverse_edge_map<Descriptor>::key_type& key)
+  {
+    return (rev_map[key]);
+  }
 
   template<BOOST_GRID_GRAPH_TEMPLATE_PARAMS>
   struct property_map<BOOST_GRID_GRAPH_TYPE, edge_reverse_t> {
@@ -429,6 +435,7 @@ namespace boost {
       return (m_edge_count[dimension_index]);
     }
 
+  public:
     // Returns the index of [vertex] (See also vertex_at)
     vertices_size_type index_of(vertex_descriptor vertex) const {
 
@@ -445,6 +452,8 @@ namespace boost {
 
       return (vertex_index);
     }
+
+  protected:
 
     // Returns the vertex whose index is [vertex_index] (See also
     // index_of(vertex_descriptor))
@@ -536,6 +545,7 @@ namespace boost {
       return (std::make_pair(vertex_source, vertex_target));
     }
     
+  public:
     // Returns the index for [edge] (See also edge_at)
     edges_size_type index_of(edge_descriptor edge) const {
       vertex_descriptor source_vertex = source(edge, *this);
@@ -618,6 +628,8 @@ namespace boost {
 
       return (edge_index);
     }
+
+  protected:
 
     // Returns the number of out-edges for [vertex]
     degree_size_type out_degree(vertex_descriptor vertex) const {
@@ -953,48 +965,6 @@ namespace boost {
     // Index Property Map Functions
     //=============================
 
-    friend inline typename type::vertices_size_type
-    get(vertex_index_t,
-        const type& graph,
-        typename type::vertex_descriptor vertex) {
-      return (graph.index_of(vertex));
-    }
-
-    friend inline typename type::edges_size_type
-    get(edge_index_t,
-        const type& graph,
-        typename type::edge_descriptor edge) {
-      return (graph.index_of(edge));
-    }
-
-    friend inline grid_graph_index_map<
-                    type,
-                    typename type::vertex_descriptor,
-                    typename type::vertices_size_type>
-    get(vertex_index_t, const type& graph) {
-      return (grid_graph_index_map<
-                type,
-                typename type::vertex_descriptor,
-                typename type::vertices_size_type>(graph));
-    }
-
-    friend inline grid_graph_index_map<
-                    type,
-                    typename type::edge_descriptor,
-                    typename type::edges_size_type>
-    get(edge_index_t, const type& graph) {
-      return (grid_graph_index_map<
-                type,
-                typename type::edge_descriptor,
-                typename type::edges_size_type>(graph));
-    }                                       
-
-    friend inline grid_graph_reverse_edge_map<
-                    typename type::edge_descriptor>
-    get(edge_reverse_t, const type& graph) {
-      return (grid_graph_reverse_edge_map<
-                typename type::edge_descriptor>());
-    }                                       
 
     template<typename Graph,
              typename Descriptor,
@@ -1006,6 +976,63 @@ namespace boost {
 
   }; // grid_graph
 
+  template <std::size_t Dimensions,
+            typename VertexIndex = std::size_t,
+            typename EdgeIndex = VertexIndex>
+  inline VertexIndex
+  get(vertex_index_t,
+      const grid_graph<Dimensions, VertexIndex, EdgeIndex> & graph,
+      typename grid_graph<Dimensions, VertexIndex, EdgeIndex>::vertex_descriptor vertex) {
+    return (graph.index_of(vertex));
+  }
+
+  template <std::size_t Dimensions,
+            typename VertexIndex = std::size_t,
+            typename EdgeIndex = VertexIndex>
+  inline VertexIndex
+  get(edge_index_t,
+      const grid_graph<Dimensions, VertexIndex, EdgeIndex>& graph,
+      typename grid_graph<Dimensions, VertexIndex, EdgeIndex>::edge_descriptor edge) {
+    return (graph.index_of(edge));
+  }
+
+  template <std::size_t Dimensions,
+            typename VertexIndex = std::size_t,
+            typename EdgeIndex = VertexIndex>
+  inline grid_graph_index_map<
+                  grid_graph<Dimensions, VertexIndex, EdgeIndex>,
+                  typename grid_graph<Dimensions, VertexIndex, EdgeIndex>::vertex_descriptor,
+                  VertexIndex>
+  get(vertex_index_t, const grid_graph<Dimensions, VertexIndex, EdgeIndex>& graph) {
+    return (grid_graph_index_map<
+              grid_graph<Dimensions, VertexIndex, EdgeIndex>,
+              typename grid_graph<Dimensions, VertexIndex, EdgeIndex>::vertex_descriptor,
+              VertexIndex>(graph));
+  }
+
+  template <std::size_t Dimensions,
+            typename VertexIndex = std::size_t,
+            typename EdgeIndex = VertexIndex>
+  inline grid_graph_index_map<
+                  grid_graph<Dimensions, VertexIndex, EdgeIndex>,
+                  typename grid_graph<Dimensions, VertexIndex, EdgeIndex>::edge_descriptor,
+                  EdgeIndex>
+  get(edge_index_t, const grid_graph<Dimensions, VertexIndex, EdgeIndex>& graph) {
+    return (grid_graph_index_map<
+              grid_graph<Dimensions, VertexIndex, EdgeIndex>,
+              typename grid_graph<Dimensions, VertexIndex, EdgeIndex>::edge_descriptor,
+              EdgeIndex>(graph));
+  }
+
+  template <std::size_t Dimensions,
+            typename VertexIndex = std::size_t,
+            typename EdgeIndex = VertexIndex>
+  inline grid_graph_reverse_edge_map<
+                  typename grid_graph<Dimensions, VertexIndex, EdgeIndex>::edge_descriptor>
+  get(edge_reverse_t, const grid_graph<Dimensions, VertexIndex, EdgeIndex>& graph) {
+    return (grid_graph_reverse_edge_map<
+              typename grid_graph<Dimensions, VertexIndex, EdgeIndex>::edge_descriptor>());
+  }
 } // namespace boost
 
 #undef BOOST_GRID_GRAPH_TYPE

--- a/include/boost/graph/grid_graph.hpp
+++ b/include/boost/graph/grid_graph.hpp
@@ -417,8 +417,7 @@ namespace boost {
       return (vertex);    
     }
 
-  protected:
-
+  public:
     // Returns the number of vertices in the graph
     inline vertices_size_type num_vertices() const {
       return (m_num_vertices);
@@ -435,7 +434,6 @@ namespace boost {
       return (m_edge_count[dimension_index]);
     }
 
-  public:
     // Returns the index of [vertex] (See also vertex_at)
     vertices_size_type index_of(vertex_descriptor vertex) const {
 
@@ -452,8 +450,6 @@ namespace boost {
 
       return (vertex_index);
     }
-
-  protected:
 
     // Returns the vertex whose index is [vertex_index] (See also
     // index_of(vertex_descriptor))
@@ -751,35 +747,6 @@ namespace boost {
 
   public:
 
-    //================
-    // VertexListGraph
-    //================
-
-    friend inline std::pair<typename type::vertex_iterator,
-                            typename type::vertex_iterator> 
-    vertices(const type& graph) {
-      typedef typename type::vertex_iterator vertex_iterator;
-      typedef typename type::vertex_function vertex_function;
-      typedef typename type::vertex_index_iterator vertex_index_iterator;
-
-      return (std::make_pair
-              (vertex_iterator(vertex_index_iterator(0),
-                               vertex_function(&graph)),
-               vertex_iterator(vertex_index_iterator(graph.num_vertices()),
-                               vertex_function(&graph))));
-    }
-
-    friend inline typename type::vertices_size_type
-    num_vertices(const type& graph) {
-      return (graph.num_vertices());
-    }
-
-    friend inline typename type::vertex_descriptor
-    vertex(typename type::vertices_size_type vertex_index,
-           const type& graph) {
-
-      return (graph.vertex_at(vertex_index));
-    }
 
     //===============
     // IncidenceGraph
@@ -975,6 +942,45 @@ namespace boost {
     friend struct grid_graph_reverse_edge_map;
 
   }; // grid_graph
+
+  //================
+  // VertexListGraph
+  //================
+
+  template <std::size_t Dimensions,
+            typename VertexIndex = std::size_t,
+            typename EdgeIndex = VertexIndex>
+  inline std::pair<typename grid_graph<Dimensions, VertexIndex, EdgeIndex>::vertex_iterator,
+                          typename grid_graph<Dimensions, VertexIndex, EdgeIndex>::vertex_iterator> 
+  vertices(const grid_graph<Dimensions, VertexIndex, EdgeIndex>& graph) {
+    typedef typename grid_graph<Dimensions, VertexIndex, EdgeIndex>::vertex_iterator vertex_iterator;
+    typedef typename grid_graph<Dimensions, VertexIndex, EdgeIndex>::vertex_function vertex_function;
+    typedef typename grid_graph<Dimensions, VertexIndex, EdgeIndex>::vertex_index_iterator vertex_index_iterator;
+
+    return (std::make_pair
+            (vertex_iterator(vertex_index_iterator(0),
+                             vertex_function(&graph)),
+             vertex_iterator(vertex_index_iterator(graph.num_vertices()),
+                             vertex_function(&graph))));
+  }
+
+  template <std::size_t Dimensions,
+            typename VertexIndex = std::size_t,
+            typename EdgeIndex = VertexIndex>
+  inline typename grid_graph<Dimensions, VertexIndex, EdgeIndex>::vertices_size_type
+  num_vertices(const grid_graph<Dimensions, VertexIndex, EdgeIndex>& graph) {
+    return (graph.num_vertices());
+  }
+
+  template <std::size_t Dimensions,
+            typename VertexIndex = std::size_t,
+            typename EdgeIndex = VertexIndex>
+  inline typename grid_graph<Dimensions, VertexIndex, EdgeIndex>::vertex_descriptor
+  vertex(typename grid_graph<Dimensions, VertexIndex, EdgeIndex>::vertices_size_type vertex_index,
+         const grid_graph<Dimensions, VertexIndex, EdgeIndex>& graph) {
+
+    return (graph.vertex_at(vertex_index));
+  }
 
   template <std::size_t Dimensions,
             typename VertexIndex = std::size_t,

--- a/include/boost/graph/grid_graph.hpp
+++ b/include/boost/graph/grid_graph.hpp
@@ -800,34 +800,6 @@ namespace boost {
                                  adjacent_vertex_function(vertex, &graph))));
     }
 
-    //==============
-    // EdgeListGraph
-    //==============
-
-    friend inline typename type::edges_size_type
-    num_edges(const type& graph) {
-      return (graph.num_edges());
-    }
-
-    friend inline typename type::edge_descriptor
-    edge_at(typename type::edges_size_type edge_index,
-            const type& graph) {
-      return (graph.edge_at(edge_index));
-    }
-
-    friend inline std::pair<typename type::edge_iterator,
-                            typename type::edge_iterator>
-    edges(const type& graph) {
-      typedef typename type::edge_index_iterator edge_index_iterator;
-      typedef typename type::edge_function edge_function;
-      typedef typename type::edge_iterator edge_iterator;
-
-      return (std::make_pair
-              (edge_iterator(edge_index_iterator(0),
-                             edge_function(&graph)),
-               edge_iterator(edge_index_iterator(graph.num_edges()),
-                             edge_function(&graph))));
-    }
 
     //===================
     // BiDirectionalGraph
@@ -1038,6 +1010,44 @@ namespace boost {
   get(edge_reverse_t, const grid_graph<Dimensions, VertexIndex, EdgeIndex>& graph) {
     return (grid_graph_reverse_edge_map<
               typename grid_graph<Dimensions, VertexIndex, EdgeIndex>::edge_descriptor>());
+  }
+
+  //==============
+  // EdgeListGraph
+  //==============
+
+  template <std::size_t Dimensions,
+            typename VertexIndex = std::size_t,
+            typename EdgeIndex = VertexIndex>
+  inline EdgeIndex 
+  num_edges(const grid_graph<Dimensions, VertexIndex, EdgeIndex>& graph) {
+    return (graph.num_edges());
+  }
+
+  template <std::size_t Dimensions,
+            typename VertexIndex = std::size_t,
+            typename EdgeIndex = VertexIndex>
+  inline typename grid_graph<Dimensions, VertexIndex, EdgeIndex>::edge_descriptor
+  edge_at(EdgeIndex edge_index,
+          const grid_graph<Dimensions, VertexIndex, EdgeIndex>& graph) {
+    return (graph.edge_at(edge_index));
+  }
+
+  template <std::size_t Dimensions,
+            typename VertexIndex = std::size_t,
+            typename EdgeIndex = VertexIndex>
+  inline std::pair<typename grid_graph<Dimensions, VertexIndex, EdgeIndex>::edge_iterator,
+                          typename grid_graph<Dimensions, VertexIndex, EdgeIndex>::edge_iterator>
+  edges(const grid_graph<Dimensions, VertexIndex, EdgeIndex>& graph) {
+    typedef typename grid_graph<Dimensions, VertexIndex, EdgeIndex>::edge_index_iterator edge_index_iterator;
+    typedef typename grid_graph<Dimensions, VertexIndex, EdgeIndex>::edge_function edge_function;
+    typedef typename grid_graph<Dimensions, VertexIndex, EdgeIndex>::edge_iterator edge_iterator;
+
+    return (std::make_pair
+            (edge_iterator(edge_index_iterator(0),
+                           edge_function(&graph)),
+             edge_iterator(edge_index_iterator(graph.num_edges()),
+                           edge_function(&graph))));
   }
 } // namespace boost
 

--- a/test/grid_graph_test.cpp
+++ b/test/grid_graph_test.cpp
@@ -92,7 +92,7 @@ void do_test(minstd_rand& generator) {
 
   // Verify all vertices are within bounds
   vertices_size_type vertex_count = 0;
-  BOOST_FOREACH(vertex_descriptor current_vertex, vertices(graph)) {
+  BOOST_FOREACH(vertex_descriptor current_vertex, boost::vertices(graph)) {
 
     vertices_size_type current_index =
       boost::get(boost::vertex_index, graph, current_vertex);
@@ -154,7 +154,7 @@ void do_test(minstd_rand& generator) {
 
     // Verify that this vertex is not listed as connected to any
     // vertices outside of its adjacent vertices.
-    BOOST_FOREACH(vertex_descriptor unconnected_vertex, vertices(graph)) {
+    BOOST_FOREACH(vertex_descriptor unconnected_vertex, boost::vertices(graph)) {
       
       vertices_size_type unconnected_index =
         boost::get(boost::vertex_index, graph, unconnected_vertex);

--- a/test/grid_graph_test.cpp
+++ b/test/grid_graph_test.cpp
@@ -79,7 +79,7 @@ void do_test(minstd_rand& generator) {
   for (vertices_size_type vertex_index = 0;
        vertex_index < num_vertices(graph);
        ++vertex_index) {
-    BOOST_REQUIRE(get(boost::vertex_index, graph, vertex(vertex_index, graph)) == vertex_index);
+    BOOST_REQUIRE(boost::get(boost::vertex_index, graph, vertex(vertex_index, graph)) == vertex_index);
   }
 
   for (edges_size_type edge_index = 0;
@@ -87,7 +87,7 @@ void do_test(minstd_rand& generator) {
        ++edge_index) {
 
     edge_descriptor current_edge = edge_at(edge_index, graph);
-    BOOST_REQUIRE(get(boost::edge_index, graph, current_edge) == edge_index);
+    BOOST_REQUIRE(boost::get(boost::edge_index, graph, current_edge) == edge_index);
   }
 
   // Verify all vertices are within bounds
@@ -95,7 +95,7 @@ void do_test(minstd_rand& generator) {
   BOOST_FOREACH(vertex_descriptor current_vertex, vertices(graph)) {
 
     vertices_size_type current_index =
-      get(boost::vertex_index, graph, current_vertex);
+      boost::get(boost::vertex_index, graph, current_vertex);
 
     for (unsigned int dimension_index = 0;
          dimension_index < Dims;
@@ -112,7 +112,7 @@ void do_test(minstd_rand& generator) {
                   out_edges(current_vertex, graph)) {
 
       target_vertices.insert
-        (get(boost::vertex_index, graph, target(out_edge, graph)));
+        (boost::get(boost::vertex_index, graph, target(out_edge, graph)));
 
       ++out_edge_count;
     }
@@ -126,7 +126,7 @@ void do_test(minstd_rand& generator) {
                   in_edges(current_vertex, graph)) {
 
       BOOST_REQUIRE(target_vertices.count
-                   (get(boost::vertex_index, graph, source(in_edge, graph))) > 0);
+                   (boost::get(boost::vertex_index, graph, source(in_edge, graph))) > 0);
 
       ++in_edge_count;
     }
@@ -145,7 +145,7 @@ void do_test(minstd_rand& generator) {
                   adjacent_vertices(current_vertex, graph)) {
 
       BOOST_REQUIRE(target_vertices.count
-                   (get(boost::vertex_index, graph, adjacent_vertex)) > 0);
+                   (boost::get(boost::vertex_index, graph, adjacent_vertex)) > 0);
 
       ++adjacent_count;
     }
@@ -157,7 +157,7 @@ void do_test(minstd_rand& generator) {
     BOOST_FOREACH(vertex_descriptor unconnected_vertex, vertices(graph)) {
       
       vertices_size_type unconnected_index =
-        get(boost::vertex_index, graph, unconnected_vertex);
+        boost::get(boost::vertex_index, graph, unconnected_vertex);
 
       if ((unconnected_index == current_index) ||
           (target_vertices.count(unconnected_index) > 0)) {
@@ -178,10 +178,10 @@ void do_test(minstd_rand& generator) {
   BOOST_FOREACH(edge_descriptor current_edge, edges(graph)) {
 
     vertices_size_type source_index =
-      get(boost::vertex_index, graph, source(current_edge, graph));
+      boost::get(boost::vertex_index, graph, source(current_edge, graph));
 
     vertices_size_type target_index =
-      get(boost::vertex_index, graph, target(current_edge, graph));
+      boost::get(boost::vertex_index, graph, target(current_edge, graph));
 
     BOOST_REQUIRE(source_index != target_index);
     BOOST_REQUIRE(/* (source_index >= 0) : always true && */ (source_index < num_vertices(graph)));


### PR DESCRIPTION
This is really about whether people should be able to use the BGL API without putting "using namespace boost" in their code. I think they should, and they can with most of the API, but not all - for instance, boost::grid_graph.

Currently, removing "using namespace boost", and using the "boost::" prefix instead, causes the following compiler errors, because these functions are actually member methods of the grid_graph class, not functions in the boost namespace.

Normally, when we call, for instance, just num_vertices(graph), instead of boost::num_vertices(graph), the compiler finds the member method via argument dependent lookup.

```
grid_graph_example.cpp:34:25: error: no member named 'num_vertices' in namespace 'boost'
       v_index < boost::num_vertices(graph); ++v_index) {
                 ~~~~~~~^
grid_graph_example.cpp:38:53: error: no member named 'vertex' in namespace 'boost'
      boost::get(boost::vertex_index, graph, boost::vertex(v_index, graph)) << std::endl;
                                             ~~~~~~~^
grid_graph_example.cpp:48:51: error: no member named 'edge_at' in namespace 'boost'
      boost::get(boost::edge_index, graph, boost::edge_at(e_index, graph)) << std::endl;
                                           ~~~~~~~^
grid_graph_example.cpp:65:30: error: no member named 'vertex' in namespace 'boost'
  auto first_vertex = boost::vertex(0, graph);
```

As you can see by these example commits, fixing this involves some tedious code outside of the class. Maybe you see a better way to do it. If this is the only way then I still think it's worth it.

This would also be fixed by Bjarne Stroustroup's Unified Call proposal:
https://isocpp.org/blog/2016/02/a-bit-of-background-for-the-unified-call-proposal
but that doesn't seem likely to happen any time soon.