### PR TITLE
WIP: Fixes #122

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ kevin-bacon2.dat
 random.dot
 triangular-fr.dot
 triangular-kk.dot
+.vscode

--- a/include/boost/graph/adjacency_matrix.hpp
+++ b/include/boost/graph/adjacency_matrix.hpp
@@ -24,6 +24,7 @@
 #include <boost/mpl/bool.hpp>
 #include <boost/graph/adjacency_iterator.hpp>
 #include <boost/graph/detail/edge.hpp>
+#include <boost/graph/detail/graph_iterator_range.hpp>
 #include <boost/iterator/iterator_adaptor.hpp>
 #include <boost/iterator/filter_iterator.hpp>
 #include <boost/range/irange.hpp>
@@ -865,12 +866,11 @@ namespace boost {
   // Functions required by the VertexListGraph concept
 
   template <typename D, typename VP, typename EP, typename GP, typename A>
-  std::pair<typename adjacency_matrix<D,VP,EP,GP,A>::vertex_iterator,
-            typename adjacency_matrix<D,VP,EP,GP,A>::vertex_iterator>
+  graph_detail::iterator_range<typename adjacency_matrix<D,VP,EP,GP,A>::vertex_iterator>
   vertices(const adjacency_matrix<D,VP,EP,GP,A>& g_) {
     typedef adjacency_matrix<D,VP,EP,GP,A> Graph;
     Graph& g = const_cast<Graph&>(g_);
-    return std::make_pair(g.m_vertex_set.begin(), g.m_vertex_set.end());
+    return graph_detail::make_iterator_range(g.m_vertex_set.begin(), g.m_vertex_set.end());
   }
 
   template <typename D, typename VP, typename EP, typename GP, typename A>
@@ -883,8 +883,7 @@ namespace boost {
   // Functions required by the EdgeListGraph concept
 
   template <typename D, typename VP, typename EP, typename GP, typename A>
-  std::pair<typename adjacency_matrix<D,VP,EP,GP,A>::edge_iterator,
-            typename adjacency_matrix<D,VP,EP,GP,A>::edge_iterator>
+  graph_detail::iterator_range<typename adjacency_matrix<D,VP,EP,GP,A>::edge_iterator>
   edges(const adjacency_matrix<D,VP,EP,GP,A>& g_)
   {
     typedef adjacency_matrix<D,VP,EP,GP,A> Graph;
@@ -897,7 +896,7 @@ namespace boost {
                                     g.m_vertex_set.size());
     detail::does_edge_exist pred;
     typedef typename Graph::edge_iterator edge_iterator;
-    return std::make_pair(edge_iterator(pred, first, last),
+    return graph_detail::make_iterator_range(edge_iterator(pred, first, last),
                           edge_iterator(pred, last, last));
   }
 

--- a/include/boost/graph/adjacency_matrix.hpp
+++ b/include/boost/graph/adjacency_matrix.hpp
@@ -846,8 +846,7 @@ namespace boost {
   // Functions required by the AdjacencyGraph concept
 
   template <typename D, typename VP, typename EP, typename GP, typename A>
-  std::pair<typename adjacency_matrix<D,VP,EP,GP,A>::adjacency_iterator,
-            typename adjacency_matrix<D,VP,EP,GP,A>::adjacency_iterator>
+  graph_detail::iterator_range<typename adjacency_matrix<D,VP,EP,GP,A>::adjacency_iterator>
   adjacent_vertices
     (typename adjacency_matrix<D,VP,EP,GP,A>::vertex_descriptor u,
      const adjacency_matrix<D,VP,EP,GP,A>& g_)
@@ -858,7 +857,7 @@ namespace boost {
       typedef typename Graph::adjacency_iterator adjacency_iterator;
       typename Graph::out_edge_iterator first, last;
       boost::tie(first, last) = out_edges(u, g);
-      return std::make_pair(adjacency_iterator(first, &g),
+      return graph_detail::make_iterator_range(adjacency_iterator(first, &g),
                             adjacency_iterator(last, &g));
   }
 

--- a/include/boost/graph/compressed_sparse_row_graph.hpp
+++ b/include/boost/graph/compressed_sparse_row_graph.hpp
@@ -27,6 +27,7 @@
 #include <boost/graph/filtered_graph.hpp> // For keep_all
 #include <boost/graph/detail/indexed_properties.hpp>
 #include <boost/graph/detail/compressed_sparse_row_struct.hpp>
+#include <boost/graph/detail/graph_iterator_range.hpp>
 #include <boost/graph/iteration_macros.hpp>
 #include <boost/iterator/counting_iterator.hpp>
 #include <boost/iterator/reverse_iterator.hpp>
@@ -1115,9 +1116,9 @@ num_vertices(const BOOST_CSR_GRAPH_TYPE& g) {
 }
 
 template<BOOST_CSR_GRAPH_TEMPLATE_PARMS>
-std::pair<counting_iterator<Vertex>, counting_iterator<Vertex> >
+graph_detail::iterator_range<counting_iterator<Vertex> >
 inline vertices(const BOOST_CSR_GRAPH_TYPE& g) {
-  return std::make_pair(counting_iterator<Vertex>(0),
+  return graph_detail::make_iterator_range(counting_iterator<Vertex>(0),
                         counting_iterator<Vertex>(num_vertices(g)));
 }
 
@@ -1139,15 +1140,14 @@ target(typename BOOST_CSR_GRAPH_TYPE::edge_descriptor e,
 }
 
 template<BOOST_CSR_GRAPH_TEMPLATE_PARMS>
-inline std::pair<typename BOOST_CSR_GRAPH_TYPE::out_edge_iterator,
-                 typename BOOST_CSR_GRAPH_TYPE::out_edge_iterator>
+inline graph_detail::iterator_range<typename BOOST_CSR_GRAPH_TYPE::out_edge_iterator>
 out_edges(Vertex v, const BOOST_CSR_GRAPH_TYPE& g)
 {
   typedef typename BOOST_CSR_GRAPH_TYPE::edge_descriptor ed;
   typedef typename BOOST_CSR_GRAPH_TYPE::out_edge_iterator it;
   EdgeIndex v_row_start = g.m_forward.m_rowstart[v];
   EdgeIndex next_row_start = g.m_forward.m_rowstart[v + 1];
-  return std::make_pair(it(ed(v, v_row_start)),
+  return graph_detail::make_iterator_range(it(ed(v, v_row_start)),
                         it(ed(v, next_row_start)));
 }
 
@@ -1161,14 +1161,13 @@ out_degree(Vertex v, const BOOST_CSR_GRAPH_TYPE& g)
 }
 
 template<BOOST_BIDIR_CSR_GRAPH_TEMPLATE_PARMS>
-inline std::pair<typename BOOST_BIDIR_CSR_GRAPH_TYPE::in_edge_iterator,
-                 typename BOOST_BIDIR_CSR_GRAPH_TYPE::in_edge_iterator>
+inline graph_detail::iterator_range<typename BOOST_BIDIR_CSR_GRAPH_TYPE::in_edge_iterator>
 in_edges(Vertex v, const BOOST_BIDIR_CSR_GRAPH_TYPE& g)
 {
   typedef typename BOOST_BIDIR_CSR_GRAPH_TYPE::in_edge_iterator it;
   EdgeIndex v_row_start = g.m_backward.m_rowstart[v];
   EdgeIndex next_row_start = g.m_backward.m_rowstart[v + 1];
-  return std::make_pair(it(g, v_row_start),
+  return graph_detail::make_iterator_range(it(g, v_row_start),
                         it(g, next_row_start));
 }
 
@@ -1183,13 +1182,12 @@ in_degree(Vertex v, const BOOST_BIDIR_CSR_GRAPH_TYPE& g)
 
 // From AdjacencyGraph
 template<BOOST_CSR_GRAPH_TEMPLATE_PARMS>
-inline std::pair<typename BOOST_CSR_GRAPH_TYPE::adjacency_iterator,
-                 typename BOOST_CSR_GRAPH_TYPE::adjacency_iterator>
+inline graph_detail::iterator_range<typename BOOST_CSR_GRAPH_TYPE::adjacency_iterator>
 adjacent_vertices(Vertex v, const BOOST_CSR_GRAPH_TYPE& g)
 {
   EdgeIndex v_row_start = g.m_forward.m_rowstart[v];
   EdgeIndex next_row_start = g.m_forward.m_rowstart[v + 1];
-  return std::make_pair(g.m_forward.m_column.begin() + v_row_start,
+  return graph_detail::make_iterator_range(g.m_forward.m_column.begin() + v_row_start,
                         g.m_forward.m_column.begin() + next_row_start);
 }
 

--- a/include/boost/graph/detail/adjacency_list.hpp
+++ b/include/boost/graph/detail/adjacency_list.hpp
@@ -1553,8 +1553,7 @@ namespace boost {
     };
 
     template <class Config, class Base>
-    inline std::pair<typename Config::adjacency_iterator,
-                     typename Config::adjacency_iterator>
+    inline graph_detail::iterator_range<typename Config::adjacency_iterator>
     adjacent_vertices(typename Config::vertex_descriptor u,
                       const adj_list_helper<Config, Base>& g_)
     {
@@ -1564,7 +1563,7 @@ namespace boost {
       typedef typename Config::adjacency_iterator adjacency_iterator;
       typename Config::out_edge_iterator first, last;
       boost::tie(first, last) = out_edges(u, g);
-      return std::make_pair(adjacency_iterator(first, &g),
+      return graph_detail::make_iterator_range(adjacency_iterator(first, &g),
                             adjacency_iterator(last, &g));
     }
     template <class Config, class Base>

--- a/include/boost/graph/detail/adjacency_list.hpp
+++ b/include/boost/graph/detail/adjacency_list.hpp
@@ -32,6 +32,7 @@
 #include <boost/graph/graph_concepts.hpp>
 #include <boost/pending/container_traits.hpp>
 #include <boost/graph/detail/adj_list_edge_iterator.hpp>
+#include <boost/graph/detail/graph_iterator_range.hpp>
 #include <boost/graph/properties.hpp>
 #include <boost/pending/property.hpp>
 #include <boost/graph/adjacency_iterator.hpp>
@@ -584,15 +585,14 @@ namespace boost {
 
     // O(1)
     template <class Config>
-    inline std::pair<typename Config::edge_iterator,
-                     typename Config::edge_iterator>
+    inline graph_detail::iterator_range<typename Config::edge_iterator>
     edges(const directed_edges_helper<Config>& g_)
     {
       typedef typename Config::graph_type graph_type;
       typedef typename Config::edge_iterator edge_iterator;
       const graph_type& cg = static_cast<const graph_type&>(g_);
       graph_type& g = const_cast<graph_type&>(cg);
-      return std::make_pair( edge_iterator(g.vertex_set().begin(),
+      return graph_detail::make_iterator_range( edge_iterator(g.vertex_set().begin(),
                                            g.vertex_set().begin(),
                                            g.vertex_set().end(), g),
                              edge_iterator(g.vertex_set().begin(),
@@ -1005,15 +1005,14 @@ namespace boost {
 
     // O(1)
     template <class Config>
-    inline std::pair<typename Config::edge_iterator,
-                     typename Config::edge_iterator>
+    inline graph_detail::iterator_range<typename Config::edge_iterator>
     edges(const undirected_graph_helper<Config>& g_)
     {
       typedef typename Config::graph_type graph_type;
       typedef typename Config::edge_iterator edge_iterator;
       const graph_type& cg = static_cast<const graph_type&>(g_);
       graph_type& g = const_cast<graph_type&>(cg);
-      return std::make_pair( edge_iterator(g.m_edges.begin()),
+      return graph_detail::make_iterator_range( edge_iterator(g.m_edges.begin()),
                              edge_iterator(g.m_edges.end()) );
     }
     // O(1)
@@ -1097,8 +1096,7 @@ namespace boost {
     }
 
     template <class Config>
-    inline std::pair<typename Config::in_edge_iterator,
-                     typename Config::in_edge_iterator>
+    inline graph_detail::iterator_range<typename Config::in_edge_iterator>
     in_edges(typename Config::vertex_descriptor u,
              const undirected_graph_helper<Config>& g_)
     {
@@ -1107,7 +1105,7 @@ namespace boost {
       Graph& g = const_cast<Graph&>(cg);
       typedef typename Config::in_edge_iterator in_edge_iterator;
       return
-        std::make_pair(in_edge_iterator(g.out_edge_list(u).begin(), u),
+        graph_detail::make_iterator_range(in_edge_iterator(g.out_edge_list(u).begin(), u),
                        in_edge_iterator(g.out_edge_list(u).end(), u));
     }
 
@@ -1170,8 +1168,7 @@ namespace boost {
     }
 
     template <class Config>
-    inline std::pair<typename Config::in_edge_iterator,
-                     typename Config::in_edge_iterator>
+    inline graph_detail::iterator_range<typename Config::in_edge_iterator>
     in_edges(typename Config::vertex_descriptor u,
              const bidirectional_graph_helper<Config>& g_)
     {
@@ -1180,21 +1177,20 @@ namespace boost {
       graph_type& g = const_cast<graph_type&>(cg);
       typedef typename Config::in_edge_iterator in_edge_iterator;
       return
-        std::make_pair(in_edge_iterator(in_edge_list(g, u).begin(), u),
+        graph_detail::make_iterator_range(in_edge_iterator(in_edge_list(g, u).begin(), u),
                        in_edge_iterator(in_edge_list(g, u).end(), u));
     }
 
     // O(1)
     template <class Config>
-    inline std::pair<typename Config::edge_iterator,
-                     typename Config::edge_iterator>
+    inline graph_detail::iterator_range<typename Config::edge_iterator>
     edges(const bidirectional_graph_helper<Config>& g_)
     {
       typedef typename Config::graph_type graph_type;
       typedef typename Config::edge_iterator edge_iterator;
       const graph_type& cg = static_cast<const graph_type&>(g_);
       graph_type& g = const_cast<graph_type&>(cg);
-      return std::make_pair( edge_iterator(g.m_edges.begin()),
+      return graph_detail::make_iterator_range( edge_iterator(g.m_edges.begin()),
                              edge_iterator(g.m_edges.end()) );
     }
 
@@ -1601,14 +1597,13 @@ namespace boost {
                        out_edge_iterator(g.out_edge_list(u).end(), u));
     }
     template <class Config, class Base>
-    inline std::pair<typename Config::vertex_iterator,
-                     typename Config::vertex_iterator>
+    inline graph_detail::iterator_range<typename Config::vertex_iterator>
     vertices(const adj_list_helper<Config, Base>& g_)
     {
       typedef typename Config::graph_type AdjList;
       const AdjList& cg = static_cast<const AdjList&>(g_);
       AdjList& g = const_cast<AdjList&>(cg);
-      return std::make_pair( g.vertex_set().begin(), g.vertex_set().end() );
+      return graph_detail::make_iterator_range( g.vertex_set().begin(), g.vertex_set().end() );
     }
     template <class Config, class Base>
     inline typename Config::vertices_size_type

--- a/include/boost/graph/detail/graph_iterator_range.hpp
+++ b/include/boost/graph/detail/graph_iterator_range.hpp
@@ -1,0 +1,883 @@
+//
+//=======================================================================
+// Copyright 1997, 1998, 1999, 2000 University of Notre Dame.
+// Authors: Andrew Lumsdaine, Lie-Quan Lee, Jeremy G. Siek
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//=======================================================================
+//
+
+// Boost.Range library
+//
+//  Copyright Neil Groves & Thorsten Ottosen & Pavol Droba 2003-2004.
+//  Use, modification and distribution is subject to the Boost Software
+//  License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// For more information, see http://www.boost.org/libs/range/
+//
+// Credits:
+// 'michel' reported Trac 9072 which included a patch for allowing references
+// to function types.
+//
+#ifndef BOOST_GRAPH_DETAIL_GRAPH_ITERATOR_RANGE_HPP_INCLUDED
+#define BOOST_GRAPH_DETAIL_GRAPH_ITERATOR_RANGE_HPP_INCLUDED
+
+#include <boost/config.hpp> // Define __STL_CONFIG_H, if appropriate.
+#include <boost/detail/workaround.hpp>
+
+#if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1500))
+    #pragma warning( push )
+    #pragma warning( disable : 4996 )
+#endif
+
+#include <boost/assert.hpp>
+#include <boost/iterator/iterator_traits.hpp>
+#include <boost/iterator/iterator_facade.hpp>
+#include <boost/mpl/if.hpp>
+#include <boost/mpl/not.hpp>
+#include <boost/mpl/or.hpp>
+#include <boost/type_traits/is_abstract.hpp>
+#include <boost/type_traits/is_array.hpp>
+#include <boost/type_traits/is_base_and_derived.hpp>
+#include <boost/type_traits/is_convertible.hpp>
+#include <boost/type_traits/is_function.hpp>
+#include <boost/type_traits/is_pointer.hpp>
+#include <boost/type_traits/is_same.hpp>
+#include <boost/range/iterator_range.hpp>
+#include <boost/range/functions.hpp>
+#include <boost/range/iterator.hpp>
+#include <boost/range/difference_type.hpp>
+#include <boost/range/has_range_iterator.hpp>
+#include <boost/range/algorithm/equal.hpp>
+#include <boost/range/detail/safe_bool.hpp>
+#include <boost/utility/enable_if.hpp>
+#include <boost/next_prior.hpp>
+#include <iterator>
+#include <algorithm>
+#include <cstddef>
+#include <utility>
+
+/*! \file
+    Defines the \c graph_detail::iterator_range class and related functions.
+    \c graph_detail::iterator_range is a (simple wrapper of iterator pair idiom). It provides
+    a rich subset of Container interface.
+
+    TODO: make proper description.
+*/
+
+
+namespace boost
+{
+    namespace graph_detail
+    {
+        namespace iterator_range_detail
+        {
+            //
+            // The functions adl_begin and adl_end are implemented in a separate
+            // class for gcc-2.9x
+            //
+            template<class IteratorT>
+            struct iterator_range_impl {
+                template< class ForwardRange >
+                static IteratorT adl_begin( ForwardRange& r )
+                {
+                    return IteratorT( boost::begin( r ) );
+                }
+
+                template< class ForwardRange >
+                static IteratorT adl_end( ForwardRange& r )
+                {
+                    return IteratorT( boost::end( r ) );
+                }
+            };
+
+            template< class Left, class Right >
+            inline bool less_than( const Left& l, const Right& r )
+            {
+                return std::lexicographical_compare( boost::begin(l),
+                                                    boost::end(l),
+                                                    boost::begin(r),
+                                                    boost::end(r) );
+            }
+            
+            template< class Left, class Right >
+            inline bool greater_than( const Left& l, const Right& r )
+            {
+                return iterator_range_detail::less_than(r,l);
+            }
+            
+            template< class Left, class Right >
+            inline bool less_or_equal_than( const Left& l, const Right& r )
+            {
+                return !iterator_range_detail::less_than(r,l);
+            }
+            
+            template< class Left, class Right >
+            inline bool greater_or_equal_than( const Left& l, const Right& r )
+            {
+                return !iterator_range_detail::less_than(l,r);
+            }
+
+            // This version is maintained since it is used in other boost libraries
+            // such as Boost.Assign
+            template< class Left, class Right >
+            inline bool equal(const Left& l, const Right& r)
+            {
+                return boost::equal(l, r);
+            }
+
+            struct range_tag
+            {
+            };
+
+            struct const_range_tag
+            {
+            };
+
+            struct iterator_range_tag
+            {
+            };
+
+            typedef char (&incrementable_t)[1];
+            typedef char (&bidirectional_t)[2];
+            typedef char (&random_access_t)[3];
+
+            incrementable_t test_traversal_tag(boost::incrementable_traversal_tag);
+            bidirectional_t test_traversal_tag(boost::bidirectional_traversal_tag);
+            random_access_t test_traversal_tag(boost::random_access_traversal_tag);
+
+            template<std::size_t S>
+            struct pure_iterator_traversal_impl
+            {
+                typedef boost::incrementable_traversal_tag type;
+            };
+
+            template<>
+            struct pure_iterator_traversal_impl<sizeof(bidirectional_t)>
+            {
+                typedef boost::bidirectional_traversal_tag type;
+            };
+
+            template<>
+            struct pure_iterator_traversal_impl<sizeof(random_access_t)>
+            {
+                typedef boost::random_access_traversal_tag type;
+            };
+
+            template<typename IteratorT>
+            struct pure_iterator_traversal
+            {
+                typedef
+                    BOOST_DEDUCED_TYPENAME iterator_traversal<IteratorT>::type
+                traversal_t;
+                BOOST_STATIC_CONSTANT(
+                    std::size_t,
+                    traversal_i = sizeof(iterator_range_detail::test_traversal_tag((traversal_t())))
+                );
+                typedef
+                    BOOST_DEDUCED_TYPENAME pure_iterator_traversal_impl<traversal_i>::type
+                type;
+            };
+
+            template<class IteratorT, class TraversalTag>
+            class iterator_range_base
+                : public iterator_range_tag
+                , public std::pair<IteratorT, IteratorT>
+            {
+                typedef range_detail::safe_bool<
+                            IteratorT iterator_range_base<IteratorT, TraversalTag>::*
+                > safe_bool_t;
+
+                typedef iterator_range_base<IteratorT, TraversalTag> type;
+
+            protected:
+                typedef iterator_range_impl<IteratorT> impl;
+
+            public:
+                typedef BOOST_DEDUCED_TYPENAME
+                    safe_bool_t::unspecified_bool_type unspecified_bool_type;
+
+                typedef BOOST_DEDUCED_TYPENAME
+                    iterator_value<IteratorT>::type value_type;
+
+                typedef BOOST_DEDUCED_TYPENAME
+                    iterator_difference<IteratorT>::type difference_type;
+
+                typedef std::size_t size_type; // note: must be unsigned
+
+                // Needed because value-type is the same for
+                // const and non-const iterators
+                typedef BOOST_DEDUCED_TYPENAME
+                            iterator_reference<IteratorT>::type reference;
+
+                //! const_iterator type
+                /*!
+                    There is no distinction between const_iterator and iterator.
+                    These typedefs are provides to fulfill container interface
+                */
+                typedef IteratorT const_iterator;
+                //! iterator type
+                typedef IteratorT iterator;
+
+            protected:
+                iterator_range_base()
+                {
+                }
+
+                template<class Iterator>
+                iterator_range_base(Iterator Begin, Iterator End)
+                    : std::pair<IteratorT, IteratorT>(Begin, End)
+                {
+                }
+
+            public:
+                IteratorT begin() const
+                {
+                    return this->first;
+                }
+
+                IteratorT end() const
+                {
+                    return this->second;
+                }
+
+                bool empty() const
+                {
+                    return this->first == this->second;
+                }
+
+                operator unspecified_bool_type() const
+                {
+                    return safe_bool_t::to_unspecified_bool(
+                                this->first != this->second, &iterator_range_base::first);
+                }
+
+                bool operator!() const
+                {
+                    return empty();
+                }
+
+                bool equal(const iterator_range_base& r) const
+                {
+                    return this->first == r.first && this->second == r.second;
+                }
+
+            reference front() const
+            {
+                BOOST_ASSERT(!empty());
+                return *this->first;
+            }
+
+            void drop_front()
+            {
+                BOOST_ASSERT(!empty());
+                ++this->first;
+            }
+
+            void drop_front(difference_type n)
+            {
+                BOOST_ASSERT(n >= difference_type());
+                std::advance(this->first, n);
+            }
+            
+            // Deprecated
+            void pop_front() { drop_front(); }
+
+            protected:
+                template<class Iterator>
+                void assign(Iterator first, Iterator last)
+                {
+                    this->first = first;
+                    this->second = last;
+                }
+
+                template<class SinglePassRange>
+                void assign(const SinglePassRange& r)
+                {
+                    this->first = impl::adl_begin(r);
+                    this->second = impl::adl_end(r);
+                }
+
+                template<class SinglePassRange>
+                void assign(SinglePassRange& r)
+                {
+                    this->first = impl::adl_begin(r);
+                    this->second = impl::adl_end(r);
+                }
+            };
+
+            template<class IteratorT>
+            class iterator_range_base<IteratorT, bidirectional_traversal_tag>
+                    : public iterator_range_base<IteratorT, incrementable_traversal_tag>
+            {
+                typedef iterator_range_base<IteratorT, incrementable_traversal_tag> base_type;
+
+            protected:
+                iterator_range_base()
+                {
+                }
+
+                template<class Iterator>
+                iterator_range_base(Iterator first, Iterator last)
+                    : base_type(first, last)
+                {
+                }
+
+            public:
+                typedef BOOST_DEDUCED_TYPENAME base_type::difference_type difference_type;
+                typedef BOOST_DEDUCED_TYPENAME base_type::reference reference;
+
+                reference back() const
+                {
+                    BOOST_ASSERT(!this->empty());
+                    return *boost::prior(this->second);
+                }
+
+                void drop_back()
+                {
+                    BOOST_ASSERT(!this->empty());
+                    --this->second;
+                }
+
+                void drop_back(difference_type n)
+                {
+                    BOOST_ASSERT(n >= difference_type());
+                    std::advance(this->second, -n);
+                }
+                
+                // Deprecated
+                void pop_back() { drop_back(); }
+            };
+
+            template<class IteratorT>
+            class iterator_range_base<IteratorT, random_access_traversal_tag>
+                    : public iterator_range_base<IteratorT, bidirectional_traversal_tag>
+            {
+                typedef iterator_range_base<
+                            IteratorT, bidirectional_traversal_tag> base_type;
+
+            public:
+                typedef BOOST_DEDUCED_TYPENAME
+                    boost::mpl::if_<
+                        boost::mpl::or_<
+                            boost::is_abstract<
+                                BOOST_DEDUCED_TYPENAME base_type::value_type
+                            >,
+                            boost::is_array<
+                                BOOST_DEDUCED_TYPENAME base_type::value_type
+                            >,
+                            boost::is_function<
+                                BOOST_DEDUCED_TYPENAME base_type::value_type
+                            >
+                        >,
+                        BOOST_DEDUCED_TYPENAME base_type::reference,
+                        BOOST_DEDUCED_TYPENAME base_type::value_type
+                    >::type abstract_value_type;
+
+                // Rationale:
+                // typedef these here to reduce verbiage in the implementation of this
+                // type.
+                typedef BOOST_DEDUCED_TYPENAME base_type::difference_type difference_type;
+                typedef BOOST_DEDUCED_TYPENAME base_type::size_type size_type;
+                typedef BOOST_DEDUCED_TYPENAME base_type::reference reference;
+
+            protected:
+                iterator_range_base()
+                {
+                }
+
+                template<class Iterator>
+                iterator_range_base(Iterator first, Iterator last)
+                    : base_type(first, last)
+                {
+                }
+
+            public:
+                reference operator[](difference_type at) const
+                {
+                    BOOST_ASSERT(at >= 0);
+                    BOOST_ASSERT(static_cast<typename base_type::size_type>(at) < size());
+                    return this->first[at];
+                }
+
+                //
+                // When storing transform iterators, operator[]()
+                // fails because it returns by reference. Therefore
+                // operator()() is provided for these cases.
+                //
+                abstract_value_type operator()(difference_type at) const
+                {
+                    BOOST_ASSERT(at >= 0);
+                    BOOST_ASSERT(static_cast<typename base_type::size_type>(at) < size());
+                    return this->first[at];
+                }
+
+                BOOST_DEDUCED_TYPENAME base_type::size_type size() const
+                {
+                    return this->second - this->first;
+                }
+            };
+
+        }
+
+        //  iterator range template class -----------------------------------------//
+
+        //! iterator_range class
+        /*!
+            An \c iterator_range delimits a range in a sequence by beginning and ending iterators.
+            An iterator_range can be passed to an algorithm which requires a sequence as an input.
+            For example, the \c toupper() function may be used most frequently on strings,
+            but can also be used on iterator_ranges:
+
+            \code
+                boost::tolower( find( s, "UPPERCASE STRING" ) );
+            \endcode
+
+            Many algorithms working with sequences take a pair of iterators,
+            delimiting a working range, as an arguments. The \c iterator_range class is an
+            encapsulation of a range identified by a pair of iterators.
+            It provides a collection interface,
+            so it is possible to pass an instance to an algorithm requiring a collection as an input.
+        */
+        template<class IteratorT>
+        class iterator_range
+            : public iterator_range_detail::iterator_range_base<
+                    IteratorT,
+                    BOOST_DEDUCED_TYPENAME iterator_range_detail::pure_iterator_traversal<IteratorT>::type
+                >
+        {
+            typedef iterator_range_detail::iterator_range_base<
+                    IteratorT,
+                    BOOST_DEDUCED_TYPENAME iterator_range_detail::pure_iterator_traversal<IteratorT>::type
+            > base_type;
+
+            template<class Source>
+            struct is_compatible_range_
+                : is_convertible<
+                    BOOST_DEDUCED_TYPENAME mpl::eval_if<
+                        has_range_iterator<Source>,
+                        range_iterator<Source>,
+                        mpl::identity<void>
+                    >::type,
+                    BOOST_DEDUCED_TYPENAME base_type::iterator
+                >
+            {
+            };
+
+            template<class Source>
+            struct is_compatible_range
+                : mpl::and_<
+                    mpl::not_<
+                        is_convertible<
+                            Source,
+                            BOOST_DEDUCED_TYPENAME base_type::iterator
+                        >
+                    >,
+                    is_compatible_range_<Source>
+                >
+            {
+            };
+
+        protected:
+            typedef iterator_range_detail::iterator_range_impl<IteratorT> impl;
+
+        public:
+            typedef iterator_range<IteratorT> type;
+
+            iterator_range()
+            {
+            }
+
+            template<class Iterator>
+            iterator_range(Iterator first, Iterator last)
+                : base_type(first, last)
+            {
+            }
+
+            template<class SinglePassRange>
+            iterator_range(
+                const SinglePassRange& r,
+                BOOST_DEDUCED_TYPENAME ::boost::enable_if<
+                    is_compatible_range<const SinglePassRange>
+                >::type* = 0
+            )
+                : base_type(impl::adl_begin(r), impl::adl_end(r))
+            {
+            }
+
+            template<class SinglePassRange>
+            iterator_range(
+                SinglePassRange& r,
+                BOOST_DEDUCED_TYPENAME ::boost::enable_if<
+                    is_compatible_range<SinglePassRange>
+                >::type* = 0
+            )
+                : base_type(impl::adl_begin(r), impl::adl_end(r))
+            {
+            }
+
+            template<class SinglePassRange>
+            iterator_range(const SinglePassRange& r,
+                            iterator_range_detail::const_range_tag)
+                : base_type(impl::adl_begin(r), impl::adl_end(r))
+            {
+            }
+
+            template<class SinglePassRange>
+            iterator_range(SinglePassRange& r,
+                            iterator_range_detail::range_tag)
+                : base_type(impl::adl_begin(r), impl::adl_end(r))
+            {
+            }
+
+            template<class Iterator>
+            iterator_range& operator=(const iterator_range<Iterator>& other)
+            {
+                this->assign(other.begin(), other.end());
+                return *this;
+            }
+
+            template<class Iterator>
+            iterator_range& operator=(iterator_range<Iterator>& other)
+            {
+                this->assign(other.begin(), other.end());
+                return *this;
+            }
+
+            template<class SinglePassRange>
+            iterator_range& operator=(SinglePassRange& r)
+            {
+                this->assign(r);
+                return *this;
+            }
+
+            template<class SinglePassRange>
+            iterator_range& operator=(const SinglePassRange& r)
+            {
+                this->assign(r);
+                return *this;
+            }
+
+            iterator_range& advance_begin(
+                BOOST_DEDUCED_TYPENAME base_type::difference_type n)
+            {
+                std::advance(this->first, n);
+                return *this;
+            }
+
+            iterator_range& advance_end(
+                BOOST_DEDUCED_TYPENAME base_type::difference_type n)
+            {
+                std::advance(this->second, n);
+                return *this;
+            }
+
+        protected:
+            //
+            // Allow subclasses an easy way to access the
+            // base type
+            //
+            typedef iterator_range iterator_range_;
+        };
+
+        //  iterator range free-standing operators ---------------------------//
+
+        /////////////////////////////////////////////////////////////////////
+        // comparison operators
+        /////////////////////////////////////////////////////////////////////
+
+        template< class IteratorT, class ForwardRange >
+        inline BOOST_DEDUCED_TYPENAME boost::enable_if<
+            mpl::not_<is_base_and_derived<iterator_range_detail::iterator_range_tag, ForwardRange> >,
+            bool
+        >::type
+        operator==( const ForwardRange& l, const iterator_range<IteratorT>& r )
+        {
+            return boost::equal( l, r );
+        }
+
+        template< class IteratorT, class ForwardRange >
+        inline BOOST_DEDUCED_TYPENAME boost::enable_if<
+            mpl::not_<boost::is_base_and_derived<iterator_range_detail::iterator_range_tag, ForwardRange> >,
+            bool
+        >::type
+        operator!=( const ForwardRange& l, const iterator_range<IteratorT>& r )
+        {
+            return !boost::equal( l, r );
+        }
+
+        template< class IteratorT, class ForwardRange >
+        inline BOOST_DEDUCED_TYPENAME boost::enable_if<
+            mpl::not_<boost::is_base_and_derived<iterator_range_detail::iterator_range_tag, ForwardRange> >,
+            bool
+        >::type
+        operator<( const ForwardRange& l, const iterator_range<IteratorT>& r )
+        {
+            return iterator_range_detail::less_than( l, r );
+        }
+        
+        template< class IteratorT, class ForwardRange >
+        inline BOOST_DEDUCED_TYPENAME boost::enable_if<
+            mpl::not_<boost::is_base_and_derived<iterator_range_detail::iterator_range_tag, ForwardRange> >,
+            bool
+        >::type
+        operator<=( const ForwardRange& l, const iterator_range<IteratorT>& r )
+        {
+            return iterator_range_detail::less_or_equal_than( l, r );
+        }
+        
+        template< class IteratorT, class ForwardRange >
+        inline BOOST_DEDUCED_TYPENAME boost::enable_if<
+            mpl::not_<boost::is_base_and_derived<iterator_range_detail::iterator_range_tag, ForwardRange> >,
+            bool
+        >::type
+        operator>( const ForwardRange& l, const iterator_range<IteratorT>& r )
+        {
+            return iterator_range_detail::greater_than( l, r );
+        }
+        
+        template< class IteratorT, class ForwardRange >
+        inline BOOST_DEDUCED_TYPENAME boost::enable_if<
+            mpl::not_<boost::is_base_and_derived<iterator_range_detail::iterator_range_tag, ForwardRange> >,
+            bool
+        >::type
+        operator>=( const ForwardRange& l, const iterator_range<IteratorT>& r )
+        {
+            return iterator_range_detail::greater_or_equal_than( l, r );
+        }
+
+    #ifdef BOOST_NO_FUNCTION_TEMPLATE_ORDERING
+    #else
+        template< class Iterator1T, class Iterator2T >
+        inline bool
+        operator==( const iterator_range<Iterator1T>& l, const iterator_range<Iterator2T>& r )
+        {
+            return boost::equal( l, r );
+        }
+
+        template< class IteratorT, class ForwardRange >
+        inline BOOST_DEDUCED_TYPENAME boost::enable_if<
+            mpl::not_<boost::is_base_and_derived<iterator_range_detail::iterator_range_tag, ForwardRange> >,
+            bool
+        >::type
+        operator==( const iterator_range<IteratorT>& l, const ForwardRange& r )
+        {
+            return boost::equal( l, r );
+        }
+
+
+        template< class Iterator1T, class Iterator2T >
+        inline bool
+        operator!=( const iterator_range<Iterator1T>& l, const iterator_range<Iterator2T>& r )
+        {
+            return !boost::equal( l, r );
+        }
+
+        template< class IteratorT, class ForwardRange >
+        inline BOOST_DEDUCED_TYPENAME boost::enable_if<
+            mpl::not_<boost::is_base_and_derived<iterator_range_detail::iterator_range_tag, ForwardRange> >,
+            bool
+        >::type
+        operator!=( const iterator_range<IteratorT>& l, const ForwardRange& r )
+        {
+            return !boost::equal( l, r );
+        }
+
+
+        template< class Iterator1T, class Iterator2T >
+        inline bool
+        operator<( const iterator_range<Iterator1T>& l, const iterator_range<Iterator2T>& r )
+        {
+            return iterator_range_detail::less_than( l, r );
+        }
+
+        template< class IteratorT, class ForwardRange >
+        inline BOOST_DEDUCED_TYPENAME boost::enable_if<
+            mpl::not_<boost::is_base_and_derived<iterator_range_detail::iterator_range_tag, ForwardRange> >,
+            bool
+        >::type
+        operator<( const iterator_range<IteratorT>& l, const ForwardRange& r )
+        {
+            return iterator_range_detail::less_than( l, r );
+        }
+        
+        template< class Iterator1T, class Iterator2T >
+        inline bool
+        operator<=( const iterator_range<Iterator1T>& l, const iterator_range<Iterator2T>& r )
+        {
+            return iterator_range_detail::less_or_equal_than( l, r );
+        }
+        
+        template< class IteratorT, class ForwardRange >
+        inline BOOST_DEDUCED_TYPENAME boost::enable_if<
+            mpl::not_<boost::is_base_and_derived<iterator_range_detail::iterator_range_tag, ForwardRange> >,
+            bool
+        >::type
+        operator<=( const iterator_range<IteratorT>& l, const ForwardRange& r )
+        {
+            return iterator_range_detail::less_or_equal_than( l, r );
+        }
+        
+        template< class Iterator1T, class Iterator2T >
+        inline bool
+        operator>( const iterator_range<Iterator1T>& l, const iterator_range<Iterator2T>& r )
+        {
+            return iterator_range_detail::greater_than( l, r );
+        }
+        
+        template< class IteratorT, class ForwardRange >
+        inline BOOST_DEDUCED_TYPENAME boost::enable_if<
+            mpl::not_<boost::is_base_and_derived<iterator_range_detail::iterator_range_tag, ForwardRange> >,
+            bool
+        >::type
+        operator>( const iterator_range<IteratorT>& l, const ForwardRange& r )
+        {
+            return iterator_range_detail::greater_than( l, r );
+        }
+        
+        template< class Iterator1T, class Iterator2T >
+        inline bool
+        operator>=( const iterator_range<Iterator1T>& l, const iterator_range<Iterator2T>& r )
+        {
+            return iterator_range_detail::greater_or_equal_than( l, r );
+        }
+        
+        template< class IteratorT, class ForwardRange >
+        inline BOOST_DEDUCED_TYPENAME boost::enable_if<
+            mpl::not_<boost::is_base_and_derived<iterator_range_detail::iterator_range_tag, ForwardRange> >,
+            bool
+        >::type
+        operator>=( const iterator_range<IteratorT>& l, const ForwardRange& r )
+        {
+            return iterator_range_detail::greater_or_equal_than( l, r );
+        }
+
+    #endif // BOOST_NO_FUNCTION_TEMPLATE_ORDERING
+
+    	//  iterator range utilities -----------------------------------------//
+
+        //! iterator_range construct helper
+        /*!
+            Construct an \c iterator_range from a pair of iterators
+
+            \param Begin A begin iterator
+            \param End An end iterator
+            \return iterator_range object
+        */
+        template< typename IteratorT >
+        inline iterator_range< IteratorT >
+        make_iterator_range( IteratorT Begin, IteratorT End )
+        {
+            return iterator_range<IteratorT>( Begin, End );
+        }
+
+        template<typename IteratorT, typename IntegerT>
+        inline iterator_range<IteratorT>
+        make_iterator_range_n(IteratorT first, IntegerT n)
+        {
+            return iterator_range<IteratorT>(first, boost::next(first, n));
+        }
+
+    #ifdef BOOST_NO_FUNCTION_TEMPLATE_ORDERING
+
+        template< typename Range >
+        inline iterator_range< BOOST_DEDUCED_TYPENAME range_iterator<Range>::type >
+        make_iterator_range( Range& r )
+        {
+            return iterator_range< BOOST_DEDUCED_TYPENAME range_iterator<Range>::type >
+                ( boost::begin( r ), boost::end( r ) );
+        }
+
+    #else
+        //! iterator_range construct helper
+        /*!
+            Construct an \c iterator_range from a \c Range containing the begin
+            and end iterators.
+        */
+        template< class ForwardRange >
+        inline iterator_range< BOOST_DEDUCED_TYPENAME range_iterator<ForwardRange>::type >
+        make_iterator_range( ForwardRange& r )
+        {
+            return iterator_range< BOOST_DEDUCED_TYPENAME range_iterator<ForwardRange>::type >
+                ( r, iterator_range_detail::range_tag() );
+        }
+
+        template< class ForwardRange >
+        inline iterator_range< BOOST_DEDUCED_TYPENAME range_iterator<const ForwardRange>::type >
+        make_iterator_range( const ForwardRange& r )
+        {
+            return iterator_range< BOOST_DEDUCED_TYPENAME range_iterator<const ForwardRange>::type >
+                ( r, iterator_range_detail::const_range_tag() );
+        }
+
+    #endif // BOOST_NO_FUNCTION_TEMPLATE_ORDERING
+
+        namespace iterator_range_detail
+        {
+            template< class Range >
+            inline iterator_range< BOOST_DEDUCED_TYPENAME range_iterator<Range>::type >
+            make_range_impl( Range& r,
+                                BOOST_DEDUCED_TYPENAME range_difference<Range>::type advance_begin,
+                                BOOST_DEDUCED_TYPENAME range_difference<Range>::type advance_end )
+            {
+                //
+                // Not worth the effort
+                //
+                //if( advance_begin == 0 && advance_end == 0 )
+                //    return make_iterator_range( r );
+                //
+
+                BOOST_DEDUCED_TYPENAME range_iterator<Range>::type
+                    new_begin = boost::begin( r ),
+                    new_end   = boost::end( r );
+                std::advance( new_begin, advance_begin );
+                std::advance( new_end, advance_end );
+                return make_iterator_range( new_begin, new_end );
+            }
+        }
+
+    #ifdef BOOST_NO_FUNCTION_TEMPLATE_ORDERING
+
+        template< class Range >
+        inline iterator_range< BOOST_DEDUCED_TYPENAME range_iterator<Range>::type >
+        make_iterator_range( Range& r,
+                    BOOST_DEDUCED_TYPENAME range_difference<Range>::type advance_begin,
+                    BOOST_DEDUCED_TYPENAME range_difference<Range>::type advance_end )
+        {
+            return iterator_range_detail::make_range_impl( r, advance_begin, advance_end );
+        }
+
+    #else
+
+        template< class Range >
+        inline iterator_range< BOOST_DEDUCED_TYPENAME range_iterator<Range>::type >
+        make_iterator_range( Range& r,
+                    BOOST_DEDUCED_TYPENAME range_difference<Range>::type advance_begin,
+                    BOOST_DEDUCED_TYPENAME range_difference<Range>::type advance_end )
+        {
+            return iterator_range_detail::make_range_impl( r, advance_begin, advance_end );
+        }
+
+        template< class Range >
+        inline iterator_range< BOOST_DEDUCED_TYPENAME range_iterator<const Range>::type >
+        make_iterator_range( const Range& r,
+                    BOOST_DEDUCED_TYPENAME range_difference<Range>::type advance_begin,
+                    BOOST_DEDUCED_TYPENAME range_difference<Range>::type advance_end )
+        {
+            return iterator_range_detail::make_range_impl( r, advance_begin, advance_end );
+        }
+
+#endif // BOOST_NO_FUNCTION_TEMPLATE_ORDERING
+    } // namespace 'graph_detail'
+
+} // namespace 'boost'
+
+#if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1500))
+    #pragma warning( pop )
+#endif
+
+#endif
+

--- a/include/boost/graph/directed_graph.hpp
+++ b/include/boost/graph/directed_graph.hpp
@@ -9,6 +9,7 @@
 
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/properties.hpp>
+#include <boost/graph/detail/graph_iterator_range.hpp>
 #include <boost/pending/property.hpp>
 #include <boost/property_map/transform_value_property_map.hpp>
 #include <boost/type_traits.hpp>
@@ -427,8 +428,7 @@ num_vertices(DIRECTED_GRAPH const& g)
 { return g.num_vertices(); }
 
 template <DIRECTED_GRAPH_PARAMS>
-inline std::pair<
-    typename DIRECTED_GRAPH::vertex_iterator,
+inline graph_detail::iterator_range<
     typename DIRECTED_GRAPH::vertex_iterator
 >
 vertices(DIRECTED_GRAPH const& g)
@@ -441,8 +441,7 @@ num_edges(DIRECTED_GRAPH const& g)
 { return g.num_edges(); }
 
 template <DIRECTED_GRAPH_PARAMS>
-inline std::pair<
-    typename DIRECTED_GRAPH::edge_iterator,
+inline graph_detail::iterator_range<
     typename DIRECTED_GRAPH::edge_iterator
 >
 edges(DIRECTED_GRAPH const& g)

--- a/include/boost/graph/directed_graph.hpp
+++ b/include/boost/graph/directed_graph.hpp
@@ -384,8 +384,7 @@ in_degree(typename DIRECTED_GRAPH::vertex_descriptor v, DIRECTED_GRAPH const& g)
 { return in_degree(v, g.impl()); }
 
 template <DIRECTED_GRAPH_PARAMS>
-inline std::pair<
-    typename DIRECTED_GRAPH::in_edge_iterator,
+inline graph_detail::iterator_range<
     typename DIRECTED_GRAPH::in_edge_iterator
 >
 in_edges(typename DIRECTED_GRAPH::vertex_descriptor v,
@@ -400,8 +399,7 @@ degree(typename DIRECTED_GRAPH::vertex_descriptor v, DIRECTED_GRAPH const& g)
 
 // AdjacencyGraph concepts
 template <DIRECTED_GRAPH_PARAMS>
-inline std::pair<
-    typename DIRECTED_GRAPH::adjacency_iterator,
+inline graph_detail::iterator_range<
     typename DIRECTED_GRAPH::adjacency_iterator
     >
 adjacent_vertices(typename DIRECTED_GRAPH::vertex_descriptor v,

--- a/include/boost/graph/filtered_graph.hpp
+++ b/include/boost/graph/filtered_graph.hpp
@@ -14,6 +14,7 @@
 #include <boost/graph/properties.hpp>
 #include <boost/graph/adjacency_iterator.hpp>
 #include <boost/graph/detail/set_adaptor.hpp>
+#include <boost/graph/detail/graph_iterator_range.hpp>
 #include <boost/iterator/filter_iterator.hpp>
 
 namespace boost {
@@ -277,21 +278,19 @@ namespace boost {
   }
 
   template <typename G, typename EP, typename VP>
-  std::pair<typename filtered_graph<G, EP, VP>::vertex_iterator,
-            typename filtered_graph<G, EP, VP>::vertex_iterator>
+  graph_detail::iterator_range<typename filtered_graph<G, EP, VP>::vertex_iterator>
   vertices(const filtered_graph<G, EP, VP>& g)
   {
     typedef filtered_graph<G, EP, VP> Graph;    
     typename graph_traits<G>::vertex_iterator f, l;
     boost::tie(f, l) = vertices(g.m_g);
     typedef typename Graph::vertex_iterator iter;
-    return std::make_pair(iter(g.m_vertex_pred, f, l), 
+    return graph_detail::make_iterator_range(iter(g.m_vertex_pred, f, l), 
                           iter(g.m_vertex_pred, l, l));
   }
 
   template <typename G, typename EP, typename VP>
-  std::pair<typename filtered_graph<G, EP, VP>::edge_iterator,
-            typename filtered_graph<G, EP, VP>::edge_iterator>
+  graph_detail::iterator_range<typename filtered_graph<G, EP, VP>::edge_iterator>
   edges(const filtered_graph<G, EP, VP>& g)
   {
     typedef filtered_graph<G, EP, VP> Graph;
@@ -299,7 +298,7 @@ namespace boost {
     typename graph_traits<G>::edge_iterator f, l;
     boost::tie(f, l) = edges(g.m_g);
     typedef typename Graph::edge_iterator iter;
-    return std::make_pair(iter(pred, f, l), iter(pred, l, l));
+    return graph_detail::make_iterator_range(iter(pred, f, l), iter(pred, l, l));
   }
 
   // An alternative for num_vertices() and num_edges() would be to
@@ -344,8 +343,7 @@ namespace boost {
   }
 
   template <typename G, typename EP, typename VP>
-  std::pair<typename filtered_graph<G, EP, VP>::out_edge_iterator,
-            typename filtered_graph<G, EP, VP>::out_edge_iterator>
+  graph_detail::iterator_range<typename filtered_graph<G, EP, VP>::out_edge_iterator>
   out_edges(typename filtered_graph<G, EP, VP>::vertex_descriptor u,
             const filtered_graph<G, EP, VP>& g)
   {
@@ -354,7 +352,7 @@ namespace boost {
     typedef typename Graph::out_edge_iterator iter;
     typename graph_traits<G>::out_edge_iterator f, l;
     boost::tie(f, l) = out_edges(u, g.m_g);
-    return std::make_pair(iter(pred, f, l), iter(pred, l, l));
+    return graph_detail::make_iterator_range(iter(pred, f, l), iter(pred, l, l));
   }
 
   template <typename G, typename EP, typename VP>
@@ -370,8 +368,7 @@ namespace boost {
   }
 
   template <typename G, typename EP, typename VP>
-  std::pair<typename filtered_graph<G, EP, VP>::adjacency_iterator,
-            typename filtered_graph<G, EP, VP>::adjacency_iterator>
+  graph_detail::iterator_range<typename filtered_graph<G, EP, VP>::adjacency_iterator>
   adjacent_vertices(typename filtered_graph<G, EP, VP>::vertex_descriptor u,
                     const filtered_graph<G, EP, VP>& g)
   {
@@ -379,13 +376,12 @@ namespace boost {
     typedef typename Graph::adjacency_iterator adjacency_iterator;
     typename Graph::out_edge_iterator f, l;
     boost::tie(f, l) = out_edges(u, g);
-    return std::make_pair(adjacency_iterator(f, const_cast<Graph*>(&g)),
+    return graph_detail::make_iterator_range(adjacency_iterator(f, const_cast<Graph*>(&g)),
                           adjacency_iterator(l, const_cast<Graph*>(&g)));
   }
   
   template <typename G, typename EP, typename VP>
-  std::pair<typename filtered_graph<G, EP, VP>::in_edge_iterator,
-            typename filtered_graph<G, EP, VP>::in_edge_iterator>
+  graph_detail::iterator_range<typename filtered_graph<G, EP, VP>::in_edge_iterator>
   in_edges(typename filtered_graph<G, EP, VP>::vertex_descriptor u,
             const filtered_graph<G, EP, VP>& g)
   {
@@ -394,7 +390,7 @@ namespace boost {
     typedef typename Graph::in_edge_iterator iter;
     typename graph_traits<G>::in_edge_iterator f, l;
     boost::tie(f, l) = in_edges(u, g.m_g);
-    return std::make_pair(iter(pred, f, l), iter(pred, l, l));
+    return graph_detail::make_iterator_range(iter(pred, f, l), iter(pred, l, l));
   }
 
   template <typename G, typename EP, typename VP>

--- a/include/boost/graph/graph_archetypes.hpp
+++ b/include/boost/graph/graph_archetypes.hpp
@@ -113,12 +113,11 @@ namespace boost { // should use a different namespace for this
   };
   
   template <typename V, typename D, typename P, typename B>
-  std::pair<typename adjacency_graph_archetype<V,D,P,B>::adjacency_iterator,
-            typename adjacency_graph_archetype<V,D,P,B>::adjacency_iterator>
+  graph_detail::iterator_range<typename adjacency_graph_archetype<V,D,P,B>::adjacency_iterator>
   adjacent_vertices(const V&, const adjacency_graph_archetype<V,D,P,B>& )
   {
     typedef typename adjacency_graph_archetype<V,D,P,B>::adjacency_iterator Iter;
-    return std::make_pair(Iter(), Iter());
+    return graph_detail::make_iterator_range(Iter(), Iter());
   }
 
   template <typename V, typename D, typename P, typename B>

--- a/include/boost/graph/graph_archetypes.hpp
+++ b/include/boost/graph/graph_archetypes.hpp
@@ -14,6 +14,7 @@
 #include <boost/concept_archetype.hpp>
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/properties.hpp>
+#include <boost/graph/detail/graph_iterator_range.hpp>
 
 namespace boost { // should use a different namespace for this
 
@@ -163,12 +164,11 @@ namespace boost { // should use a different namespace for this
   };
   
   template <typename V, typename D, typename P, typename B>
-  std::pair<typename vertex_list_graph_archetype<V,D,P,B>::vertex_iterator,
-            typename vertex_list_graph_archetype<V,D,P,B>::vertex_iterator>
+  graph_detail::iterator_range<typename vertex_list_graph_archetype<V,D,P,B>::vertex_iterator>
   vertices(const vertex_list_graph_archetype<V,D,P,B>& )
   {
     typedef typename vertex_list_graph_archetype<V,D,P,B>::vertex_iterator Iter;
-    return std::make_pair(Iter(), Iter());
+    return graph_detail::make_iterator_range(Iter(), Iter());
   }
 
   template <typename V, typename D, typename P, typename B>

--- a/include/boost/graph/grid_graph.hpp
+++ b/include/boost/graph/grid_graph.hpp
@@ -19,6 +19,7 @@
 #include <boost/limits.hpp>
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/properties.hpp>
+#include <boost/graph/detail/graph_iterator_range.hpp>
 #include <boost/iterator/counting_iterator.hpp>
 #include <boost/iterator/transform_iterator.hpp>
 #include <boost/property_map/property_map.hpp>
@@ -743,14 +744,13 @@ namespace boost {
     // VertexListGraph
     //================
 
-    friend inline std::pair<typename type::vertex_iterator,
-                            typename type::vertex_iterator> 
+    friend inline graph_detail::iterator_range<typename type::vertex_iterator> 
     vertices(const type& graph) {
       typedef typename type::vertex_iterator vertex_iterator;
       typedef typename type::vertex_function vertex_function;
       typedef typename type::vertex_index_iterator vertex_index_iterator;
 
-      return (std::make_pair
+      return (graph_detail::make_iterator_range
               (vertex_iterator(vertex_index_iterator(0),
                                vertex_function(&graph)),
                vertex_iterator(vertex_index_iterator(graph.num_vertices()),
@@ -773,15 +773,14 @@ namespace boost {
     // IncidenceGraph
     //===============
 
-    friend inline std::pair<typename type::out_edge_iterator,
-                            typename type::out_edge_iterator>
+    friend inline graph_detail::iterator_range<typename type::out_edge_iterator>
     out_edges(typename type::vertex_descriptor vertex,
               const type& graph) {
       typedef typename type::degree_iterator degree_iterator;
       typedef typename type::out_edge_function out_edge_function;
       typedef typename type::out_edge_iterator out_edge_iterator;
 
-      return (std::make_pair
+      return (graph_detail::make_iterator_range
               (out_edge_iterator(degree_iterator(0),
                                  out_edge_function(vertex, &graph)),
                out_edge_iterator(degree_iterator(graph.out_degree(vertex)),
@@ -806,15 +805,14 @@ namespace boost {
     // AdjacencyGraph
     //===============
 
-    friend typename std::pair<typename type::adjacency_iterator,
-                              typename type::adjacency_iterator>
+    friend typename graph_detail::iterator_range<typename type::adjacency_iterator>
     adjacent_vertices (typename type::vertex_descriptor vertex,
                        const type& graph) {
       typedef typename type::degree_iterator degree_iterator;
       typedef typename type::adjacent_vertex_function adjacent_vertex_function;
       typedef typename type::adjacency_iterator adjacency_iterator;
 
-      return (std::make_pair
+      return (graph_detail::make_iterator_range
               (adjacency_iterator(degree_iterator(0),
                                  adjacent_vertex_function(vertex, &graph)),
                adjacency_iterator(degree_iterator(graph.out_degree(vertex)),
@@ -836,14 +834,13 @@ namespace boost {
       return (graph.edge_at(edge_index));
     }
 
-    friend inline std::pair<typename type::edge_iterator,
-                            typename type::edge_iterator>
+    friend inline graph_detail::iterator_range<typename type::edge_iterator>
     edges(const type& graph) {
       typedef typename type::edge_index_iterator edge_index_iterator;
       typedef typename type::edge_function edge_function;
       typedef typename type::edge_iterator edge_iterator;
 
-      return (std::make_pair
+      return (graph_detail::make_iterator_range
               (edge_iterator(edge_index_iterator(0),
                              edge_function(&graph)),
                edge_iterator(edge_index_iterator(graph.num_edges()),
@@ -854,15 +851,14 @@ namespace boost {
     // BiDirectionalGraph
     //===================
 
-    friend inline std::pair<typename type::in_edge_iterator,
-                            typename type::in_edge_iterator>
+    friend inline graph_detail::iterator_range<typename type::in_edge_iterator>
     in_edges(typename type::vertex_descriptor vertex,
              const type& graph) {
       typedef typename type::in_edge_function in_edge_function;
       typedef typename type::degree_iterator degree_iterator;
       typedef typename type::in_edge_iterator in_edge_iterator;
 
-      return (std::make_pair
+      return (graph_detail::make_iterator_range
               (in_edge_iterator(degree_iterator(0),
                                 in_edge_function(vertex, &graph)),
                in_edge_iterator(degree_iterator(graph.in_degree(vertex)),

--- a/include/boost/graph/labeled_graph.hpp
+++ b/include/boost/graph/labeled_graph.hpp
@@ -19,6 +19,7 @@
 #include <boost/type_traits/is_unsigned.hpp>
 #include <boost/pending/container_traits.hpp>
 #include <boost/graph/graph_traits.hpp>
+#include <boost/graph/detail/graph_iterator_range.hpp>
 
 // This file implements a utility for creating mappings from arbitrary
 // identifiers to the vertices of a graph.
@@ -628,8 +629,7 @@ adjacenct_vertices(typename LABELED_GRAPH::vertex_descriptor v, LABELED_GRAPH co
 /** @name VertexListGraph */
 //@{
 template <LABELED_GRAPH_PARAMS>
-inline std::pair<
-    typename LABELED_GRAPH::vertex_iterator,
+inline graph_detail::iterator_range<
     typename LABELED_GRAPH::vertex_iterator>
 vertices(LABELED_GRAPH const& g)
 { return vertices(g.graph()); }
@@ -643,8 +643,7 @@ num_vertices(LABELED_GRAPH const& g)
 /** @name EdgeListGraph */
 //@{
 template <LABELED_GRAPH_PARAMS>
-inline std::pair<
-    typename LABELED_GRAPH::edge_iterator,
+inline graph_detail::iterator_range<
     typename LABELED_GRAPH::edge_iterator>
 edges(LABELED_GRAPH const& g)
 { return edges(g.graph()); }

--- a/include/boost/graph/labeled_graph.hpp
+++ b/include/boost/graph/labeled_graph.hpp
@@ -599,8 +599,7 @@ target(typename LABELED_GRAPH::edge_descriptor e, LABELED_GRAPH const& g)
 /** @name Bidirectional Graph */
 //@{
 template <LABELED_GRAPH_PARAMS>
-inline std::pair<
-    typename LABELED_GRAPH::in_edge_iterator,
+inline graph_detail::iterator_range<
     typename LABELED_GRAPH::in_edge_iterator>
 in_edges(typename LABELED_GRAPH::vertex_descriptor v, LABELED_GRAPH const& g)
 { return in_edges(v, g.graph()); }
@@ -619,8 +618,7 @@ degree(typename LABELED_GRAPH::vertex_descriptor v, LABELED_GRAPH const& g)
 /** @name Adjacency Graph */
 //@{
 template <LABELED_GRAPH_PARAMS>
-inline std::pair<
-    typename LABELED_GRAPH::adjacency_iterator,
+inline graph_detail::iterator_range<
     typename LABELED_GRAPH::adjacency_iterator>
 adjacenct_vertices(typename LABELED_GRAPH::vertex_descriptor v, LABELED_GRAPH const& g)
 { return adjacent_vertices(v, g.graph()); }

--- a/include/boost/graph/leda_graph.hpp
+++ b/include/boost/graph/leda_graph.hpp
@@ -16,6 +16,7 @@
 #include <boost/iterator/iterator_facade.hpp>
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/properties.hpp>
+#include <boost/graph/detail/graph_iterator_range.hpp>
 
 #include <LEDA/graph/graph.h>
 #include <LEDA/graph/node_array.h>
@@ -393,8 +394,7 @@ namespace boost {
   }
 
   template <class vtype, class etype>
-  inline std::pair<
-    typename graph_traits< leda::GRAPH<vtype,etype> >::in_edge_iterator,
+  inline graph_detail::iterator_range<
     typename graph_traits< leda::GRAPH<vtype,etype> >::in_edge_iterator >  
   in_edges(
     typename graph_traits< leda::GRAPH<vtype,etype> >::vertex_descriptor u, 
@@ -402,7 +402,7 @@ namespace boost {
   {
     typedef typename graph_traits< leda::GRAPH<vtype,etype> >
       ::in_edge_iterator Iter;
-    return std::make_pair( Iter(g.first_adj_edge(u,1),&g), Iter(0,&g) );
+    return graph_detail::make_iterator_range( Iter(g.first_adj_edge(u,1),&g), Iter(0,&g) );
   }
 
   template <class vtype, class etype>
@@ -590,8 +590,7 @@ namespace boost {
     return std::make_pair( Iter(g.first_adj_edge(u),&g), Iter(0,&g) );
   }
 
-  inline std::pair<
-    graph_traits<leda::graph>::in_edge_iterator,
+  inline graph_detail::iterator_range<
     graph_traits<leda::graph>::in_edge_iterator >
   in_edges(
     graph_traits<leda::graph>::vertex_descriptor u, 
@@ -599,11 +598,10 @@ namespace boost {
   {
     typedef graph_traits<leda::graph>
       ::in_edge_iterator Iter;
-    return std::make_pair( Iter(g.first_in_edge(u),&g), Iter(0,&g) );
+    return graph_detail::make_iterator_range( Iter(g.first_in_edge(u),&g), Iter(0,&g) );
   }
 
-  inline std::pair<
-    graph_traits<leda::graph>::adjacency_iterator,
+  inline graph_detail::iterator_range<
     graph_traits<leda::graph>::adjacency_iterator >  
   adjacent_vertices(
     graph_traits<leda::graph>::vertex_descriptor u, 
@@ -611,7 +609,7 @@ namespace boost {
   {
     typedef graph_traits<leda::graph>
       ::adjacency_iterator Iter;
-    return std::make_pair( Iter(g.first_adj_edge(u),&g), Iter(0,&g) );
+    return graph_detail::make_iterator_range( Iter(g.first_adj_edge(u),&g), Iter(0,&g) );
   }
 
   graph_traits<leda::graph>::vertices_size_type

--- a/include/boost/graph/matrix_as_graph.hpp
+++ b/include/boost/graph/matrix_as_graph.hpp
@@ -43,22 +43,22 @@ namespace boost { \
     typedef Matrix::size_type size_type; \
     typedef boost::int_iterator<size_type> vertex_iterator; \
     \
-    friend std::pair<vertex_iterator, vertex_iterator> \
+    friend graph_detail::iterator_range<vertex_iterator> \
     vertices(const Matrix& g) { \
       typedef vertex_iterator VIter; \
-      return std::make_pair(VIter(0), VIter(g.nrows())); \
+      return graph_detail::make_iterator_range(VIter(0), VIter(g.nrows())); \
     } \
     \
-    friend std::pair<out_edge_iterator, out_edge_iterator> \
+    friend graph_detail::iterator_range<out_edge_iterator> \
     out_edges(V v, const Matrix& g) { \
       typedef out_edge_iterator IncIter; \
-      return std::make_pair(IncIter(g[v].begin()), \
+      return graph_detail::make_iterator_range(IncIter(g[v].begin()), \
                             IncIter(g[v].end())); \
     } \
-    friend std::pair<adjacency_iterator, adjacency_iterator> \
+    friend graph_detail::iterator_range<adjacency_iterator> \
     adjacent_vertices(V v, const Matrix& g) { \
       typedef adjacency_iterator AdjIter; \
-      return std::make_pair(AdjIter(g[v].begin()), \
+      return graph_detail::make_iterator_range(AdjIter(g[v].begin()), \
                             AdjIter(g[v].end())); \
     } \
     friend vertex_descriptor \

--- a/include/boost/graph/reverse_graph.hpp
+++ b/include/boost/graph/reverse_graph.hpp
@@ -8,6 +8,7 @@
 
 #include <boost/graph/adjacency_iterator.hpp>
 #include <boost/graph/properties.hpp>
+#include <boost/graph/detail/graph_iterator_range.hpp>
 #include <boost/iterator/transform_iterator.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/type_traits.hpp>
@@ -278,8 +279,7 @@ edge(const typename graph_traits<BidirectionalGraph>::vertex_descriptor u,
 }
 
 template <class BidirectionalGraph, class GRef>
-inline std::pair<typename reverse_graph<BidirectionalGraph>::in_edge_iterator,
-                 typename reverse_graph<BidirectionalGraph>::in_edge_iterator>
+inline graph_detail::iterator_range<typename reverse_graph<BidirectionalGraph>::in_edge_iterator>
 in_edges(const typename graph_traits<BidirectionalGraph>::vertex_descriptor u,
          const reverse_graph<BidirectionalGraph,GRef>& g)
 {
@@ -287,8 +287,7 @@ in_edges(const typename graph_traits<BidirectionalGraph>::vertex_descriptor u,
 }
 
 template <class BidirectionalGraph, class GRef>
-inline std::pair<typename reverse_graph<BidirectionalGraph,GRef>::adjacency_iterator,
-    typename reverse_graph<BidirectionalGraph,GRef>::adjacency_iterator>
+inline graph_detail::iterator_range<typename reverse_graph<BidirectionalGraph,GRef>::adjacency_iterator>
 adjacent_vertices(typename graph_traits<BidirectionalGraph>::vertex_descriptor u,
                   const reverse_graph<BidirectionalGraph,GRef>& g)
 {
@@ -296,7 +295,7 @@ adjacent_vertices(typename graph_traits<BidirectionalGraph>::vertex_descriptor u
     typename graph_traits<Graph>::out_edge_iterator first, last;
     boost::tie(first, last) = out_edges(u, g);
     typedef typename graph_traits<Graph>::adjacency_iterator adjacency_iterator;
-    return std::make_pair(adjacency_iterator(first, const_cast<Graph*>(&g)),
+    return graph_detail::make_iterator_range(adjacency_iterator(first, const_cast<Graph*>(&g)),
                           adjacency_iterator(last, const_cast<Graph*>(&g)));
 }
 

--- a/include/boost/graph/stanford_graph.hpp
+++ b/include/boost/graph/stanford_graph.hpp
@@ -14,6 +14,7 @@
 #include <boost/property_map/property_map.hpp>
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/properties.hpp>
+#include <boost/graph/graph_iterator_range.hpp>
 
 // Thanks to Andreas Scherer for numerous suggestions and fixes!
 
@@ -206,17 +207,17 @@ namespace boost {
 
 namespace boost {
 
-  inline std::pair<sgb_vertex_iterator,sgb_vertex_iterator>
+  inline graph_detail::iterator_range<sgb_vertex_iterator>
   vertices(sgb_const_graph_ptr g)
   {
-    return std::make_pair(sgb_vertex_iterator(g->vertices),
+    return graph_detail::make_iterator_range(sgb_vertex_iterator(g->vertices),
                           sgb_vertex_iterator(g->vertices + g->n));
   }
 
-  inline std::pair<sgb_out_edge_iterator,sgb_out_edge_iterator>
+  inline graph_detail::iterator_range<sgb_out_edge_iterator>
   out_edges(Vertex* u, sgb_const_graph_ptr)
   {
-    return std::make_pair( sgb_out_edge_iterator(u, u->arcs),
+    return graph_detail::make_iterator_range( sgb_out_edge_iterator(u, u->arcs),
                            sgb_out_edge_iterator(u, 0) );
   }
 
@@ -230,10 +231,10 @@ namespace boost {
 
   // in_edges?
 
-  inline std::pair<sgb_adj_iterator,sgb_adj_iterator>
+  inline graph_detail::iterator_range<sgb_adj_iterator>
   adjacent_vertices(Vertex* u, sgb_const_graph_ptr)
   {
-    return std::make_pair( sgb_adj_iterator(u->arcs),
+    return graph_detail::make_iterator_range( sgb_adj_iterator(u->arcs),
                            sgb_adj_iterator(0) );
   }
 

--- a/include/boost/graph/subgraph.hpp
+++ b/include/boost/graph/subgraph.hpp
@@ -20,6 +20,7 @@
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/graph_mutability_traits.hpp>
 #include <boost/graph/properties.hpp>
+#include <boost/graph/detail/graph_iterator_range.hpp>
 #include <boost/iterator/indirect_iterator.hpp>
 
 #include <boost/static_assert.hpp>
@@ -479,8 +480,7 @@ adjacent_vertices(typename subgraph<G>::vertex_descriptor v, const subgraph<G>& 
 // Functions required by the VertexListGraph concept
 
 template <typename G>
-std::pair<typename subgraph<G>::vertex_iterator,
-          typename subgraph<G>::vertex_iterator>
+graph_detail::iterator_range<typename subgraph<G>::vertex_iterator>
 vertices(const subgraph<G>& g)
 { return vertices(g.m_graph); }
 
@@ -493,8 +493,7 @@ num_vertices(const subgraph<G>& g)
 // Functions required by the EdgeListGraph concept
 
 template <typename G>
-std::pair<typename subgraph<G>::edge_iterator,
-          typename subgraph<G>::edge_iterator>
+graph_detail::iterator_range<typename subgraph<G>::edge_iterator>
 edges(const subgraph<G>& g)
 { return edges(g.m_graph); }
 

--- a/include/boost/graph/subgraph.hpp
+++ b/include/boost/graph/subgraph.hpp
@@ -428,8 +428,7 @@ add_vertex(typename subgraph<G>::vertex_descriptor u_global,
 // Functions required by the IncidenceGraph concept
 
 template <typename G>
-std::pair<typename graph_traits<G>::out_edge_iterator,
-          typename graph_traits<G>::out_edge_iterator>
+graph_detail::iterator_range<typename graph_traits<G>::out_edge_iterator>
 out_edges(typename graph_traits<G>::vertex_descriptor v, const subgraph<G>& g)
 { return out_edges(v, g.m_graph); }
 
@@ -452,8 +451,7 @@ target(typename graph_traits<G>::edge_descriptor e, const subgraph<G>& g)
 // Functions required by the BidirectionalGraph concept
 
 template <typename G>
-std::pair<typename graph_traits<G>::in_edge_iterator,
-          typename graph_traits<G>::in_edge_iterator>
+graph_detail::iterator_range<typename graph_traits<G>::in_edge_iterator>
 in_edges(typename graph_traits<G>::vertex_descriptor v, const subgraph<G>& g)
 { return in_edges(v, g.m_graph); }
 
@@ -471,8 +469,7 @@ degree(typename graph_traits<G>::vertex_descriptor v, const subgraph<G>& g)
 // Functions required by the AdjacencyGraph concept
 
 template <typename G>
-std::pair<typename subgraph<G>::adjacency_iterator,
-          typename subgraph<G>::adjacency_iterator>
+graph_detail::iterator_range<typename subgraph<G>::adjacency_iterator>
 adjacent_vertices(typename subgraph<G>::vertex_descriptor v, const subgraph<G>& g)
 { return adjacent_vertices(v, g.m_graph); }
 

--- a/include/boost/graph/undirected_graph.hpp
+++ b/include/boost/graph/undirected_graph.hpp
@@ -373,8 +373,7 @@ in_degree(typename UNDIRECTED_GRAPH::vertex_descriptor v,
 { return in_degree(v, g.impl()); }
 
 template <UNDIRECTED_GRAPH_PARAMS>
-inline std::pair<
-    typename UNDIRECTED_GRAPH::in_edge_iterator,
+inline graph_detail::iterator_range<
     typename UNDIRECTED_GRAPH::in_edge_iterator
 >
 in_edges(typename UNDIRECTED_GRAPH::vertex_descriptor v,
@@ -382,8 +381,7 @@ in_edges(typename UNDIRECTED_GRAPH::vertex_descriptor v,
 { return in_edges(v, g.impl()); }
 
 template <UNDIRECTED_GRAPH_PARAMS>
-inline std::pair<
-    typename UNDIRECTED_GRAPH::out_edge_iterator,
+inline graph_detail::iterator_range<
     typename UNDIRECTED_GRAPH::out_edge_iterator
 >
 incident_edges(typename UNDIRECTED_GRAPH::vertex_descriptor v,
@@ -398,8 +396,7 @@ degree(typename UNDIRECTED_GRAPH::vertex_descriptor v,
 
 // AdjacencyGraph concepts
 template <UNDIRECTED_GRAPH_PARAMS>
-inline std::pair<
-    typename UNDIRECTED_GRAPH::adjacency_iterator,
+inline graph_detail::iterator_range<
     typename UNDIRECTED_GRAPH::adjacency_iterator
     >
 adjacent_vertices(typename UNDIRECTED_GRAPH::vertex_descriptor v,

--- a/include/boost/graph/undirected_graph.hpp
+++ b/include/boost/graph/undirected_graph.hpp
@@ -9,6 +9,7 @@
 
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/properties.hpp>
+#include <boost/graph/detail/graph_iterator_range.hpp>
 #include <boost/pending/property.hpp>
 #include <boost/property_map/transform_value_property_map.hpp>
 #include <boost/type_traits.hpp>
@@ -425,8 +426,7 @@ num_vertices(UNDIRECTED_GRAPH const& g)
 { return g.num_vertices(); }
 
 template <UNDIRECTED_GRAPH_PARAMS>
-inline std::pair<
-    typename UNDIRECTED_GRAPH::vertex_iterator,
+inline graph_detail::iterator_range<
     typename UNDIRECTED_GRAPH::vertex_iterator
 >
 vertices(UNDIRECTED_GRAPH const& g)
@@ -439,8 +439,7 @@ num_edges(UNDIRECTED_GRAPH const& g)
 { return g.num_edges(); }
 
 template <UNDIRECTED_GRAPH_PARAMS>
-inline std::pair<
-    typename UNDIRECTED_GRAPH::edge_iterator,
+inline graph_detail::iterator_range<
     typename UNDIRECTED_GRAPH::edge_iterator
 >
 edges(UNDIRECTED_GRAPH const& g)

--- a/include/boost/graph/vector_as_graph.hpp
+++ b/include/boost/graph/vector_as_graph.hpp
@@ -168,12 +168,11 @@ namespace boost {
   }
 
   template <class EdgeList, class Alloc>
-  std::pair<typename EdgeList::const_iterator,
-            typename EdgeList::const_iterator>
+  graph_detail::iterator_range<typename EdgeList::const_iterator>
   adjacent_vertices(typename EdgeList::value_type v,
                     const std::vector<EdgeList, Alloc>& g)
   {
-    return std::make_pair(g[v].begin(), g[v].end());
+    return graph_detail::make_iterator_range(g[v].begin(), g[v].end());
   }
 
   // source() and target() already provided for pairs in graph_traits.hpp

--- a/include/boost/graph/vector_as_graph.hpp
+++ b/include/boost/graph/vector_as_graph.hpp
@@ -24,6 +24,7 @@
 #include <boost/graph/graph_traits.hpp>
 #include <boost/property_map/property_map.hpp>
 #include <boost/graph/properties.hpp>
+#include <boost/graph/detail/graph_iterator_range.hpp>
 #include <algorithm>
 
 /*
@@ -32,7 +33,7 @@
   graph object). The edge-lists type of the graph is templated, so the
   user can choose any STL container, so long as the value_type of the
   container is convertible to the size_type of the vector. For now any
-  graph properties must be stored seperately.
+  graph properties must be stored separately.
 
   This module requires the C++ compiler to support partial
   specialization for the graph_traits class, so this is not portable
@@ -178,12 +179,11 @@ namespace boost {
   // source() and target() already provided for pairs in graph_traits.hpp
 
   template <class EdgeList, class Alloc>
-  std::pair<boost::counting_iterator<typename EdgeList::value_type>,
-            boost::counting_iterator<typename EdgeList::value_type> >
+  graph_detail::iterator_range<boost::counting_iterator<typename EdgeList::value_type> >
   vertices(const std::vector<EdgeList, Alloc>& v)
   {
     typedef boost::counting_iterator<typename EdgeList::value_type> Iter;
-    return std::make_pair(Iter(0), Iter(v.size()));
+    return graph_detail::make_iterator_range(Iter(0), Iter(v.size()));
   }
 
   template <class EdgeList, class Alloc>

--- a/include/boost/graph/vertex_and_edge_range.hpp
+++ b/include/boost/graph/vertex_and_edge_range.hpp
@@ -11,6 +11,7 @@
 #define BOOST_GRAPH_VERTEX_AND_EDGE_RANGE_HPP
 
 #include <boost/graph/graph_traits.hpp>
+#include <boost/graph/detail/graph_iterator_range.hpp>
 #include <iterator>
 
 namespace boost { 
@@ -80,9 +81,9 @@ namespace graph {
   };
 
   template<typename Graph, typename VertexIterator, typename EdgeIterator>
-  inline std::pair<VertexIterator, VertexIterator>
+  inline graph_detail::iterator_range<VertexIterator>
   vertices(const vertex_and_edge_range<Graph, VertexIterator, EdgeIterator>& g)
-  { return std::make_pair(g.first_vertex, g.last_vertex); }
+  { return graph_detail::make_iterator_range(g.first_vertex, g.last_vertex); }
 
   template<typename Graph, typename VertexIterator, typename EdgeIterator>
   inline typename vertex_and_edge_range<Graph, VertexIterator, EdgeIterator>
@@ -92,9 +93,9 @@ namespace graph {
   { return g.m_num_vertices; }
 
   template<typename Graph, typename VertexIterator, typename EdgeIterator>
-  inline std::pair<EdgeIterator, EdgeIterator>
+  inline graph_detail::iterator_range<EdgeIterator, EdgeIterator>
   edges(const vertex_and_edge_range<Graph, VertexIterator, EdgeIterator>& g)
-  { return std::make_pair(g.first_edge, g.last_edge); }
+  { return graph_detail::make_iterator_range(g.first_edge, g.last_edge); }
 
   template<typename Graph, typename VertexIterator, typename EdgeIterator>
   inline typename vertex_and_edge_range<Graph, VertexIterator, EdgeIterator>

--- a/test/graph_test.hpp
+++ b/test/graph_test.hpp
@@ -89,6 +89,11 @@ namespace boost {
           BOOST_CHECK(source(e, g) == u);
           BOOST_CHECK(container_contains(adj, target(e, g)) == true);
         }
+
+        for (edge_t e : out_edges(u, g)) {
+          BOOST_CHECK(source(e, g) == u);
+          BOOST_CHECK(container_contains(adj, target(e, g)) == true);
+        }
       }
     }
 
@@ -118,6 +123,11 @@ namespace boost {
           BOOST_CHECK(target(e, g) == v);
           BOOST_CHECK(container_contains(inv_adj, source(e, g)) == true);
         }
+
+        for (edge_t e : in_edges(v, g)) {
+          BOOST_CHECK(target(e, g) == v);
+          BOOST_CHECK(container_contains(inv_adj, source(e, g)));
+        }
       }
     }
 
@@ -144,6 +154,9 @@ namespace boost {
           vertex_t v = *p.first;
           BOOST_CHECK(container_contains(adj, v) == true);
         }
+
+        for (vertex_t v : adjacent_vertices(u, g))
+          BOOST_CHECK(container_contains(adj, v));
       }
     }      
 
@@ -159,6 +172,9 @@ namespace boost {
         vertex_t v = *p.first;
         BOOST_CHECK(container_contains(vertex_set, v) == true);
       }
+
+      for (vertex_t v : vertices(g))
+        BOOST_CHECK(container_contains(vertex_set, v));
     }
 
     void test_edge_list_graph
@@ -176,6 +192,12 @@ namespace boost {
         BOOST_CHECK(find_if(edge_set, connects(source(e, g), target(e, g), g)) != boost::end(edge_set));
         BOOST_CHECK(container_contains(vertex_set, source(e, g)) == true);
         BOOST_CHECK(container_contains(vertex_set, target(e, g)) == true);
+      }
+
+      for (edge_t e : edges(g)) {
+        BOOST_CHECK(find_if(edge_set, connects(source(e, g), target(e, g), g)) != boost::end(edge_set));
+        BOOST_CHECK(container_contains(vertex_set, source(e, g)));
+        BOOST_CHECK(container_contains(vertex_set, target(e, g)));
       }
     }
 

--- a/test/test_iteration.hpp
+++ b/test/test_iteration.hpp
@@ -28,6 +28,8 @@ void test_vertex_list_graph(Graph const& g) {
     BOOST_ASSERT(num_vertices(g) == N);
     BOOST_ASSERT(rng.first != rng.second);
     BOOST_ASSERT(std::distance(rng.first, rng.second) == int(N));
+    BOOST_ASSERT(vertices(g).begin() != vertices(g).end());
+    BOOST_ASSERT(std::distance(vertices(g).begin(), vertices(g).end()) == int(N));
 }
 //@}
 
@@ -49,6 +51,8 @@ void test_edge_list_graph(Graph const& g) {
     BOOST_ASSERT(num_edges(g) == M);
     BOOST_ASSERT(rng.first != rng.second);
     BOOST_ASSERT(std::distance(rng.first, rng.second) == int(M));
+    BOOST_ASSERT(edges(g).begin() != edges(g).end());
+    BOOST_ASSERT(std::distance(edges(g).begin(), edges(g).end()) == int(M));
 }
 //@}
 


### PR DESCRIPTION
I have changed the `vertices()`, `edges()`, `adjacent_vertices()`, `in_edges()`, `out_edges()` functions such that they return an object which inherits `std::pair<Iterator, Iterator>`, and additionally models a container. This allows the use of range-based for loops with the results of those functions, and keeps compatibility with the existing code.