### PR TITLE
Include graph_parallel headers through a BOOST_GRAPH_MPI_INCLUDE macro

### DIFF
--- a/include/boost/graph/breadth_first_search.hpp
+++ b/include/boost/graph/breadth_first_search.hpp
@@ -24,11 +24,10 @@
 #include <boost/graph/overloading.hpp>
 #include <boost/graph/graph_concepts.hpp>
 #include <boost/graph/two_bit_color_map.hpp>
+#include <boost/graph/detail/mpi_include.hpp>
 #include <boost/concept/assert.hpp>
 
-#ifdef BOOST_GRAPH_USE_MPI
-#include <boost/graph/distributed/concepts.hpp>
-#endif // BOOST_GRAPH_USE_MPI
+#include BOOST_GRAPH_MPI_INCLUDE(<boost/graph/distributed/concepts.hpp>)
 
 namespace boost {
 
@@ -405,9 +404,7 @@ namespace boost {
 
 } // namespace boost
 
-#ifdef BOOST_GRAPH_USE_MPI
-#  include <boost/graph/distributed/breadth_first_search.hpp>
-#endif
+#include BOOST_GRAPH_MPI_INCLUDE(<boost/graph/distributed/breadth_first_search.hpp>)
 
 #endif // BOOST_GRAPH_BREADTH_FIRST_SEARCH_HPP
 

--- a/include/boost/graph/connected_components.hpp
+++ b/include/boost/graph/connected_components.hpp
@@ -16,6 +16,7 @@
 #include <boost/graph/properties.hpp>
 #include <boost/graph/graph_concepts.hpp>
 #include <boost/graph/overloading.hpp>
+#include <boost/graph/detail/mpi_include.hpp>
 #include <boost/static_assert.hpp>
 #include <boost/concept/assert.hpp>
 
@@ -100,8 +101,6 @@ namespace boost {
   
 } // namespace boost
 
-#ifdef BOOST_GRAPH_USE_MPI
-#  include <boost/graph/distributed/connected_components.hpp>
-#endif
+#include BOOST_GRAPH_MPI_INCLUDE(<boost/graph/distributed/connected_components.hpp>)
 
 #endif // BOOST_GRAPH_CONNECTED_COMPONENTS_HPP

--- a/include/boost/graph/depth_first_search.hpp
+++ b/include/boost/graph/depth_first_search.hpp
@@ -19,6 +19,7 @@
 #include <boost/graph/properties.hpp>
 #include <boost/graph/visitors.hpp>
 #include <boost/graph/named_function_params.hpp>
+#include <boost/graph/detail/mpi_include.hpp>
 #include <boost/ref.hpp>
 #include <boost/implicit_cast.hpp>
 #include <boost/optional.hpp>
@@ -366,8 +367,6 @@ namespace boost {
   }
 } // namespace boost
 
-#ifdef BOOST_GRAPH_USE_MPI
-#  include <boost/graph/distributed/depth_first_search.hpp>
-#endif
+#include BOOST_GRAPH_MPI_INCLUDE(<boost/graph/distributed/depth_first_search.hpp>)
 
 #endif

--- a/include/boost/graph/detail/empty_header.hpp
+++ b/include/boost/graph/detail/empty_header.hpp
@@ -1,0 +1,10 @@
+#ifndef BOOST_GRAPH_DETAIL_EMPTY_HEADER_HPP_INCLUDED
+#define BOOST_GRAPH_DETAIL_EMPTY_HEADER_HPP_INCLUDED
+
+// Copyright 2018 Peter Dimov
+//
+// Use, modification and distribution are subject to the
+// Boost Software License, Version 1.0 (See accompanying file
+// LICENSE_1_0.txt or http://www.boost.org/LICENSE_1_0.txt)
+
+#endif // #ifndef BOOST_GRAPH_DETAIL_EMPTY_HEADER_HPP_INCLUDED

--- a/include/boost/graph/detail/mpi_include.hpp
+++ b/include/boost/graph/detail/mpi_include.hpp
@@ -1,0 +1,16 @@
+#ifndef BOOST_GRAPH_DETAIL_MPI_INCLUDE_HPP_INCLUDED
+#define BOOST_GRAPH_DETAIL_MPI_INCLUDE_HPP_INCLUDED
+
+// Copyright 2018 Peter Dimov
+//
+// Use, modification and distribution are subject to the
+// Boost Software License, Version 1.0 (See accompanying file
+// LICENSE_1_0.txt or http://www.boost.org/LICENSE_1_0.txt)
+
+#if defined BOOST_GRAPH_USE_MPI
+#  define BOOST_GRAPH_MPI_INCLUDE(x) x
+#else
+#  define BOOST_GRAPH_MPI_INCLUDE(x) <boost/graph/detail/empty_header.hpp>
+#endif
+
+#endif // #ifndef BOOST_GRAPH_DETAIL_MPI_INCLUDE_HPP_INCLUDED

--- a/include/boost/graph/dijkstra_shortest_paths.hpp
+++ b/include/boost/graph/dijkstra_shortest_paths.hpp
@@ -27,6 +27,7 @@
 #include <boost/smart_ptr.hpp>
 #include <boost/graph/detail/d_ary_heap.hpp>
 #include <boost/graph/two_bit_color_map.hpp>
+#include <boost/graph/detail/mpi_include.hpp>
 #include <boost/property_map/property_map.hpp>
 #include <boost/property_map/vector_property_map.hpp>
 #include <boost/type_traits.hpp>
@@ -616,8 +617,6 @@ namespace boost {
 
 } // namespace boost
 
-#ifdef BOOST_GRAPH_USE_MPI
-#  include <boost/graph/distributed/dijkstra_shortest_paths.hpp>
-#endif
+#include BOOST_GRAPH_MPI_INCLUDE(<boost/graph/distributed/dijkstra_shortest_paths.hpp>)
 
 #endif // BOOST_GRAPH_DIJKSTRA_HPP

--- a/include/boost/graph/fruchterman_reingold.hpp
+++ b/include/boost/graph/fruchterman_reingold.hpp
@@ -14,6 +14,7 @@
 #include <boost/graph/named_function_params.hpp>
 #include <boost/graph/iteration_macros.hpp>
 #include <boost/graph/topology.hpp> // For topology concepts
+#include <boost/graph/detail/mpi_include.hpp>
 #include <vector>
 #include <list>
 #include <algorithm> // for std::min and std::max
@@ -433,8 +434,6 @@ fruchterman_reingold_force_directed_layout
 
 } // end namespace boost
 
-#ifdef BOOST_GRAPH_USE_MPI
-#  include <boost/graph/distributed/fruchterman_reingold.hpp>
-#endif
+#include BOOST_GRAPH_MPI_INCLUDE(<boost/graph/distributed/fruchterman_reingold.hpp>)
 
 #endif // BOOST_GRAPH_FRUCHTERMAN_REINGOLD_FORCE_DIRECTED_LAYOUT_HPP

--- a/include/boost/graph/graphviz.hpp
+++ b/include/boost/graph/graphviz.hpp
@@ -27,6 +27,7 @@
 #include <boost/graph/dll_import_export.hpp>
 #include <boost/graph/compressed_sparse_row_graph.hpp>
 #include <boost/graph/iteration_macros.hpp>
+#include <boost/graph/detail/mpi_include.hpp>
 #include <boost/spirit/include/classic_multi_pass.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/static_assert.hpp>
@@ -951,8 +952,6 @@ bool read_graphviz(std::istream& in, MutableGraph& graph,
 
 } // namespace boost
 
-#ifdef BOOST_GRAPH_USE_MPI
-#  include <boost/graph/distributed/graphviz.hpp>
-#endif
+#include BOOST_GRAPH_MPI_INCLUDE(<boost/graph/distributed/graphviz.hpp>)
 
 #endif // BOOST_GRAPHVIZ_HPP

--- a/include/boost/graph/one_bit_color_map.hpp
+++ b/include/boost/graph/one_bit_color_map.hpp
@@ -16,6 +16,7 @@
 
 #include <boost/property_map/property_map.hpp>
 #include <boost/graph/properties.hpp>
+#include <boost/graph/detail/mpi_include.hpp>
 #include <boost/shared_array.hpp>
 #include <boost/config.hpp>
 #include <boost/assert.hpp>
@@ -97,8 +98,6 @@ make_one_bit_color_map(std::size_t n, const IndexMap& index_map)
 
 } // end namespace boost
 
-#endif // BOOST_ONE_BIT_COLOR_MAP_HPP
+#include BOOST_GRAPH_MPI_INCLUDE(<boost/graph/distributed/one_bit_color_map.hpp>)
 
-#ifdef BOOST_GRAPH_USE_MPI
-#  include <boost/graph/distributed/one_bit_color_map.hpp>
-#endif
+#endif // BOOST_ONE_BIT_COLOR_MAP_HPP

--- a/include/boost/graph/page_rank.hpp
+++ b/include/boost/graph/page_rank.hpp
@@ -16,6 +16,7 @@
 #include <boost/graph/properties.hpp>
 #include <boost/graph/iteration_macros.hpp>
 #include <boost/graph/overloading.hpp>
+#include <boost/graph/detail/mpi_include.hpp>
 #include <vector>
 
 namespace boost { namespace graph {
@@ -154,8 +155,6 @@ remove_dangling_links(MutableGraph& g
 
 } } // end namespace boost::graph
 
-#ifdef BOOST_GRAPH_USE_MPI
-#  include <boost/graph/distributed/page_rank.hpp>
-#endif
+#include BOOST_GRAPH_MPI_INCLUDE(<boost/graph/distributed/page_rank.hpp>)
 
 #endif // BOOST_GRAPH_PAGE_RANK_HPP

--- a/include/boost/graph/rmat_graph_generator.hpp
+++ b/include/boost/graph/rmat_graph_generator.hpp
@@ -20,6 +20,7 @@
 #include <boost/random/uniform_int.hpp>
 #include <boost/random/uniform_01.hpp>
 #include <boost/graph/graph_traits.hpp>
+#include <boost/graph/detail/mpi_include.hpp>
 #include <boost/type_traits/is_base_and_derived.hpp>
 #include <boost/type_traits/is_same.hpp>
 // #include <boost/test/floating_point_comparison.hpp>
@@ -588,8 +589,6 @@ namespace boost {
 
 } // end namespace boost
 
-#ifdef BOOST_GRAPH_USE_MPI
-#include <boost/graph/distributed/rmat_graph_generator.hpp>
-#endif // BOOST_GRAPH_USE_MPI
+#include BOOST_GRAPH_MPI_INCLUDE(<boost/graph/distributed/rmat_graph_generator.hpp>)
 
 #endif // BOOST_GRAPH_RMAT_GENERATOR_HPP

--- a/include/boost/graph/strong_components.hpp
+++ b/include/boost/graph/strong_components.hpp
@@ -18,6 +18,7 @@
 #include <boost/type_traits/conversion_traits.hpp>
 #include <boost/static_assert.hpp>
 #include <boost/graph/overloading.hpp>
+#include <boost/graph/detail/mpi_include.hpp>
 #include <boost/concept/assert.hpp>
 
 namespace boost {
@@ -336,8 +337,6 @@ namespace boost {
 
 } // namespace boost
 
-#ifdef BOOST_GRAPH_USE_MPI
-#  include <boost/graph/distributed/strong_components.hpp>
-#endif
+#include BOOST_GRAPH_MPI_INCLUDE(<boost/graph/distributed/strong_components.hpp>)
 
 #endif // BOOST_GRAPH_STRONG_COMPONENTS_HPP

--- a/include/boost/graph/two_bit_color_map.hpp
+++ b/include/boost/graph/two_bit_color_map.hpp
@@ -15,6 +15,7 @@
 
 #include <boost/property_map/property_map.hpp>
 #include <boost/graph/properties.hpp>
+#include <boost/graph/detail/mpi_include.hpp>
 #include <boost/shared_array.hpp>
 #include <boost/config.hpp>
 #include <boost/assert.hpp>
@@ -102,8 +103,6 @@ make_two_bit_color_map(std::size_t n, const IndexMap& index_map)
 
 } // end namespace boost
 
-#endif // BOOST_TWO_BIT_COLOR_MAP_HPP
+#include BOOST_GRAPH_MPI_INCLUDE(<boost/graph/distributed/two_bit_color_map.hpp>)
 
-#ifdef BOOST_GRAPH_USE_MPI
-#  include <boost/graph/distributed/two_bit_color_map.hpp>
-#endif
+#endif // BOOST_TWO_BIT_COLOR_MAP_HPP


### PR DESCRIPTION
… to hide them from boostdep