### PR TITLE
couldn't infer unused template argument

### DIFF
--- a/include/boost/graph/copy.hpp
+++ b/include/boost/graph/copy.hpp
@@ -395,7 +395,7 @@ namespace boost {
                          CopyVertex cv, CopyEdge ce)
         : g_out(graph), orig2copy(c), copy_vertex(cv), copy_edge(ce) { }
 
-      template <class Vertex, class Graph>
+      template <class Vertex>
       typename graph_traits<NewGraph>::vertex_descriptor copy_one_vertex(Vertex u) const {
         typename graph_traits<NewGraph>::vertex_descriptor
           new_u = add_vertex(g_out);


### PR DESCRIPTION
Couldn't compile code calling boost::copy_component because got compiler error from clang7:

> /usr/include/boost/graph/copy.hpp:399:58: note: candidate template ignored: couldn't infer template argument 'Graph'
>       typename graph_traits<NewGraph>::vertex_descriptor copy_one_vertex(Vertex u) const {
> 

I noticed that the 'Graph' template argument is un-referenced within graph_copy_visitor::copy_one_vertex, so I removed it. Afterwards, example compiles and runs.