### PR TITLE
Remove deprecated std::unary_function and std::binary_function from examples

### DIFF
--- a/example/astar_maze.cpp
+++ b/example/astar_maze.cpp
@@ -46,7 +46,9 @@ typedef boost::graph_traits<grid>::vertex_descriptor vertex_descriptor;
 typedef boost::graph_traits<grid>::vertices_size_type vertices_size_type;
 
 // A hash function for vertices.
-struct vertex_hash:std::unary_function<vertex_descriptor, std::size_t> {
+struct vertex_hash {
+  typedef vertex_descriptor argument_type;
+  typedef std::size_t result_type;
   std::size_t operator()(vertex_descriptor const& u) const {
     std::size_t seed = 0;
     boost::hash_combine(seed, u[0]);

--- a/example/gerdemann.cpp
+++ b/example/gerdemann.cpp
@@ -63,8 +63,10 @@ void merge_vertex
 
 template <class StoredEdge>
 struct order_by_name
-  : public std::binary_function<StoredEdge,StoredEdge,bool> 
 {
+  typedef StoredEdge first_argument_type;
+  typedef StoredEdge second_argument_type;
+  typedef bool result_type;
   bool operator()(const StoredEdge& e1, const StoredEdge& e2) const {
     // Using std::pair operator< as an easy way to get lexicographical
     // compare over tuples.

--- a/example/ordered_out_edges.cpp
+++ b/example/ordered_out_edges.cpp
@@ -32,8 +32,10 @@
 
 template <class StoredEdge>
 struct order_by_name
-  : public std::binary_function<StoredEdge,StoredEdge,bool> 
 {
+  typedef StoredEdge first_argument_type;
+  typedef StoredEdge second_argument_type;
+  typedef bool result_type;
   bool operator()(const StoredEdge& e1, const StoredEdge& e2) const {
     // Order by target vertex, then by name. 
     // std::pair's operator< does a nice job of implementing


### PR DESCRIPTION
std::binary_function was removed in C++17 and is no longer available while compiling with MS Visual Studio 2017