### PR TITLE
Fix bucket_sorter example. Bug #151

### DIFF
--- a/example/Jamfile.v2
+++ b/example/Jamfile.v2
@@ -26,7 +26,7 @@ exe boost_web_graph : boost_web_graph.cpp ;
 exe boykov_kolmogorov-eg : boykov_kolmogorov-eg.cpp ;
 exe bron_kerbosch_clique_number : bron_kerbosch_clique_number.cpp ;
 exe bron_kerbosch_print_cliques : bron_kerbosch_print_cliques.cpp ;
-#exe bucket_sorter : bucket_sorter.cpp ;
+exe bucket_sorter : bucket_sorter.cpp ;
 exe canonical_ordering : canonical_ordering.cpp ;
 # exe cc-internet : cc-internet.cpp ../build//boost_graph ;
 exe city_visitor : city_visitor.cpp ;

--- a/example/bucket_sorter.cpp
+++ b/example/bucket_sorter.cpp
@@ -13,38 +13,27 @@
 #include <stdlib.h>
 #include <boost/pending/bucket_sorter.hpp>
 
-template <class Integral>
-struct trivial_id {
-  std::size_t operator[](Integral i) {
-    return i;
-  }
-  std::size_t operator[](Integral i) const {
-    return i;
-  }
-};
-
-
 int main() {
   using namespace std;
   using boost::bucket_sorter;
-  
+
   const std::size_t N = 10;
 
   vector<std::size_t> bucket(N);
   for (std::size_t i=0; i<N; i++) {
     bucket[i] = rand() % N;
     cout.width(6);
-    cout << "Number " << i << " has its bucket "  << bucket[i] << endl;
+    cout << "Number " << i << " is in bucket "  << bucket[i] << endl;
   }
 
-  typedef trivial_id<int> ID;
-  typedef bucket_sorter<std::size_t, int, 
+  typedef boost::identity_property_map ID;
+  typedef bucket_sorter<std::size_t, int,
     vector<std::size_t>::iterator, ID> BS;
   BS my_bucket_sorter(N, N, bucket.begin());
 
   for (std::size_t ii=0; ii<N; ii++)
     my_bucket_sorter.push(ii);
-    
+
   std::size_t j;
   for (j=0; j<N; j++) {
     cout << "The bucket " << j;
@@ -57,7 +46,7 @@ int main() {
       } while ( ! my_bucket_sorter[j].empty() );
       cout << endl;
     } else {
-      cout << " has no number associated with." << endl;
+      cout << " has no number associated with it." << endl;
     }
   }
 
@@ -67,7 +56,7 @@ int main() {
   my_bucket_sorter.remove(5);
   my_bucket_sorter.remove(7);
 
-  cout << "Afer remove number 5 and 7, check correctness again." << endl;
+  cout << "After removing numbers 5 and 7, check correctness again." << endl;
 
   for (j=0; j<N; j++) {
     cout << "The bucket " << j;
@@ -80,7 +69,7 @@ int main() {
       } while ( ! my_bucket_sorter[j].empty() );
       cout << endl;
     } else {
-      cout << " has no number associated with." << endl;
+      cout << " has no number associated with it." << endl;
     }
   }
 

--- a/include/boost/pending/bucket_sorter.hpp
+++ b/include/boost/pending/bucket_sorter.hpp
@@ -19,34 +19,37 @@
 #include <vector>
 #include <cassert>
 #include <boost/limits.hpp>
+#include <boost/concept/assert.hpp>
+#include <boost/property_map/property_map.hpp>
 
 namespace boost {
 
-  template <class BucketType, class ValueType, class Bucket, 
+  template <class BucketType, class ValueType, class Bucket,
             class ValueIndexMap>
   class bucket_sorter {
+    BOOST_CONCEPT_ASSERT(( ReadablePropertyMapConcept<ValueIndexMap, ValueType> ));
   public:
     typedef BucketType bucket_type;
     typedef ValueType value_type;
     typedef typename std::vector<value_type>::size_type size_type;
-    
-    bucket_sorter(size_type _length, bucket_type _max_bucket, 
-                  const Bucket& _bucket = Bucket(), 
-                  const ValueIndexMap& _id = ValueIndexMap()) 
+
+    bucket_sorter(size_type _length, bucket_type _max_bucket,
+                  const Bucket& _bucket = Bucket(),
+                  const ValueIndexMap& _id = ValueIndexMap())
       : head(_max_bucket, invalid_value()),
-        next(_length, invalid_value()), 
+        next(_length, invalid_value()),
         prev(_length, invalid_value()),
         id_to_value(_length),
         bucket(_bucket), id(_id) { }
-    
+
     void remove(const value_type& x) {
       const size_type i = get(id, x);
       const size_type& next_node = next[i];
       const size_type& prev_node = prev[i];
-    
-      //check if i is the end of the bucket list 
+
+      //check if i is the end of the bucket list
       if ( next_node != invalid_value() )
-        prev[next_node] = prev_node; 
+        prev[next_node] = prev_node;
       //check if i is the begin of the bucket list
       if ( prev_node != invalid_value() )
         next[prev_node] = next_node;
@@ -58,21 +61,21 @@ namespace boost {
       id_to_value[get(id, x)] = x;
       (*this)[bucket[x]].push(x);
     }
-    
+
     void update(const value_type& x) {
       remove(x);
       (*this)[bucket[x]].push(x);
     }
-    //  private: 
+    //  private:
     //    with KCC, the nested stack class is having access problems
     //    despite the friend decl.
     static size_type invalid_value() {
       return (std::numeric_limits<size_type>::max)();
     }
-    
+
     typedef typename std::vector<size_type>::iterator Iter;
     typedef typename std::vector<value_type>::iterator IndexValueMap;
-    
+
   public:
     friend class stack;
 
@@ -86,7 +89,7 @@ namespace boost {
       // constructor of the ValueIndexMap is not required if not used.
       stack(bucket_type _bucket_id, Iter h, Iter n, Iter p, IndexValueMap v)
         : bucket_id(_bucket_id), head(h), next(n), prev(p), value(v) {}
-      
+
       void push(const value_type& x) {
         const size_type new_head = get(id, x);
         const size_type current = head[bucket_id];
@@ -114,7 +117,7 @@ namespace boost {
       IndexValueMap value;
       ValueIndexMap id;
     };
-    
+
     stack operator[](const bucket_type& i) {
       assert(i < head.size());
       return stack(i, head.begin(), next.begin(), prev.begin(),
@@ -128,7 +131,7 @@ namespace boost {
     Bucket bucket;
     ValueIndexMap id;
   };
-  
+
 }
 
 #endif


### PR DESCRIPTION
Changed ID to identity_property_map.
Added concept check to bucket_sorter.hpp.
Fixed minor grammar nits.

This is just a fix to #151.  We cannot abandon the bucket_sorter, as it is used by `minimum_degree_ordering.hpp` and  `smallest_last_ordering.hpp`.  I do not think that these changes break either of these, but neither are tested, and only minimum_degree_ordering has an example.  The minimum_degree_ordering example seems to work with some Harwell Boeing files I dredged off the web, but I have little idea whether the results are correct.

Possibly more importantly, BucketSorter is used in the graph coloring example from the book.

This change does show that the ValueType template parameter is redundant, but it is probably not worth removing it.