### PR TITLE
Inheriting std::iterator is deprecated in C++17

### DIFF
--- a/include/boost/graph/adjacency_matrix.hpp
+++ b/include/boost/graph/adjacency_matrix.hpp
@@ -14,9 +14,9 @@
 #include <boost/config.hpp>
 #include <vector>
 #include <memory>
+#include <iterator>
 #include <boost/assert.hpp>
 #include <boost/limits.hpp>
-#include <boost/iterator.hpp>
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/graph_mutability_traits.hpp>
 #include <boost/graph/graph_selectors.hpp>

--- a/include/boost/graph/detail/array_binary_tree.hpp
+++ b/include/boost/graph/detail/array_binary_tree.hpp
@@ -14,7 +14,6 @@
 #include <iterator>
 #include <functional>
 #include <boost/config.hpp>
-#include <boost/iterator.hpp>
 
 namespace boost {
 
@@ -43,9 +42,12 @@ public:
 
   struct children_type {
     struct iterator
-        : boost::iterator<std::bidirectional_iterator_tag, ArrayBinaryTreeNode,
-                       difference_type, array_binary_tree_node*, ArrayBinaryTreeNode&>
     { // replace with iterator_adaptor implementation -JGS
+      typedef std::bidirectional_iterator_tag iterator_category;
+      typedef ArrayBinaryTreeNode value_type;
+      typedef size_type difference_type;
+      typedef array_binary_tree_node* pointer;
+      typedef ArrayBinaryTreeNode& reference;
 
       inline iterator() : i(0), n(0) { }
       inline iterator(const iterator& x) : r(x.r), i(x.i), n(x.n), id(x.id) { }

--- a/include/boost/graph/matrix_as_graph.hpp
+++ b/include/boost/graph/matrix_as_graph.hpp
@@ -12,6 +12,8 @@
 #define BOOST_GRAPH_MATRIX2GRAPH_HPP
 
 #include <utility>
+#include <cstddef>
+#include <iterator>
 #include <boost/config.hpp>
 #include <boost/operators.hpp>
 #include <boost/pending/detail/int_iterator.hpp>
@@ -86,10 +88,14 @@ namespace boost {
 
   template <class Iter, class Vertex>
   class matrix_adj_iterator
-    : public std::iterator<std::input_iterator_tag, Vertex >
   {
     typedef matrix_adj_iterator self;
   public:
+    typedef std::input_iterator_tag iterator_category;
+    typedef Vertex value_type;
+    typedef std::ptrdiff_t difference_type;
+    typedef Vertex* pointer;
+    typedef Vertex& reference;
     matrix_adj_iterator() { }
     matrix_adj_iterator(Iter i) : _iter(i) { }
     matrix_adj_iterator(const self& x) : _iter(x._iter) { }
@@ -105,10 +111,14 @@ namespace boost {
 
   template <class Iter, class Vertex>
   class matrix_incidence_iterator
-    : public std::iterator<std::input_iterator_tag, Iter >
   {
     typedef matrix_incidence_iterator self;
   public:
+    typedef std::input_iterator_tag iterator_category;
+    typedef Iter value_type;
+    typedef std::ptrdiff_t difference_type;
+    typedef Iter* pointer;
+    typedef Iter& reference;
     matrix_incidence_iterator() { }
     matrix_incidence_iterator(Iter i) : _iter(i) { }
     matrix_incidence_iterator(const self& x) : _iter(x._iter) { }

--- a/include/boost/graph/stanford_graph.hpp
+++ b/include/boost/graph/stanford_graph.hpp
@@ -10,7 +10,6 @@
 #define BOOST_GRAPH_SGB_GRAPH_HPP
 
 #include <boost/config.hpp>
-#include <boost/iterator.hpp>
 #include <boost/operators.hpp>
 #include <boost/property_map/property_map.hpp>
 #include <boost/graph/graph_traits.hpp>

--- a/include/boost/graph/vector_as_graph.hpp
+++ b/include/boost/graph/vector_as_graph.hpp
@@ -18,7 +18,7 @@
 #include <utility>
 #include <vector>
 #include <cstddef>
-#include <boost/iterator.hpp>
+#include <iterator>
 #include <boost/iterator/counting_iterator.hpp>
 #include <boost/range/irange.hpp>
 #include <boost/graph/graph_traits.hpp>
@@ -110,12 +110,15 @@ namespace boost {
     // need rewrite this using boost::iterator_adaptor
     template <class V, class Iter>
     class val_out_edge_iterator
-      : public boost::iterator<std::input_iterator_tag, std::pair<V,V>,
-         std::ptrdiff_t, std::pair<V,V>*, const std::pair<V,V> >
     {
       typedef val_out_edge_iterator self;
       typedef std::pair<V,V> Edge;
     public:
+      typedef std::input_iterator_tag iterator_category;
+      typedef std::pair<V,V> value_type;
+      typedef std::ptrdiff_t difference_type;
+      typedef std::pair<V,V>* pointer;
+      typedef const std::pair<V,V> reference;
       val_out_edge_iterator() { }
       val_out_edge_iterator(V s, Iter i) : _source(s), _iter(i) { }
       Edge operator*() const { return Edge(_source, *_iter); }


### PR DESCRIPTION
Boost's iterator.hpp is deprecated, too. Therefore get rid of all of that and replace inheritance by lifting std::iterator's members into the derived class.

Signed-off-by: Daniela Engert <dani@ngrt.de>