### PR TITLE
Fix friend declarations for iterator_core_access

### DIFF
--- a/include/boost/graph/detail/compressed_sparse_row_struct.hpp
+++ b/include/boost/graph/detail/compressed_sparse_row_struct.hpp
@@ -459,7 +459,7 @@ namespace detail {
 
     edge_descriptor m_edge;
 
-    friend class iterator_core_access;
+    friend class boost::iterator_core_access;
   };
 
   template<typename CSRGraph>
@@ -547,7 +547,7 @@ namespace detail {
     EdgeIndex m_index_in_backward_graph;
     const CSRGraph* m_graph;
 
-    friend class iterator_core_access;
+    friend class boost::iterator_core_access;
   };
 
   template <typename A, typename B>


### PR DESCRIPTION
csr_out_edge_iterator and csr_in_edge_iterator are part of the
boost::detail namespace, so they need to explicitly qualify
iterator_core_access in their friend declarations. Note that
csr_edge_iterator already gets this correct.