### PR TITLE
Add missing check for 'degree' in BidirectionalGraphConcept. Fix the …

### DIFF
--- a/doc/BidirectionalGraph.html
+++ b/doc/BidirectionalGraph.html
@@ -149,16 +149,21 @@ undirected graphs).
       BOOST_CONCEPT_ASSERT(( MultiPassInputIteratorConcept&lt;in_edge_iterator&gt; ));
 
       p = in_edges(v, g);
+      n = in_degree(v, g);
+      n = degree(v, g);
       e = *p.first;
       const_constraints(g);
     }
     void const_constraints(const G&amp; g) {
       p = in_edges(v, g);
+      n = in_degree(v, g);
+      n = degree(v, g);
       e = *p.first;
     }
     std::pair&lt;in_edge_iterator, in_edge_iterator&gt; p;
     typename boost::graph_traits&lt;G&gt;::vertex_descriptor v;
     typename boost::graph_traits&lt;G&gt;::edge_descriptor e;
+    typename boost::graph_traits&lt;G&gt;::degree_size_type n;
     G g;
   };
 </PRE>

--- a/include/boost/graph/filtered_graph.hpp
+++ b/include/boost/graph/filtered_graph.hpp
@@ -410,6 +410,26 @@ namespace boost {
   }
 
   template <typename G, typename EP, typename VP>
+  typename enable_if<typename is_directed_graph<G>::type,
+    typename filtered_graph<G, EP, VP>::degree_size_type
+  >::type
+  degree(typename filtered_graph<G, EP, VP>::vertex_descriptor u,
+          const filtered_graph<G, EP, VP>& g)
+  {
+    return out_degree(u, g) + in_degree(u, g);
+  }
+
+  template <typename G, typename EP, typename VP>
+  typename disable_if<typename is_directed_graph<G>::type,
+    typename filtered_graph<G, EP, VP>::degree_size_type
+  >::type
+  degree(typename filtered_graph<G, EP, VP>::vertex_descriptor u,
+          const filtered_graph<G, EP, VP>& g)
+  {
+    return out_degree(u, g);
+  }
+
+  template <typename G, typename EP, typename VP>
   std::pair<typename filtered_graph<G, EP, VP>::edge_descriptor, bool>
   edge(typename filtered_graph<G, EP, VP>::vertex_descriptor u,
        typename filtered_graph<G, EP, VP>::vertex_descriptor v,

--- a/include/boost/graph/graph_concepts.hpp
+++ b/include/boost/graph/graph_concepts.hpp
@@ -128,12 +128,14 @@ typename T::ThereReallyIsNoMemberByThisNameInT vertices(T const&);
 
         p = in_edges(v, g);
         n = in_degree(v, g);
+        n = degree(v, g);
         e = *p.first;
         const_constraints(g);
         }
         void const_constraints(const G& cg) {
         p = in_edges(v, cg);
         n = in_degree(v, cg);
+        n = degree(v, cg);
         e = *p.first;
         }
         std::pair<in_edge_iterator, in_edge_iterator> p;

--- a/test/filtered_graph_cc.cpp
+++ b/test/filtered_graph_cc.cpp
@@ -38,5 +38,13 @@ int main(int,char*[])
     typedef filtered_graph<Graph, is_residual_edge<ResCapMap> > ResGraph;
     BOOST_CONCEPT_ASSERT(( BidirectionalGraphConcept<ResGraph> ));
   }
+  // Check filtered_graph with undirected adjacency_list
+  {
+    typedef adjacency_list<vecS, vecS, undirectedS, 
+      no_property, property<edge_residual_capacity_t, long> > Graph;
+    typedef property_map<Graph, edge_residual_capacity_t>::type ResCapMap;
+    typedef filtered_graph<Graph, is_residual_edge<ResCapMap> > ResGraph;
+    BOOST_CONCEPT_ASSERT(( BidirectionalGraphConcept<ResGraph> ));
+  }
   return 0;
 }


### PR DESCRIPTION
…concept checking class in the documentation for BidirectionalGraphConcept. Implementation of missing 'degree' function for filtered_graph.

I'm going through other forks and came across this.