### PR TITLE
Fix typo in the documentation

### DIFF
--- a/doc/fruchterman_reingold.html
+++ b/doc/fruchterman_reingold.html
@@ -130,7 +130,7 @@ computes the attractive force as <code>dist<sup>2</sup>/k</code>.<br>
 IN: <tt>repulsive_force(RepulsiveForce fr)</tt>
 <blockquote>
 Computes the magnitude of the repulsive force between any two
-vertices. The function object <tt>fa</tt> must accept five
+vertices. The function object <tt>fr</tt> must accept five
 parameters: the two vertex descriptors, <tt>k</tt>, the distance between the
 vertices, and the graph. <tt>k</tt> is the square root of the ratio
 of the display area to the number of vertices. <br>


### PR DESCRIPTION
Hello.

In this PR I just fix one very small typo - in this section should be used 'fr' instead of 'fa' (I guess it's simply copy-paste error from previous section).