### PR TITLE
Replace /bin/bash with /bin/sh

### DIFF
--- a/doc/grid_graph_export_svg.sh
+++ b/doc/grid_graph_export_svg.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 #=======================================================================
 # Copyright 2009 Trustees of Indiana University.


### PR DESCRIPTION
/bin/bash is a Linuxism.  /bin/sh is portable, and this script isn't
using any bash-specific features.