### PR TITLE
 Fix regressions & update .yml scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -274,6 +274,8 @@ install:
   - cd ..
   - git clone -b $BOOST_BRANCH --depth 1 https://github.com/boostorg/boost.git boost-root
   - cd boost-root
+  - git submodule update --init tools/boost_install
+  - git submodule update --init libs/headers
   - git submodule update --init tools/build
   - git submodule update --init libs/config
   - git submodule update --init tools/boostdep

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,6 +44,8 @@ install:
   - cd ..
   - git clone -b %APPVEYOR_REPO_BRANCH% --depth 1 https://github.com/boostorg/boost.git boost-root
   - cd boost-root
+  - git submodule update --init tools/boost_install
+  - git submodule update --init libs/headers
   - git submodule update --init tools/build
   - git submodule update --init libs/config
   - xcopy /s /e /q %APPVEYOR_BUILD_FOLDER% libs\graph

--- a/include/boost/graph/isomorphism.hpp
+++ b/include/boost/graph/isomorphism.hpp
@@ -501,6 +501,7 @@ fi_adj_loop_k:++fi_adj.first;
       template <typename Graph1, typename Graph2>
       struct isomorphism_impl {
         typedef bool result_type;
+        typedef result_type type;
         template <typename ArgPack>
         bool operator()(const Graph1& g1, const Graph2& g2, const ArgPack& arg_pack) const {
           using namespace boost::graph::keywords;

--- a/include/boost/graph/named_function_params.hpp
+++ b/include/boost/graph/named_function_params.hpp
@@ -515,17 +515,26 @@ BOOST_BGL_DECLARE_NAMED_PARAMS
   BOOST_GRAPH_MAKE_FORWARDING_FUNCTION_ONEX(z, nnamed, BOOST_PP_SEQ_ELEM(0, seq), BOOST_PP_SEQ_ELEM(1, seq))
 
 #define BOOST_GRAPH_MAKE_FORWARDING_FUNCTION_ONEX(z, nnamed, name, nfixed) \
-  template <BOOST_PP_ENUM_PARAMS(nfixed, typename Param) BOOST_PP_ENUM_TRAILING_PARAMS(nnamed, typename Keyword) BOOST_PP_ENUM_TRAILING_PARAMS(nnamed, typename Arg)> \
-  typename boost::result_of< \
-             detail::BOOST_PP_CAT(name, _impl)<BOOST_PP_ENUM_PARAMS(nfixed, Param)> \
-               (BOOST_PP_ENUM_PARAMS(nfixed, Param) BOOST_PP_COMMA_IF(nfixed) \
-                const typename boost::detail::make_arg_pack_type<void(BOOST_PP_ENUM_PARAMS(nnamed, Keyword) BOOST_PP_COMMA_IF(nnamed) BOOST_PP_ENUM_PARAMS(nnamed, Arg))>::type&) \
-           >::type \
-  name(BOOST_PP_ENUM_BINARY_PARAMS(nfixed, const Param, & param) \
-       BOOST_PP_ENUM_TRAILING(nnamed, BOOST_GRAPH_MAKE_PAIR_PARAM, ~)) { \
-    return detail::BOOST_PP_CAT(name, _impl)<BOOST_PP_ENUM_PARAMS(nfixed, Param)>() \
-             (BOOST_PP_ENUM_PARAMS(nfixed, param), \
-              (boost::parameter::aux::empty_arg_list() BOOST_PP_ENUM_TRAILING_PARAMS(nnamed, kw))); \
+  template < \
+    BOOST_PP_ENUM_PARAMS_Z(z, nfixed, typename Param) \
+    BOOST_PP_ENUM_TRAILING_PARAMS_Z(z, nnamed, typename ArgumentPack) \
+  > \
+  typename \
+  BOOST_PP_EXPR_IF(nnamed, boost::lazy_enable_if<boost::parameter::is_argument_pack<ArgumentPack0>) \
+  BOOST_PP_COMMA_IF(nnamed) \
+    ::boost::graph::detail::BOOST_PP_CAT(name, _impl)<BOOST_PP_ENUM_PARAMS_Z(z, nfixed, Param)> \
+  BOOST_PP_EXPR_IF(nnamed, >)::type \
+  name( \
+    BOOST_PP_ENUM_BINARY_PARAMS_Z(z, nfixed, Param, const& param) \
+    BOOST_PP_ENUM_TRAILING_BINARY_PARAMS_Z(z, nnamed, ArgumentPack, const& tagged_arg) \
+  ) \
+  { \
+    return ::boost::graph::BOOST_PP_CAT(name, _with_named_params)( \
+      BOOST_PP_ENUM_PARAMS_Z(z, nfixed, param) \
+      BOOST_PP_COMMA_IF(nnamed) BOOST_PP_LPAREN_IF(nnamed) \
+      BOOST_PP_ENUM_PARAMS_Z(z, nnamed, tagged_arg) \
+      BOOST_PP_RPAREN_IF(nnamed) \
+    ); \
   }
 
 #define BOOST_GRAPH_MAKE_OLD_STYLE_PARAMETER_FUNCTION(name, nfixed) \
@@ -539,16 +548,6 @@ BOOST_BGL_DECLARE_NAMED_PARAMS
     typedef boost::bgl_named_params<P, T, R> old_style_params_type; \
     BOOST_GRAPH_DECLARE_CONVERTED_PARAMETERS(old_style_params_type, old_style_params) \
     return ::boost::graph::BOOST_PP_CAT(name, _with_named_params)(BOOST_PP_ENUM_PARAMS(nfixed, param) BOOST_PP_COMMA_IF(nfixed) arg_pack); \
-  } \
-  namespace graph { \
-  template <BOOST_PP_ENUM_PARAMS(nfixed, typename Param) BOOST_PP_COMMA_IF(nfixed) typename ArgumentPack> \
-  typename boost::lazy_enable_if<boost::parameter::is_argument_pack<ArgumentPack>, boost::result_of< \
-    ::boost::graph::detail::BOOST_PP_CAT(name, _impl) BOOST_PP_EXPR_IF(nfixed, <) BOOST_PP_ENUM_PARAMS(nfixed, Param) BOOST_PP_EXPR_IF(nfixed, >) \
-      (BOOST_PP_ENUM_PARAMS(nfixed, Param) BOOST_PP_COMMA_IF(nfixed) const ArgumentPack&) \
-  > >::type \
-  name(BOOST_PP_ENUM_BINARY_PARAMS(nfixed, const Param, & param) BOOST_PP_COMMA_IF(nfixed) const ArgumentPack& tagged_arg) { \
-    return ::boost::graph::BOOST_PP_CAT(name, _with_named_params)(BOOST_PP_ENUM_PARAMS(nfixed, param) BOOST_PP_COMMA_IF(nfixed) tagged_arg); \
-  } \
   } \
   BOOST_PP_EXPR_IF(nfixed, template <) BOOST_PP_ENUM_PARAMS(nfixed, typename Param) BOOST_PP_EXPR_IF(nfixed, >) \
   BOOST_PP_EXPR_IF(nfixed, typename) boost::result_of< \

--- a/test/isomorphism.cpp
+++ b/test/isomorphism.cpp
@@ -133,7 +133,8 @@ void test_isomorphism2()
   bool isomorphism_correct;
   clock_t start = clock();
   BOOST_CHECK(isomorphism_correct = boost::graph::isomorphism
-               (g1, g2, _isomorphism_map = make_assoc_property_map(mapping)));
+               (g1, g2, _vertex_index1_map = get(vertex_index, g1),
+                _isomorphism_map = make_assoc_property_map(mapping)));
   clock_t end = clock();
 
   std::cout << "Elapsed time (clock cycles): " << (end - start) << std::endl;


### PR DESCRIPTION
<boost/graph/named_function_params.hpp>
* Original fix worked only when one boost::parameter::keyword was bound and passed in.  This fix now works when binding and passing in one or more boost::parameter::keyword objects.

<boost/graph/isomorphism.hpp>
* Make isomorphism_impl a metafunction that returns the function object result_type for the fix to work.

"test/isomorphism.cpp"
* Test the fix with two boost::parameter::keyword objects.

".travis.yml"
"appveyor.yml"
* Update as per Peter Dimov's message announcing the merging of CMake into boostorg/develop.