### PR TITLE
fix typos

### DIFF
--- a/doc/two_graphs_common_spanning_trees.html
+++ b/doc/two_graphs_common_spanning_trees.html
@@ -6,7 +6,7 @@
           http://www.boost.org/LICENSE_1_0.txt)
 
           Two Graphs Common Spanning Trees Algorithm
-      Based on academic article of Mint, Read and Tarjan
+      Based on academic article of Minty, Read and Tarjan
      Efficient Algorithm for Common Spanning Tree Problem
  Electron. Lett., 28 April 1983, Volume 19, Issue 9, p.346–347
 -->
@@ -20,7 +20,7 @@
 <h1><tt><a name="sec:two-graphs-common-spanning-trees">Two-Graphs Common Spanning Trees (MRT Algorithm)</a></tt></h1>
 
 <p>
-The <b>MRT</b> algorithm, based on an academic article of <b>Mint</b>, <b>Read</b> and
+The <b>MRT</b> algorithm, based on an academic article of <b>Minty</b>, <b>Read</b> and
 <b>Tarjan</b>, is an efficient algorithm for the common spanning tree problem.<br/>
 This kind of algorithm is widely used in electronics, being the basis of the
 analysis of electrical circuits. Another area of interest may be that of the


### PR DESCRIPTION
I cannot find the exact paper for this algorithm. I think the name Mint refers to Professor George J. Minty, an expert in networking algorithms.

A book titled *Graph Theory for Programmers: Algorithms for Processing Trees* cites Professor Minty's paper *A Simple Algorithm for Listing All the Trees of a Graph* and made a note like this,

> [Mint] A simple algorithm for listing all the trees of a graph, IEEE Tran. Circuit Theory, CT-12, No. 1, 120(1965)

Surname Minty is abbreviated to Mint by the book author to limit the number of characters to four.