### PR TITLE
adjacency_list: Fix example broken link

### DIFF
--- a/doc/adjacency_list.html
+++ b/doc/adjacency_list.html
@@ -86,7 +86,7 @@ Section <A HREF="./using_adjacency_list.html">Using
 
 <P>
 The example in <a
-href="../example/family-tree-eg.cpp"><tt>examples/family-tree-eg.cpp</tt></a>
+href="../example/family_tree.cpp"><tt>examples/family_tree.cpp</tt></a>
 shows how to represent a family tree with a graph.
 
 <H3>Template Parameters</H3>

--- a/example/regression.cfg
+++ b/example/regression.cfg
@@ -47,7 +47,7 @@ compile libs/graph/example/edge_property.cpp
 compile libs/graph/example/edmonds-karp-eg.cpp
 compile libs/graph/example/exterior_properties.cpp
 compile libs/graph/example/exterior_property_map.cpp
-compile libs/graph/example/family-tree-eg.cpp
+compile libs/graph/example/family_tree.cpp
 compile libs/graph/example/fibonacci_heap.cpp
 compile libs/graph/example/file_dependencies.cpp
 compile libs/graph/example/filtered_graph.cpp


### PR DESCRIPTION
The file was renamed from family-tree-eg.cpp to family_tree.cpp