### PR TITLE
Fix for a number of broken links.

### DIFF
--- a/doc/AStarHeuristic.html
+++ b/doc/AStarHeuristic.html
@@ -129,7 +129,7 @@ Called for the target of every out edge of a vertex being examined.
 <TABLE>
 <TR valign=top>
 <TD nowrap>Copyright &copy; 2004</TD><TD>
-<A HREF="http://www.cs.rpi.edu/~beevek/">Kristopher Beevers</A>,
+<A HREF="http://cs.krisbeevers.com/">Kristopher Beevers</A>,
 Rensselaer Polytechnic Institute (<A
 HREF="mailto:beevek@cs.rpi.edu">beevek@cs.rpi.edu</A>)
 </TD></TR></TABLE>

--- a/doc/AStarVisitor.html
+++ b/doc/AStarVisitor.html
@@ -204,7 +204,7 @@ happens after all of its out-edges have been examined.
 <TABLE>
 <TR valign=top>
 <TD nowrap>Copyright &copy; 2004</TD><TD>
-<A HREF="http://www.cs.rpi.edu/~beevek/">Kristopher Beevers</A>,
+<A HREF="http://cs.krisbeevers.com/">Kristopher Beevers</A>,
 Rensselaer Polytechnic Institute (<A
 HREF="mailto:beevek@cs.rpi.edu">beevek@cs.rpi.edu</A>)
 </TD></TR></TABLE>

--- a/doc/BFSVisitor.html
+++ b/doc/BFSVisitor.html
@@ -211,7 +211,7 @@ class count_tree_edges_bfs_visitor(bgl.Graph.BFSVisitor):
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/BellmanFordVisitor.html
+++ b/doc/BellmanFordVisitor.html
@@ -175,7 +175,7 @@ class count_tree_edges_bellman_ford_visitor(bgl.Graph.BellmanFordVisitor):
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/ColorValue.html
+++ b/doc/ColorValue.html
@@ -99,7 +99,7 @@ href="http://www.boost.org/sgi/stl/DefaultConstructible.html">DefaultConstructib
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/DFSVisitor.html
+++ b/doc/DFSVisitor.html
@@ -212,7 +212,7 @@ class count_tree_edges_dfs_visitor(bgl.Graph.DFSVisitor):
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/DijkstraVisitor.html
+++ b/doc/DijkstraVisitor.html
@@ -213,7 +213,7 @@ class count_tree_edges_dijkstra_visitor(bgl.Graph.DijkstraVisitor):
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/EventVisitor.html
+++ b/doc/EventVisitor.html
@@ -152,7 +152,7 @@ either a vertex or edge descriptor of the graph.
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/EventVisitorList.html
+++ b/doc/EventVisitorList.html
@@ -118,7 +118,7 @@ std::make_pair(<i>visitor1</i>,
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/IncidenceGraph.html
+++ b/doc/IncidenceGraph.html
@@ -193,7 +193,7 @@ Therefore, the extra requirement is added that the out-edge connecting
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/IteratorConstructibleGraph.html
+++ b/doc/IteratorConstructibleGraph.html
@@ -152,7 +152,7 @@ constructor lacking the graph size information.
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/Monoid.html
+++ b/doc/Monoid.html
@@ -113,7 +113,7 @@ Return type: <TT>bool</TT>
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/acknowledgements.html
+++ b/doc/acknowledgements.html
@@ -67,7 +67,7 @@ Science of the U.S. Department of Energy.
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/adjacency_list.html
+++ b/doc/adjacency_list.html
@@ -1127,7 +1127,7 @@ Include <a href="../../../boost/graph/adj_list_serialize.hpp"><tt>boost/graph/ad
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/adjacency_list_traits.html
+++ b/doc/adjacency_list_traits.html
@@ -149,7 +149,7 @@ parallel edges (<tt>disallow_parallel_edge_tag</tt>).
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/astar_heuristic.html
+++ b/doc/astar_heuristic.html
@@ -87,7 +87,7 @@ to a goal.
 <TABLE>
 <TR valign=top>
 <TD nowrap>Copyright &copy; 2004</TD><TD>
-<A HREF="http://www.cs.rpi.edu/~beevek/">Kristopher Beevers</A>,
+<A HREF="http://cs.krisbeevers.com/">Kristopher Beevers</A>,
 Rensselaer Polytechnic Institute (<A
 HREF="mailto:beevek@cs.rpi.edu">beevek@cs.rpi.edu</A>)
 </TD></TR></TABLE>

--- a/doc/astar_search.html
+++ b/doc/astar_search.html
@@ -580,7 +580,7 @@ this state by pointer or reference.
 <TABLE>
 <TR valign=top>
 <TD nowrap>Copyright &copy; 2004</TD><TD>
-<A HREF="http://www.cs.rpi.edu/~beevek/">Kristopher Beevers</A>,
+<A HREF="http://cs.krisbeevers.com/">Kristopher Beevers</A>,
 Rensselaer Polytechnic Institute (<A
 HREF="mailto:beevek@cs.rpi.edu">beevek@cs.rpi.edu</A>)
 </TD></TR></TABLE>

--- a/doc/astar_visitor.html
+++ b/doc/astar_visitor.html
@@ -99,7 +99,7 @@ and <a href="./property_writer.html"><tt>property_writer</tt></a>.
 <TABLE>
 <TR valign=top>
 <TD nowrap>Copyright &copy; 2004</TD><TD>
-<A HREF="http://www.cs.rpi.edu/~beevek/">Kristopher Beevers</A>,
+<A HREF="http://cs.krisbeevers.com/">Kristopher Beevers</A>,
 Rensselaer Polytechnic Institute (<A
 HREF="mailto:beevek@cs.rpi.edu">beevek@cs.rpi.edu</A>)
 </TD></TR></TABLE>

--- a/doc/bc_clustering.html
+++ b/doc/bc_clustering.html
@@ -142,7 +142,7 @@ IN: <tt>VertexIndexMap vertex_index</tt>
 <td nowrap>Copyright &copy; 2004</td>
 <td><a href="http://www.boost.org/people/doug_gregor.html">Douglas Gregor</a>,
 Indiana University (dgregor@cs.indiana.edu)<br>
-<a href="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</a>, Indiana
+<a href="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</a>, Indiana
 University (<a href=
 "mailto:lums@osl.iu.edu">lums@osl.iu.edu</a>)</td>
 </tr>

--- a/doc/bellman_visitor.html
+++ b/doc/bellman_visitor.html
@@ -102,7 +102,7 @@ and <a href="./property_writer.html"><tt>property_writer</tt></a>.
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/betweenness_centrality.html
+++ b/doc/betweenness_centrality.html
@@ -297,7 +297,7 @@ is <em>O(VE)</em>.
 <TR valign=top>
 <TD nowrap>Copyright &copy; 2004</TD><TD>
 <A HREF="http://www.boost.org/people/doug_gregor.html">Douglas Gregor</A>, Indiana University (dgregor@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/bfs_visitor.html
+++ b/doc/bfs_visitor.html
@@ -119,7 +119,7 @@ and <a href="./property_writer.html"><tt>property_writer</tt></a>.
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/bgl_named_params.html
+++ b/doc/bgl_named_params.html
@@ -87,7 +87,7 @@ like <tt>boost::weight_map</tt> that create an instance of
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/challenge.html
+++ b/doc/challenge.html
@@ -61,12 +61,12 @@ polygons.</li>
 <li>Rewrite the Qhull algorithm using the Boost Graph Library (this is
 high difficulty challenge).  Or, for a more manageable challenge,
 write an interface for Qhull with the BGL.  <a
-href="http://www.geom.umn.edu/locate/qhull">Qhull</a> computes the
+href="http://www.qhull.org/">Qhull</a> computes the
 convex hull, Delaunay triangulation, Voronoi diagram, and halfspace
 intersection about a point.  Qhull runs in 2-d, 3-d, 4-d, and higher
 dimensions.  Qhull is used for collision detection, animation, plate
 tectonics, 3-d modeling, robot motion planning, and other <a
-href="http://www.geom.umn.edu/~bradb/qhull-news.html#use">applications</a>.
+href="http://www.qhull.org/news/qhull-news.html#users">applications</a>.
 It is currently difficult to use from a C++ program.
 
 </li>

--- a/doc/circle_layout.html
+++ b/doc/circle_layout.html
@@ -45,7 +45,7 @@ IN: <tt>Radius radius</tt>
 <TR valign=top>
 <TD nowrap>Copyright &copy; 2004</TD><TD>
 <A HREF="http://www.boost.org/people/doug_gregor.html">Douglas Gregor</A>, Indiana University (dgregor -at- cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (lums -at- osl.iu.edu)
 </TD></TR></TABLE>
                            </body></html>

--- a/doc/compressed_sparse_row.html
+++ b/doc/compressed_sparse_row.html
@@ -964,7 +964,7 @@ BGL_FORALL_EDGES(e, g, WebGraph)
 <TD nowrap>Copyright &copy; 2005</TD><TD>
 <A HREF="http://www.boost.org/people/doug_gregor.html">Doug Gregor</A>, Indiana University (<script language="Javascript">address("cs.indiana.edu", "dgregor")</script>)<br>
 Jeremiah Willcock, Indiana University (<script language="Javascript">address("osl.iu.edu", "jewillco")</script>)<br>
-  <A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+  <A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<script language="Javascript">address("osl.iu.edu", "lums")</script>)
 </TD></TR></TABLE>
   </body>

--- a/doc/constructing_algorithms.html
+++ b/doc/constructing_algorithms.html
@@ -174,7 +174,7 @@ namespace boost {
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/depth_first_search.html
+++ b/doc/depth_first_search.html
@@ -311,7 +311,7 @@ The example in <a href="../example/dfs-example.cpp">
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/dfs_visitor.html
+++ b/doc/dfs_visitor.html
@@ -102,7 +102,7 @@ and <a href="./property_writer.html"><tt>property_writer</tt></a>.
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/dijkstra_visitor.html
+++ b/doc/dijkstra_visitor.html
@@ -116,7 +116,7 @@ and <a href="./property_writer.html"><tt>property_writer</tt></a>.
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/directed_graph.html
+++ b/doc/directed_graph.html
@@ -87,7 +87,7 @@ A simple examples of creating a directed_graph is available here <a href="../../
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/distance_recorder.html
+++ b/doc/distance_recorder.html
@@ -167,7 +167,7 @@ and <a href="./property_writer.html"><tt>property_writer</tt></a>.
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/edge_list.html
+++ b/doc/edge_list.html
@@ -212,7 +212,7 @@ Returns the target vertex of edge <TT>e</TT>.
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/edge_predecessor_recorder.html
+++ b/doc/edge_predecessor_recorder.html
@@ -182,7 +182,7 @@ and <a href="./property_writer.html"><tt>property_writer</tt></a>.
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/erdos_renyi_generator.html
+++ b/doc/erdos_renyi_generator.html
@@ -144,7 +144,7 @@ int main()
 <TR valign=top>
 <TD nowrap>Copyright &copy; 2005</TD><TD>
 <A HREF="http://www.boost.org/people/doug_gregor.html">Doug Gregor</A>, Indiana University (<script language="Javascript">address("cs.indiana.edu", "dgregor")</script>)<br>
-  <A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+  <A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<script language="Javascript">address("osl.iu.edu", "lums")</script>)
 </TD></TR></TABLE>
 

--- a/doc/filtered_graph.html
+++ b/doc/filtered_graph.html
@@ -526,7 +526,7 @@ num_edges(g))</tt>) which is assumed in many of the algorithms.
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/graph_coloring.html
+++ b/doc/graph_coloring.html
@@ -182,7 +182,7 @@ namespace boost {
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/graph_theory_review.html
+++ b/doc/graph_theory_review.html
@@ -26,7 +26,7 @@ the reader has some previous acquaintance with graph algorithms, this
 chapter should be enough to get started.  If the reader has no
 previous background in graph algorithms we suggest a more thorough
 introduction such as <a
-href="http://toc.lcs.mit.edu/~clr/">Introduction to Algorithms</a>
+href="https://mitpress.mit.edu/algorithms">Introduction to Algorithms</a>
 by Cormen, Leiserson, and Rivest.
 
 <P>

--- a/doc/graph_traits.html
+++ b/doc/graph_traits.html
@@ -247,7 +247,7 @@ of vertices in the graph.
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/gursoy_atun_layout.html
+++ b/doc/gursoy_atun_layout.html
@@ -231,7 +231,7 @@ Equivalent to the non-named <tt>vertex_index_map</tt> parameter.<br>
 <TD nowrap>Copyright &copy; 2004 Trustees of Indiana University</TD><TD>
 Jeremiah Willcock, Indiana University (<script language="Javascript">address("osl.iu.edu", "jewillco")</script>)<br>
 <A HREF="http://www.boost.org/people/doug_gregor.html">Doug Gregor</A>, Indiana University (<script language="Javascript">address("cs.indiana.edu", "dgregor")</script>)<br>
-  <A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+  <A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<script language="Javascript">address("osl.iu.edu", "lums")</script>)
 </TD></TR></TABLE>
 

--- a/doc/hawick_circuits.html
+++ b/doc/hawick_circuits.html
@@ -25,7 +25,7 @@ self-loops and redundant circuits caused by parallel edges are enumerated too.
 edges are not desired.</p>
 
 <p>The algorithm is described in detail in
-<a href="http://complexity.massey.ac.nz/cstn/013/cstn-013.pdf">http://complexity.massey.ac.nz/cstn/013/cstn-013.pdf</a>.</p>
+<a href="https://www.researchgate.net/publication/221440635_Enumerating_Circuits_and_Loops_in_Graphs_with_Self-Arcs_and_Multiple-Arcs">https://www.researchgate.net/publication/221440635_Enumerating_Circuits_and_Loops_in_Graphs_with_Self-Arcs_and_Multiple-Arcs</a>.</p>
 
 <h3 id="where-defined">Where defined</h3>
 

--- a/doc/history.html
+++ b/doc/history.html
@@ -19,16 +19,16 @@
 
 The Boost Graph Library began its life as the Generic Graph Component
 Library (GGCL), a software project at the <a
-href="http://www.lsc.nd.edu">Lab for Scientific Computing (LSC)</a> at
+href="https://web.archive.org/web/20010516042117/http://www.lsc.nd.edu/">Lab for Scientific Computing (LSC)</a> at
 the University of Notre Dame, under the direction of Professor <a
-href="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</a>. The Lab's
+href="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</a>. The Lab's
 research directions include numerical linear algebra, parallel
 computing, and software engineering (including generic programming).
 
 <p>
 Soon after the Standard Template Library was released, work began at
 the LSC to apply generic programming to scientific computing.  The <a
-href="http://www.lsc.nd.edu/research/mtl">Matrix Template Library</a>
+href="https://en.wikipedia.org/wiki/Matrix_Template_Library">Matrix Template Library</a>
 (Jeremy Siek's masters thesis) was one of the first projects. Many of
 the lessons learned during construction of the MTL were applied to the
 design and implementation of the GGCL.
@@ -199,7 +199,7 @@ September 27, 2000.
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/howard_cycle_ratio.html
+++ b/doc/howard_cycle_ratio.html
@@ -97,7 +97,7 @@ The algorithm is due to Howard's iteration policy algorithm, descibed in
 <A HREF="./cochet-terrasson98numerical.pdf">[1]</A>.
 Ali Dasdan, Sandy S. Irani and Rajesh K.Gupta in their paper
 <A HREF="./dasdan-dac99.pdf">Efficient Algorithms for Optimum Cycle Mean and Optimum Cost to Time Ratio
-Problems</A>state that this is the most efficient algorithm to the time being (1999).</P>
+Problems</A> state that this is the most efficient algorithm to the time being (1999).</P>
 
 <p>
 For the convenience, functions <tt>maximum_cycle_mean()</tt> and <tt>minimum_cycle_mean()</tt>
@@ -224,7 +224,7 @@ generates a random graph and computes its maximum cycle ratio.
             <P>Copyright &copy; 2006-2009</P>
         </TD>
         <TD>
-            <P><A HREF="http://www.lsi.upc.edu/~dmitry">Dmitry
+            <P><A HREF="https://web.archive.org/web/20081122083634/http://www.lsi.upc.edu/~dmitry">Dmitry
             Bufistov</A>, Andrey Parfenov</P>
         </TD>
     </TR>

--- a/doc/incident.html
+++ b/doc/incident.html
@@ -70,7 +70,7 @@ is the target. This function is equivalent to the expression
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/incremental_components.html
+++ b/doc/incremental_components.html
@@ -411,7 +411,7 @@ Returns a pair of iterators for the component at <tt>index</tt> where <tt>index<
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/index.html
+++ b/doc/index.html
@@ -297,7 +297,7 @@ iterator and implements an <a href="./EdgeListGraph.html">Edge List Graph</a>.
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/isomorphism-impl-v2.w
+++ b/doc/isomorphism-impl-v2.w
@@ -25,7 +25,7 @@
 \fi
 
 \ifpdf
-  \newcommand{\stlconcept}[1]{\href{http://www.sgi.com/tech/stl/#1.html}{{\small \textsf{#1}}}}
+  \newcommand{\stlconcept}[1]{\href{https://boost.org/sgi/stl/#1.html}{{\small \textsf{#1}}}}
   \newcommand{\bglconcept}[1]{\href{http://www.boost.org/libs/graph/doc/#1.html}{{\small \textsf{#1}}}}
   \newcommand{\pmconcept}[1]{\href{http://www.boost.org/libs/property_map/#1.html}{{\small \textsf{#1}}}}
   \newcommand{\myhyperref}[2]{\hyperref[#1]{#2}}

--- a/doc/isomorphism-impl-v3.w
+++ b/doc/isomorphism-impl-v3.w
@@ -31,7 +31,7 @@
 \fi
 
 \ifpdf
-  \newcommand{\stlconcept}[1]{\href{http://www.sgi.com/tech/stl/#1.html}{{\small \textsf{#1}}}}
+  \newcommand{\stlconcept}[1]{\href{https://boost.org/sgi/stl/#1.html}{{\small \textsf{#1}}}}
   \newcommand{\bglconcept}[1]{\href{http://www.boost.org/libs/graph/doc/#1.html}{{\small \textsf{#1}}}}
   \newcommand{\pmconcept}[1]{\href{http://www.boost.org/libs/property_map/#1.html}{{\small \textsf{#1}}}}
   \newcommand{\myhyperref}[2]{\hyperref[#1]{#2}}

--- a/doc/isomorphism-impl.w
+++ b/doc/isomorphism-impl.w
@@ -25,7 +25,7 @@
 \fi
 
 \ifpdf
-  \newcommand{\stlconcept}[1]{\href{http://www.sgi.com/tech/stl/#1.html}{{\small \textsf{#1}}}}
+  \newcommand{\stlconcept}[1]{\href{https://boost.org/sgi/stl/#1.html}{{\small \textsf{#1}}}}
   \newcommand{\bglconcept}[1]{\href{http://www.boost.org/libs/graph/doc/#1.html}{{\small \textsf{#1}}}}
   \newcommand{\pmconcept}[1]{\href{http://www.boost.org/libs/property_map/#1.html}{{\small \textsf{#1}}}}
   \newcommand{\myhyperref}[2]{\hyperref[#1]{#2}}

--- a/doc/kamada_kawai_spring_layout.html
+++ b/doc/kamada_kawai_spring_layout.html
@@ -314,7 +314,7 @@ an <tt>std::vector</tt> of <tt>Topology::point_difference_type</tt>.<br>
 <td nowrap>Copyright &copy; 2004, 2010 Trustees of Indiana University</td>
 <td><a href="http://www.boost.org/people/doug_gregor.html">Douglas Gregor</a>,
 Indiana University (dgregor -at cs.indiana.edu)<br>
-<a href="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</a>, Indiana
+<a href="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</a>, Indiana
 University (<a href=
 "mailto:lums@osl.iu.edu">lums@osl.iu.edu</a>)</td>
 </tr>

--- a/doc/known_problems.html
+++ b/doc/known_problems.html
@@ -53,7 +53,7 @@ versions.
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/leda_conversion.html
+++ b/doc/leda_conversion.html
@@ -41,7 +41,7 @@ call this free function wrapper approach <I>external adaptation</I>.
 <P>
 One of the more commonly used graph classes is the LEDA parameterized
 <a
-href="http://www.mpi-sb.mpg.de/LEDA/MANUAL/bgraph.html"><TT>GRAPH</TT></a>
+href="https://algorithmic-solutions.info/leda_guide/graphs/param_graph.html"><TT>GRAPH</TT></a>
 class&nbsp;[<A HREF="bibliography.html#mehlhorn99:_leda">22</A>]. In
 this section we will show how to create a BGL interface for this
 class. The first question is which BGL interfaces (or concepts) we
@@ -254,7 +254,7 @@ href="../test/graph.cpp"><TT>test/graph.cpp</TT></a>.
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/null_visitor.html
+++ b/doc/null_visitor.html
@@ -85,7 +85,7 @@ This does nothing.
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/opposite.html
+++ b/doc/opposite.html
@@ -70,7 +70,7 @@ assert(u == opposite(e, v, g));
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/plod_generator.html
+++ b/doc/plod_generator.html
@@ -131,7 +131,7 @@ int main()
 <TR valign=top>
 <TD nowrap>Copyright &copy; 2005</TD><TD>
 <A HREF="http://www.boost.org/people/doug_gregor.html">Doug Gregor</A>, Indiana University (<script language="Javascript">address("cs.indiana.edu", "dgregor")</script>)<br>
-  <A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+  <A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<script language="Javascript">address("osl.iu.edu", "lums")</script>)
 </TD></TR></TABLE>
 

--- a/doc/predecessor_recorder.html
+++ b/doc/predecessor_recorder.html
@@ -177,7 +177,7 @@ and <a href="./property_writer.html"><tt>property_writer</tt></a>.
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/property_map.html
+++ b/doc/property_map.html
@@ -77,7 +77,7 @@ href="../../property_map/doc/property_map.html">property map</a>.
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/property_put.html
+++ b/doc/property_put.html
@@ -172,7 +172,7 @@ and <a href="./time_stamper.html"><tt>time_stamper</tt></a>.
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR>

--- a/doc/property_writer.html
+++ b/doc/property_writer.html
@@ -188,7 +188,7 @@ and <a href="./time_stamper.html"><tt>time_stamper</tt></a>.
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/publications.html
+++ b/doc/publications.html
@@ -21,7 +21,7 @@
 
 <li><a href="http://www.ddj.com/articles/2000/0009/0009toc.htm">Dr. Dobb's Sept. 2000 Article</a></a></li>
 <li><a href="http://www.acm.org/pubs/citations/proceedings/oops/320384/p399-siek/">OOPSLA'99 GGCL Paper</a></li>
-<li>Lie-Quan Lee's Master's Thesis about GGCL<a href="http://www.lsc.nd.edu/downloads/research/ggcl/papers/thesis.ps">(ps)</a> <a href="http://www.lsc.nd.edu/downloads/research/ggcl/papers/thesis.pdf">(pdf)</a></li>
+<li>Lie-Quan Lee's Master's Thesis about GGCL<a href="https://web.archive.org/web/20030824105142/http://www.lsc.nd.edu/downloads/research/ggcl/papers/thesis.ps">(ps)</a> <a href="https://web.archive.org/web/20030824113405/http://www.lsc.nd.edu/downloads/research/ggcl/papers/thesis.pdf">(pdf)</a></li>
 <li><a href="http://www.dietmar-kuehl.de/generic-graph-algorithms.pdf">Dietmar K&uuml;hl's Master's Thesis: Design Pattern for the Implementation of Graph Algorithms</a></li>
 <li>ISCOPE'99 Sparse Matrix Ordering <a href="./iscope99.pdf">(pdf)</a></li>
 <li><a href="http://www.oonumerics.org/tmpw00/">C++ Template Workshop 2000</a>, Concept Checking</li>
@@ -37,7 +37,7 @@
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/python.html
+++ b/doc/python.html
@@ -36,7 +36,7 @@
     using the BGL in Python.</p>
 
     <p>The Python bindings for the BGL are now part of a <a
-    href="http://www.osl.iu.edu/~dgregor/bgl-python/">separate
+    href="https://web.archive.org/web/20121030074643/http://www.osl.iu.edu:80/~dgregor/bgl-python/">separate
     project</a>. They are no longer available within the Boost
     tree.</p>
     <HR>
@@ -44,7 +44,7 @@
       <TR valign=top>
         <TD nowrap>Copyright &copy; 2005</TD><TD>
           <A HREF="http://www.boost.org/people/doug_gregor.html">Doug Gregor</A>, Indiana University (<script language="Javascript">address("cs.indiana.edu", "dgregor")</script>)<br>
-          <A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+          <A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
           Indiana University (<script language="Javascript">address("osl.iu.edu", "lums")</script>)
     </TD></TR></TABLE>
   </body>

--- a/doc/r_c_shortest_paths.html
+++ b/doc/r_c_shortest_paths.html
@@ -123,7 +123,7 @@ in:<br>
 Desaulniers, G.; Desrosiers, J.; Solomon, M. (eds.) (2005):<br>
 Column Generation<br>
 Springer, New York, pp. 33&ndash;65<br>
-(available online <a href="http://logistik.bwl.uni-mainz.de/Dateien/or_2004-01.pdf">
+(available online <a href="https://www.researchgate.net/publication/227142556_Shortest_Path_Problems_with_Resource_Constraints">
 here</a>)
 <p>
 

--- a/doc/random_spanning_tree.html
+++ b/doc/random_spanning_tree.html
@@ -151,7 +151,7 @@ IN: <tt>weight_map(WeightMap weight)</tt>
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/read_dimacs.html
+++ b/doc/read_dimacs.html
@@ -65,7 +65,7 @@ int read_dimacs_min_cut(Graph&amp; g,
 </pre>
 
 <p>
-These functions read a BGL graph object from a max-flow or min-cut problem description in extended dimacs format. (see <a href="http://www.avglab.com/andrew/CATS/maxflow_formats.htm"><TT>Goldberg's site</TT></a> for more information). For each edge found in the 
+These functions read a BGL graph object from a max-flow or min-cut problem description in extended dimacs format. (see <a href="https://web.archive.org/web/20120102213028/http://www.avglab.com/andrew/CATS/maxflow_formats.htm"><TT>Goldberg's site</TT></a> for more information). For each edge found in the 
 file an additional reverse_edge is added and set in the reverse_edge map.  For
 max-flow problems, source and sink vertex descriptors are set according to the
 dimacs file.

--- a/doc/sequential_vertex_coloring.html
+++ b/doc/sequential_vertex_coloring.html
@@ -107,7 +107,7 @@ in the graph, and <em>k</em> is the number of colors used.
 <TABLE>
 <TR valign=top>
 <TD nowrap>Copyright &copy; 1997-2004</TD><TD>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/doug_gregor.html">Douglas Gregor</A>, Indiana University (dgregor -at- cs.indiana.edu)</A>)

--- a/doc/small_world_generator.html
+++ b/doc/small_world_generator.html
@@ -118,7 +118,7 @@ int main()
 <TR valign=top>
 <TD nowrap>Copyright &copy; 2005</TD><TD>
 <A HREF="http://www.boost.org/people/doug_gregor.html">Doug Gregor</A>, Indiana University (<script language="Javascript">address("cs.indiana.edu", "dgregor")</script>)<br>
-  <A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+  <A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<script language="Javascript">address("osl.iu.edu", "lums")</script>)
 </TD></TR></TABLE>
 

--- a/doc/sorted_erdos_renyi_gen.html
+++ b/doc/sorted_erdos_renyi_gen.html
@@ -125,7 +125,7 @@ int main()
 Jeremiah Willcock, Indiana University (<script language="Javascript">address("cs.indiana.edu", "jewillco")</script>)<br>
   
 <A HREF="http://www.boost.org/people/doug_gregor.html">Doug Gregor</A>, Indiana University (<script language="Javascript">address("cs.indiana.edu", "dgregor")</script>)<br>
-  <A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+  <A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<script language="Javascript">address("osl.iu.edu", "lums")</script>)
 </TD></TR></TABLE>
 

--- a/doc/stanford_graph.html
+++ b/doc/stanford_graph.html
@@ -449,7 +449,7 @@ HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>,
 Indiana University (<A
 HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/table_of_contents.html
+++ b/doc/table_of_contents.html
@@ -333,7 +333,7 @@
       <LI><a href="./trouble_shooting.html">Trouble Shooting</a>
       <LI><a href="./known_problems.html">Known Problems</a>
       <LI><a href="./faq.html">FAQ</a>
-      <LI><a href="http://siek.info/bgl.html">BGL Book Errata</a>
+      <LI><a href="https://web.archive.org/web/20071012123707/http://siek.info/bgl.html">BGL Book Errata</a>
       </OL>
 <p>
 
@@ -348,7 +348,7 @@
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/time_stamper.html
+++ b/doc/time_stamper.html
@@ -187,7 +187,7 @@ and <a href="./property_writer.html"><tt>property_writer</tt></a>.
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/topology.html
+++ b/doc/topology.html
@@ -272,7 +272,7 @@ class heart_topology
 <TD nowrap>Copyright &copy; 2004, 2010 Trustees of Indiana University</TD><TD>
 Jeremiah Willcock, Indiana University (<script language="Javascript">address("osl.iu.edu", "jewillco")</script>)<br>
 <A HREF="http://www.boost.org/people/doug_gregor.html">Doug Gregor</A>, Indiana University (<script language="Javascript">address("cs.indiana.edu", "dgregor")</script>)<br>
-  <A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+  <A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<script language="Javascript">address("osl.iu.edu", "lums")</script>)
 </TD></TR></TABLE>
 

--- a/doc/trouble_shooting.html
+++ b/doc/trouble_shooting.html
@@ -120,7 +120,7 @@ for (std::size_t j = 0; j < n_edges; ++j)
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/undirected_dfs.html
+++ b/doc/undirected_dfs.html
@@ -333,7 +333,7 @@ An example is in <a href="../example/undirected_dfs.cpp">
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/undirected_graph.html
+++ b/doc/undirected_graph.html
@@ -87,7 +87,7 @@ A simple example of creating an undirected_graph is available here <a href="../.
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/users.html
+++ b/doc/users.html
@@ -25,18 +25,18 @@ or form.</p>
 <ul>
   <li><a href="http://www.cs.rpi.edu/~musser/gsd/">Generic Software Design Course at RPI</a></li>
   <li><a href="http://alps.comp-phys.org/">The ALPS quantum mechanics project</a></li>
-  <li><a href="http://bioinformatics.icmb.utexas.edu/lgl/">Large Graph Layout</a> at
+  <li><a href="http://lgl.sourceforge.net">Large Graph Layout</a> at
   University of Texas</li>
    <li><a href="http://www.cs.concordia.ca/~gregb/home/c691R-w2004.html">
      Bioinformatics Algorithms at Concordia University</a></li>
-  <li><a href="http://photon.poly.edu/~hbr/cs903/">Algorithm Course at Polytechnic University in Brooklyn</a></li>
-  <li><a href="http://www.bioconductor.org/repository/devel/vignette/RBGL.pdf">
+  <li><a href="https://web.archive.org/web/20130709183732/http://photon.poly.edu/~hbr/cs903/">Algorithm Course at Polytechnic University in Brooklyn</a></li>
+  <li><a href="https://www.bioconductor.org/packages/devel/bioc/vignettes/RBGL/inst/doc/RBGL.pdf">
      BGL interface for language R.</a></li>
   <li><a href="http://www.cuj.com/documents/s=8470/cuj0307tan/">CUJ Article about Electronic Design Automation</a></li>
   <li><a href="http://www.rubydoc.info/github/monora/rgl">A BGL-inspired Ruby Graph Library</a></li>
-  <li><a href="http://www.codeproject.com/cs/miscctrl/quickgraph.asp">A BGL-inspired C# Graph Library</a></li>
+  <li><a href="https://www.codeproject.com/Articles/5603/QuickGraph-A-100-C-graph-library-with-Graphviz-Sup">A BGL-inspired C# Graph Library</a></li>
   <li><a href="http://map1.squeakfoundation.org/sm/package/5729d80a-822b-4bc2-9420-ef7ecaea8553">A BGL-inspired Squeak (Smalltalk) Graph Library</a></li>
-  <li><a href="http://www.datasim.nl/education/coursedetails.asp?coursecategory=CPP&coursecode=ADCPP">BGL course at DataSim</a></li>
+  <li><a href="https://web.archive.org/web/20060510074143/http://www.datasim.nl:80/education/coursedetails.asp?coursecategory=CPP&coursecode=ADCPP">BGL course at DataSim</a></li>
   <li><a href="http://www.vrjuggler.org/">VR Juggler: Virtual Reality Tools</a></li>
   <li><a href="http://hyperworx.org">Hyperworx Platform Project</a></li>
   <li><a href="http://www.opencog.org/">OpenCog, an open source Artificial General Intelligence framework</a></li>

--- a/doc/visitor_concepts.html
+++ b/doc/visitor_concepts.html
@@ -54,7 +54,7 @@ the following visitor concepts:
 Indiana University (<A
 HREF="mailto:jsiek@osl.iu.edu">jsiek@osl.iu.edu</A>)<br>
 <A HREF="http://www.boost.org/people/liequan_lee.htm">Lie-Quan Lee</A>, Indiana University (<A HREF="mailto:llee@cs.indiana.edu">llee@cs.indiana.edu</A>)<br>
-<A HREF="http://www.osl.iu.edu/~lums">Andrew Lumsdaine</A>,
+<A HREF="https://homes.cs.washington.edu/~al75">Andrew Lumsdaine</A>,
 Indiana University (<A
 HREF="mailto:lums@osl.iu.edu">lums@osl.iu.edu</A>)
 </TD></TR></TABLE>

--- a/doc/write_dimacs.html
+++ b/doc/write_dimacs.html
@@ -59,7 +59,7 @@ void write_dimacs_max_flow(Graph& g,
 </pre>
 
 <p>
-This method writes a BGL graph object as an max-flow problem into an output stream in extended dimacs format (see <a href="http://www.avglab.com/andrew/CATS/maxflow_formats.htm"><TT>Goldbergs site</TT></a> for more information).
+This method writes a BGL graph object as an max-flow problem into an output stream in extended dimacs format (see <a href="https://web.archive.org/web/20120102213028/http://www.avglab.com/andrew/CATS/maxflow_formats.htm"><TT>Goldbergs site</TT></a> for more information).
 The output can be read in again using the <a href="../../../boost/graph/read_dimacs.hpp"><TT>boost/graph/read_dimacs.hpp</TT></a> method. 
 
 <H3>Where Defined</H3>

--- a/example/sloan_ordering.cpp
+++ b/example/sloan_ordering.cpp
@@ -1,7 +1,8 @@
 //
 //=======================================================================
 // Copyright 2002 Marc Wintermantel (wintermantel@imes.mavt.ethz.ch)
-// ETH Zurich, Center of Structure Technologies (www.imes.ethz.ch/st)
+// ETH Zurich, Center of Structure Technologies
+// (https://web.archive.org/web/20050307090307/http://www.structures.ethz.ch/)
 //
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at

--- a/include/boost/graph/depth_first_search.hpp
+++ b/include/boost/graph/depth_first_search.hpp
@@ -103,7 +103,7 @@ namespace boost {
     // The corresponding context shift back from the adjacent vertex occurs
     // after all of its out-edges have been examined.
     //
-    // See http://lists.boost.org/MailArchives/boost/msg48752.php for FAQ.
+    // See https://lists.boost.org/Archives/boost/2003/06/49265.php for FAQ.
 
     template <class IncidenceGraph, class DFSVisitor, class ColorMap,
             class TerminatorFunc>

--- a/include/boost/graph/detail/read_graphviz_new.hpp
+++ b/include/boost/graph/detail/read_graphviz_new.hpp
@@ -5,13 +5,13 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 //
-// read_graphviz_new.hpp - 
+// read_graphviz_new.hpp -
 //   Initialize a model of the BGL's MutableGraph concept and an associated
 //  collection of property maps using a graph expressed in the GraphViz
-// DOT Language.  
+// DOT Language.
 //
 //   Based on the grammar found at:
-//   http://www.graphviz.org/cvs/doc/info/lang.html
+//   https://web.archive.org/web/20041213234742/http://www.graphviz.org/cvs/doc/info/lang.html
 //
 //   Jeremiah rewrite used grammar found at:
 //   http://www.graphviz.org/doc/info/lang.html

--- a/include/boost/graph/detail/read_graphviz_spirit.hpp
+++ b/include/boost/graph/detail/read_graphviz_spirit.hpp
@@ -5,13 +5,13 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 //
-// read_graphviz_spirit.hpp - 
+// read_graphviz_spirit.hpp -
 //   Initialize a model of the BGL's MutableGraph concept and an associated
 //  collection of property maps using a graph expressed in the GraphViz
-// DOT Language.  
+// DOT Language.
 //
 //   Based on the grammar found at:
-//   http://www.graphviz.org/cvs/doc/info/lang.html
+//   https://web.archive.org/web/20041213234742/http://www.graphviz.org/cvs/doc/info/lang.html
 //
 //   See documentation for this code at: 
 //     http://www.boost.org/libs/graph/doc/read_graphviz.html

--- a/include/boost/graph/profile.hpp
+++ b/include/boost/graph/profile.hpp
@@ -1,7 +1,8 @@
 //
 //=======================================================================
 // Copyright 2002 Marc Wintermantel (wintermantel@even-ag.ch)
-// ETH Zurich, Center of Structure Technologies (www.imes.ethz.ch/st)
+// ETH Zurich, Center of Structure Technologies
+// (https://web.archive.org/web/20050307090307/http://www.structures.ethz.ch/)
 //
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at

--- a/include/boost/graph/sloan_ordering.hpp
+++ b/include/boost/graph/sloan_ordering.hpp
@@ -1,7 +1,8 @@
 //
 //=======================================================================
 // Copyright 2002 Marc Wintermantel (wintermantel@even-ag.ch)
-// ETH Zurich, Center of Structure Technologies (www.imes.ethz.ch/st)
+// ETH Zurich, Center of Structure Technologies
+// (https://web.archive.org/web/20050307090307/http://www.structures.ethz.ch/)
 //
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at

--- a/include/boost/graph/wavefront.hpp
+++ b/include/boost/graph/wavefront.hpp
@@ -1,7 +1,8 @@
 //
 //=======================================================================
 // Copyright 2002 Marc Wintermantel (wintermantel@even-ag.ch)
-// ETH Zurich, Center of Structure Technologies (www.imes.ethz.ch/st)
+// ETH Zurich, Center of Structure Technologies
+// (https://web.archive.org/web/20050307090307/http://www.structures.ethz.ch/)
 //
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at

--- a/src/read_graphviz_new.cpp
+++ b/src/read_graphviz_new.cpp
@@ -5,13 +5,13 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 //
-// read_graphviz_new.cpp - 
+// read_graphviz_new.cpp -
 //   Initialize a model of the BGL's MutableGraph concept and an associated
 //  collection of property maps using a graph expressed in the GraphViz
-// DOT Language.  
+// DOT Language.
 //
 //   Based on the grammar found at:
-//   http://www.graphviz.org/cvs/doc/info/lang.html
+//   https://web.archive.org/web/20041213234742/http://www.graphviz.org/cvs/doc/info/lang.html
 //
 //   Jeremiah rewrite used grammar found at:
 //   http://www.graphviz.org/doc/info/lang.html


### PR DESCRIPTION
Hi,

sorry for this pretty large commit. It is intended to fix a large number of broken external links in the Boost.Graph library. Here is what it does:

1. Replaces all instances of http://www.sgi.com/tech with https://boost.org/sgi .
2. Replaces all instances of http://www.osl.iu.edu/~lums with https://homes.cs.washington.edu/~al75 . I hope, this is appropriate, it is his most current homepage I could find.
3. Replaces all instances of http://www.cs.rpi.edu/~beevek with http://cs.krisbeevers.com (See 2) )
4. Replaces links to the old qhull websites with links to qhull.org
5. Replace two broken deep links to pdfs of papers with links to the ResearchGate page holding the full-text pdfs.
6. Numerous links that are dead were prefixed with webarchive-links, so the old content is shown. I hope the chosen dates are appropriate but ultimately I was not able to confirm whether I've linked the correct versions so I used my best judgment.
7. Replaced a dead link to an e-mail in the boost mailing list archive with a link to (almost surely) the same e-mail in the current archive. The old e-mail is not in the web archive, but if the list of alternative urls in this https://www.mail-archive.com/boost@lists.boost.org/msg09308.html is accurate, then it should be the same. It makes sense in the context.
8. Some more link updates. 

If you want me break this up into smaller commits or revert some of the changes, please let me know.

Kind regards,
Tinko Bartels

(Edit: I did not build the tests because I was not changing any actual code and because, in case I messed up, I am still trusting the CI to do that.)