### PR TITLE
Fix build failure with gcc 4.9.1

### DIFF
--- a/include/boost/graph/depth_first_search.hpp
+++ b/include/boost/graph/depth_first_search.hpp
@@ -77,7 +77,7 @@ namespace boost {
 
     template <typename E, typename G, typename Vis>
     void call_finish_edge(Vis& vis, E e, const G& g) { // Only call if method exists
-#if ((defined(__GNUC__) && (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 9))) || \
+#if ((defined(__GNUC__) && (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 9) && (__GNUC_PATCHLEVEL__ >= 3))) || \
       defined(__clang__) || \
      (defined(__INTEL_COMPILER) && (__INTEL_COMPILER >= 1200)))
       do_call_finish_edge<


### PR DESCRIPTION
- This is a gcc bug existing in 4.9.1 but it was fixed in 4.9.3. See comipler bug link https://gcc.gnu.org/bugzilla/show_bug.cgi?id=62255#c2 for details.