### PR TITLE
Dijkstra uses std::plus

### DIFF
--- a/doc/dijkstra_shortest_paths.html
+++ b/doc/dijkstra_shortest_paths.html
@@ -320,7 +320,7 @@ IN: <tt>distance_combine(CombineFunction cmb)</tt>
   <tt>WeightMap</tt> property map.  The result type must be the same
   type as the distance value type.<br>
 
-  <b>Default:</b> <tt>closed_plus&lt;D&gt;</tt> with
+  <b>Default:</b> <tt>std::plus&lt;D&gt;</tt> with
    <tt>D=typename property_traits&lt;DistanceMap&gt;::value_type</tt><br>
 
   <b>Python</b>: Unsupported parameter.

--- a/include/boost/graph/dijkstra_shortest_paths.hpp
+++ b/include/boost/graph/dijkstra_shortest_paths.hpp
@@ -124,7 +124,7 @@ namespace boost {
 
       template <class Edge, class Graph>
       void tree_edge(Edge e, Graph& g) {
-        bool decreased = relax(e, g, m_weight, m_predecessor, m_distance,
+        bool decreased = relax_target(e, g, m_weight, m_predecessor, m_distance,
                                m_combine, m_compare);
         if (decreased)
           m_vis.edge_relaxed(e, g);
@@ -135,7 +135,7 @@ namespace boost {
       void gray_target(Edge e, Graph& g) {
         D old_distance = get(m_distance, target(e, g));
 
-        bool decreased = relax(e, g, m_weight, m_predecessor, m_distance,
+        bool decreased = relax_target(e, g, m_weight, m_predecessor, m_distance,
                                m_combine, m_compare);
         if (decreased) {
           dijkstra_queue_update(m_Q, target(e, g), old_distance);
@@ -540,7 +540,7 @@ namespace boost {
          choose_param(get_param(params, distance_compare_t()),
                       std::less<D>()),
          choose_param(get_param(params, distance_combine_t()),
-                      closed_plus<D>(inf)),
+                      std::plus<D>()),
          inf,
          choose_param(get_param(params, distance_zero_t()),
                       D()),

--- a/include/boost/graph/dijkstra_shortest_paths_no_color_map.hpp
+++ b/include/boost/graph/dijkstra_shortest_paths_no_color_map.hpp
@@ -97,7 +97,7 @@ namespace boost {
           !distance_compare(neighbor_vertex_distance, distance_infinity);
 
         // Attempt to relax the edge
-        bool was_edge_relaxed = relax(current_edge, graph, weight_map,
+        bool was_edge_relaxed = relax_target(current_edge, graph, weight_map,
           predecessor_map, distance_map,
           distance_weight_combine, distance_compare);
 
@@ -186,7 +186,7 @@ namespace boost {
          choose_param(get_param(params, distance_compare_t()),
                       std::less<DistanceType>()),
          choose_param(get_param(params, distance_combine_t()),
-                      closed_plus<DistanceType>(inf)),
+                      std::plus<DistanceType>()),
          inf,
          choose_param(get_param(params, distance_zero_t()),
                       DistanceType()),

--- a/include/boost/graph/relax.hpp
+++ b/include/boost/graph/relax.hpp
@@ -76,6 +76,37 @@ namespace boost {
       } else
         return false;
     }
+
+    template <class Graph, class WeightMap,
+            class PredecessorMap, class DistanceMap,
+            class BinaryFunction, class BinaryPredicate>
+    bool relax_target(typename graph_traits<Graph>::edge_descriptor e,
+                      const Graph& g, const WeightMap& w,
+                      PredecessorMap& p, DistanceMap& d,
+                      const BinaryFunction& combine, const BinaryPredicate& compare)
+    {
+      typedef typename graph_traits<Graph>::vertex_descriptor Vertex;
+      typedef typename property_traits<DistanceMap>::value_type D;
+      typedef typename property_traits<WeightMap>::value_type W;
+      const Vertex u = source(e, g);
+      const Vertex v = target(e, g);
+      const D d_u = get(d, u);
+      const D d_v = get(d, v);
+      const W& w_e = get(w, e);
+
+      // The seemingly redundant comparisons after the distance puts are to
+      // ensure that extra floating-point precision in x87 registers does not
+      // lead to relax() returning true when the distance did not actually
+      // change.
+      if (compare(combine(d_u, w_e), d_v)) {
+        put(d, v, combine(d_u, w_e));
+        if (compare(get(d, v), d_v)) {
+          put(p, v, u);
+          return true;
+        }
+      }
+      return false;
+    }
     
     template <class Graph, class WeightMap, 
       class PredecessorMap, class DistanceMap>


### PR DESCRIPTION
This commit changes the relax function that dijkstra shortest paths uses to only update the distance and predecessor map of the target vertex of each edge. This has the benefit that from now on we can use std::plus as the default combine function.

This supersedes  #48, see the discussion there