### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/include/boost/graph/bron_kerbosch_all_cliques.hpp
+++ b/include/boost/graph/bron_kerbosch_all_cliques.hpp
@@ -84,7 +84,7 @@ namespace boost
 //          number = {1},
 //          year = {2006},
 //          pages = {28-42}
-//          ee = {http://dx.doi.org/10.1016/j.tcs.2006.06.015}
+//          ee = {https://doi.org/10.1016/j.tcs.2006.06.015}
 //      }
 
 /**

--- a/include/boost/graph/detail/geodesic.hpp
+++ b/include/boost/graph/detail/geodesic.hpp
@@ -33,7 +33,7 @@ namespace boost
 //         pages = {466--484},
 //         priority = {0},
 //         title = {A Graph-theoretic perspective on centrality},
-//         url = {http://dx.doi.org/10.1016/j.socnet.2005.11.005},
+//         url = {https://doi.org/10.1016/j.socnet.2005.11.005},
 //             volume = {28},
 //             year = {2006}
 //         }

--- a/include/boost/graph/gursoy_atun_layout.hpp
+++ b/include/boost/graph/gursoy_atun_layout.hpp
@@ -14,7 +14,7 @@
 // "Neighbourhood Preserving Load Balancing: A Self-Organizing Approach"
 // in 6th International Euro-Par Conference Munich, Germany, August 29 – September 1, 2000 Proceedings,
 // pp 234-241
-// http://dx.doi.org/10.1007/3-540-44520-X_32
+// https://doi.org/10.1007/3-540-44520-X_32
 
 #include <boost/config/no_tr1/cmath.hpp>
 #include <boost/throw_exception.hpp>


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and update all static DOI links.

Cheers!