### PR TITLE
Fixed bug 10231 partly: If finish_edge was called, then now correctly.

### DIFF
--- a/include/boost/graph/depth_first_search.hpp
+++ b/include/boost/graph/depth_first_search.hpp
@@ -137,6 +137,11 @@ namespace boost {
         src_e = back.second.first;
         boost::tie(ei, ei_end) = back.second.second;
         stack.pop_back();
+	// finish_edge has to be called here, not after the
+	// loop. Think of the pop as the return from a recursive call.
+        if (src_e) {
+	  call_finish_edge(vis, src_e.get(), g);
+	}
         while (ei != ei_end) {
           Vertex v = target(*ei, g);
           vis.examine_edge(*ei, g);
@@ -164,7 +169,6 @@ namespace boost {
         }
         put(color, u, Color::black());
         vis.finish_vertex(u, g);
-        if (src_e) call_finish_edge(vis, src_e.get(), g);
       }
     }
 


### PR DESCRIPTION
The bug that it never gets called with the current construction remains.

I was looking through other forks and came across this.  I think it is worth a look.