### PR TITLE
Fix writes/reads outside allocated memory in resource constraints shortest paths

### DIFF
--- a/include/boost/graph/r_c_shortest_paths.hpp
+++ b/include/boost/graph/r_c_shortest_paths.hpp
@@ -26,21 +26,20 @@ template<class Graph, class Resource_Container>
 struct r_c_shortest_paths_label : public boost::enable_shared_from_this<r_c_shortest_paths_label<Graph, Resource_Container> >
 {
   r_c_shortest_paths_label
-  ( const unsigned long n, 
-    const Resource_Container& rc = Resource_Container(), 
-    const boost::shared_ptr<r_c_shortest_paths_label<Graph, Resource_Container> > pl = nullptr, 
-    const typename graph_traits<Graph>::edge_descriptor& ed = 
-      graph_traits<Graph>::edge_descriptor(), 
-    const typename graph_traits<Graph>::vertex_descriptor& vd = 
-      graph_traits<Graph>::vertex_descriptor() )
-  : num( n ), 
-    cumulated_resource_consumption( rc ), 
-    p_pred_label( pl ), 
-    pred_edge( ed ), 
-    resident_vertex( vd ), 
-    b_is_dominated( false ), 
+  ( const unsigned long n,
+    const Resource_Container& rc = Resource_Container(),
+    const boost::shared_ptr<r_c_shortest_paths_label<Graph, Resource_Container> > pl = boost::shared_ptr<r_c_shortest_paths_label<Graph, Resource_Container> >(),
+    const typename graph_traits<Graph>::edge_descriptor& ed = graph_traits<Graph>::edge_descriptor(),
+    const typename graph_traits<Graph>::vertex_descriptor& vd = graph_traits<Graph>::vertex_descriptor() )
+  : num( n ),
+    cumulated_resource_consumption( rc ),
+    p_pred_label( pl ),
+    pred_edge( ed ),
+    resident_vertex( vd ),
+    b_is_dominated( false ),
     b_is_processed( false )
   {}
+
   r_c_shortest_paths_label& operator=( const r_c_shortest_paths_label& other )
   {
     if( this == &other )
@@ -192,10 +191,10 @@ void r_c_shortest_paths_dispatch
   bool b_feasible = true;
   Splabel splabel_first_label = boost::allocate_shared<r_c_shortest_paths_label<Graph, Resource_Container> >(
           l_alloc,
-          i_label_num++, 
-          rc, 
-          nullptr, 
-          typename graph_traits<Graph>::edge_descriptor(), 
+          i_label_num++,
+          rc,
+          boost::shared_ptr<r_c_shortest_paths_label<Graph, Resource_Container> >(),
+          typename graph_traits<Graph>::edge_descriptor(),
           s );
 
   unprocessed_labels.push( splabel_first_label );

--- a/include/boost/graph/r_c_shortest_paths.hpp
+++ b/include/boost/graph/r_c_shortest_paths.hpp
@@ -726,9 +726,8 @@ void check_r_c_path( const Graph& g,
       return;
   }
   if( b_result_must_be_equal_to_desired_final_resource_levels )
-    b_correctly_extended = 
-     actual_final_resource_levels == desired_final_resource_levels ? 
-       true : false;
+    b_correctly_extended =
+            actual_final_resource_levels == desired_final_resource_levels;
   else
   {
     if( actual_final_resource_levels < desired_final_resource_levels 

--- a/test/r_c_shortest_paths_test.cpp
+++ b/test/r_c_shortest_paths_test.cpp
@@ -168,7 +168,7 @@ public:
     int& i_time = new_cont.time;
     i_time = old_cont.time + arc_prop.time;
     i_time < vert_prop.eat ? i_time = vert_prop.eat : 0;
-    return i_time <= vert_prop.lat ? true : false;
+    return i_time <= vert_prop.lat;
   }
 };
 

--- a/test/r_c_shortest_paths_test.cpp
+++ b/test/r_c_shortest_paths_test.cpp
@@ -56,8 +56,7 @@ struct spp_no_rc_res_cont
   {
     if( this == &other )
       return *this;
-    this->~spp_no_rc_res_cont();
-    new( this ) spp_no_rc_res_cont( other );
+    cost = other.cost;
     return *this;
   }
   int cost;
@@ -125,8 +124,8 @@ struct spp_spptw_res_cont
   {
     if( this == &other )
       return *this;
-    this->~spp_spptw_res_cont();
-    new( this ) spp_spptw_res_cont( other );
+    cost = other.cost;
+    time = other.time;
     return *this;
   }
   int cost;
@@ -207,8 +206,9 @@ struct spp_spptw_marked_res_cont {
     {
         if( this == &other )
             return *this;
-        this->~spp_spptw_marked_res_cont();
-        new( this ) spp_spptw_marked_res_cont( other );
+        cost = other.cost;
+        time = other.time;
+        marked = other.marked;
         return *this;
     }
     int cost;

--- a/test/r_c_shortest_paths_test.cpp
+++ b/test/r_c_shortest_paths_test.cpp
@@ -748,11 +748,11 @@ int test_main(int, char*[])
   add_edge( 5, 4, SPPRC_Example_Graph_Arc_Prop( 18, 0, 25 ), g3 );
   add_edge( 5, 1, SPPRC_Example_Graph_Arc_Prop( 19, 0, 25 ), g3 );
 
-  std::vector<std::vector<typename graph_traits<SPPRC_Example_Graph>::edge_descriptor> >
+  std::vector<std::vector<graph_traits<SPPRC_Example_Graph>::edge_descriptor> >
   pareto_opt_marked_solutions;
   std::vector<spp_spptw_marked_res_cont> pareto_opt_marked_resource_containers;
 
-  typename graph_traits<SPPRC_Example_Graph>::vertex_descriptor g3_source = 0, g3_target = 1;
+  graph_traits<SPPRC_Example_Graph>::vertex_descriptor g3_source = 0, g3_target = 1;
   r_c_shortest_paths( g3,
                       get( &SPPRC_Example_Graph_Vert_Prop::num, g3 ),
                       get( &SPPRC_Example_Graph_Arc_Prop::num, g3 ),
@@ -769,21 +769,21 @@ int test_main(int, char*[])
                       default_r_c_shortest_paths_visitor() );
 
   BOOST_CHECK(!pareto_opt_marked_solutions.empty());
-  std::vector<std::vector<typename graph_traits<SPPRC_Example_Graph>::edge_descriptor> >::const_iterator path_it, path_end_it;
+  std::vector<std::vector<graph_traits<SPPRC_Example_Graph>::edge_descriptor> >::const_iterator path_it, path_end_it;
   for (path_it = pareto_opt_marked_solutions.begin(), path_end_it = pareto_opt_marked_solutions.end(); path_it != path_end_it; ++path_it) {
-    const std::vector<typename graph_traits<SPPRC_Example_Graph>::edge_descriptor> &path = *path_it;
+    const std::vector<graph_traits<SPPRC_Example_Graph>::edge_descriptor> &path = *path_it;
     BOOST_CHECK(!path.empty());
 
-    const typename graph_traits<SPPRC_Example_Graph>::edge_descriptor front = path.front();
+    const graph_traits<SPPRC_Example_Graph>::edge_descriptor front = path.front();
     BOOST_CHECK(boost::target(front, g3) == g3_target);
 
-    std::vector<typename graph_traits<SPPRC_Example_Graph>::edge_descriptor>::const_iterator edge_it, edge_it_end;
-    typename graph_traits<SPPRC_Example_Graph>::edge_descriptor prev_edge = front;
+    std::vector<graph_traits<SPPRC_Example_Graph>::edge_descriptor>::const_iterator edge_it, edge_it_end;
+    graph_traits<SPPRC_Example_Graph>::edge_descriptor prev_edge = front;
 
     for(edge_it = path.begin() + 1, edge_it_end = path.end(); edge_it != edge_it_end; ++edge_it) {
-        typename graph_traits<SPPRC_Example_Graph>::edge_descriptor edge = *edge_it;
+        graph_traits<SPPRC_Example_Graph>::edge_descriptor edge = *edge_it;
 
-        typename graph_traits<SPPRC_Example_Graph>::vertex_descriptor prev_end, current_end;
+        graph_traits<SPPRC_Example_Graph>::vertex_descriptor prev_end, current_end;
         prev_end = boost::source(prev_edge, g3);
         current_end = boost::target(edge, g3);
         BOOST_CHECK(prev_end == current_end);
@@ -791,7 +791,7 @@ int test_main(int, char*[])
         prev_edge = edge;
     }
 
-    const typename graph_traits<SPPRC_Example_Graph>::edge_descriptor back = path.back();
+    const graph_traits<SPPRC_Example_Graph>::edge_descriptor back = path.back();
     BOOST_CHECK(boost::source(back, g3) == g3_source);
   }
 


### PR DESCRIPTION
Found an example where existing algorithm performs writes/reads outside allocated memory when using the default allocator. Implemented repo as a test included in the pull request. Valgrind reports 38 reads/writes outside allocated memory when running the test against the original version of the algorithm.

I did not get a segmentation fault on my machine, but the algorithm returned a list of edges that do not form a path (example: 1-5 5-2 2-3 4-0).

Investigation
If an existing label is found dominated it becomes immediately deallocated. However, pointers to that label still may exist in other partial paths. Further new allocations cause appearance of invalid paths. The assumption that a pareto optimal path consists only of non-dominated labels and therefore deallocating them is not correct (safe) if the dominance function performs weak inequality checks (as suggested by original author and presented in examples).

Fix
* Replaced a raw pointer to `r_c_shortest_paths_label` with `boost::shared_ptr`. The algorihtm finds shortest paths based on feasibility/dominance criteria specified by user, so there is a risk that pointers may form a cycle. Taking this into account the algorihtm resets pointers as the final step. I considered using weak pointers in the `r_c_shortest_paths_label`, but there are examples where such approach do not work. Provided it as a comment inside the algorithm code.
* Replaced `ks_smart_pointer` by `boost::shared_ptr`. The former class did not offer the smart_pointer functionality and is not necessary.
* Removed the `b_is_valid` checks. It is possible to come up with examples, where this approach will report false negatives (provided an example in comments). It is the same reason why weak_pointers will not work.
* Added a test case to prevent regressions.

Valgrind does not detect any leaks or possible leaks when running the test against the fixed algorithm.