### PR TITLE
fix visibility of exceptions within Boost.Graph

### DIFF
--- a/include/boost/graph/bipartite.hpp
+++ b/include/boost/graph/bipartite.hpp
@@ -32,7 +32,7 @@ namespace boost {
      */
 
     template <typename Vertex>
-    struct bipartite_visitor_error: std::exception
+    struct BOOST_SYMBOL_VISIBLE bipartite_visitor_error: std::exception
     {
       std::pair <Vertex, Vertex> witnesses;
 

--- a/include/boost/graph/dimacs.hpp
+++ b/include/boost/graph/dimacs.hpp
@@ -21,7 +21,7 @@
 
 namespace boost { namespace graph {
 
-class dimacs_exception : public std::exception {};
+class BOOST_SYMBOL_VISIBLE dimacs_exception : public std::exception {};
 
 class dimacs_basic_reader {
 public:

--- a/include/boost/graph/exception.hpp
+++ b/include/boost/graph/exception.hpp
@@ -15,36 +15,36 @@
 
 namespace boost {
 
-    struct bad_graph : public std::invalid_argument {
+    struct BOOST_SYMBOL_VISIBLE bad_graph : public std::invalid_argument {
         bad_graph(const std::string& what_arg)
             : std::invalid_argument(what_arg) { }
     };
 
-    struct not_a_dag : public bad_graph {
+    struct BOOST_SYMBOL_VISIBLE not_a_dag : public bad_graph {
         not_a_dag()
             : bad_graph("The graph must be a DAG.")
         { }
     };
 
-    struct negative_edge : public bad_graph {
+    struct BOOST_SYMBOL_VISIBLE negative_edge : public bad_graph {
         negative_edge()
             : bad_graph("The graph may not contain an edge with negative weight.")
         { }
     };
 
-    struct negative_cycle : public bad_graph {
+    struct BOOST_SYMBOL_VISIBLE negative_cycle : public bad_graph {
         negative_cycle()
             : bad_graph("The graph may not contain negative cycles.")
         { }
     };
 
-    struct not_connected : public bad_graph {
+    struct BOOST_SYMBOL_VISIBLE not_connected : public bad_graph {
         not_connected()
             : bad_graph("The graph must be connected.")
         { }
     };
 
-   struct not_complete : public bad_graph {
+   struct BOOST_SYMBOL_VISIBLE not_complete : public bad_graph {
        not_complete()
            : bad_graph("The graph must be complete.")
        { }

--- a/include/boost/graph/graphml.hpp
+++ b/include/boost/graph/graphml.hpp
@@ -34,7 +34,7 @@ namespace boost
 /////////////////////////////////////////////////////////////////////////////
 // Graph reader exceptions
 /////////////////////////////////////////////////////////////////////////////
-struct parse_error: public graph_exception
+struct BOOST_SYMBOL_VISIBLE parse_error: public graph_exception
 {
     parse_error(const std::string& err) {error = err; statement = "parse error: " + error;}
     virtual ~parse_error() throw() {}

--- a/include/boost/graph/graphviz.hpp
+++ b/include/boost/graph/graphviz.hpp
@@ -616,12 +616,12 @@ namespace boost {
 /////////////////////////////////////////////////////////////////////////////
 // Graph reader exceptions
 /////////////////////////////////////////////////////////////////////////////
-struct graph_exception : public std::exception {
+struct BOOST_SYMBOL_VISIBLE graph_exception : public std::exception {
   virtual ~graph_exception() throw() {}
   virtual const char* what() const throw() = 0;
 };
 
-struct bad_parallel_edge : public graph_exception {
+struct BOOST_SYMBOL_VISIBLE bad_parallel_edge : public graph_exception {
   std::string from;
   std::string to;
   mutable std::string statement;
@@ -639,7 +639,7 @@ struct bad_parallel_edge : public graph_exception {
   }
 };
 
-struct directed_graph_error : public graph_exception {
+struct BOOST_SYMBOL_VISIBLE directed_graph_error : public graph_exception {
   virtual ~directed_graph_error() throw() {}
   virtual const char* what() const throw() {
     return
@@ -648,7 +648,7 @@ struct directed_graph_error : public graph_exception {
   }
 };
 
-struct undirected_graph_error : public graph_exception {
+struct BOOST_SYMBOL_VISIBLE undirected_graph_error : public graph_exception {
   virtual ~undirected_graph_error() throw() {}
   virtual const char* what() const throw() {
     return
@@ -657,7 +657,7 @@ struct undirected_graph_error : public graph_exception {
   }
 };
 
-struct bad_graphviz_syntax: public graph_exception {
+struct BOOST_SYMBOL_VISIBLE bad_graphviz_syntax: public graph_exception {
   std::string errmsg;
   bad_graphviz_syntax(const std::string& errmsg)
     : errmsg(errmsg) {}

--- a/include/boost/graph/loop_erased_random_walk.hpp
+++ b/include/boost/graph/loop_erased_random_walk.hpp
@@ -19,7 +19,7 @@
 
 namespace boost {
 
-  struct loop_erased_random_walk_stuck : public std::exception {
+  struct BOOST_SYMBOL_VISIBLE loop_erased_random_walk_stuck : public std::exception {
     virtual ~loop_erased_random_walk_stuck() throw() {}
     inline virtual const char* what() const throw() {
       return "Loop-erased random walk found a vertex with no out-edges";

--- a/include/boost/graph/metis.hpp
+++ b/include/boost/graph/metis.hpp
@@ -26,8 +26,8 @@
 
 namespace boost { namespace graph {
 
-class metis_exception : public std::exception {};
-class metis_input_exception : public metis_exception {};
+class BOOST_SYMBOL_VISIBLE metis_exception : public std::exception {};
+class BOOST_SYMBOL_VISIBLE metis_input_exception : public metis_exception {};
 
 class metis_reader
 {


### PR DESCRIPTION
This is required to avoid issues with `-fvisibility=hidden` builds (those are now default in Boost develop branch).

More info on the macro available [here](https://www.boost.org/doc/libs/1_68_0/libs/config/doc/html/boost_config/boost_macro_reference.html#boost_config.boost_macro_reference.macros_for_libraries_with_separate_source_code.macros_controlling_shared_library_symbol_visibility)

Related issue: https://github.com/boostorg/graph_parallel/pull/16