### PR TITLE
std::max_element requires forward iterator

### DIFF
--- a/include/boost/graph/bc_clustering.hpp
+++ b/include/boost/graph/bc_clustering.hpp
@@ -9,11 +9,11 @@
 #ifndef BOOST_GRAPH_BETWEENNESS_CENTRALITY_CLUSTERING_HPP
 #define BOOST_GRAPH_BETWEENNESS_CENTRALITY_CLUSTERING_HPP
 
+#include <boost/algorithm/minmax_element.hpp>
 #include <boost/graph/betweenness_centrality.hpp>
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/graph_utility.hpp>
 #include <boost/pending/indirect_cmp.hpp>
-#include <algorithm>
 #include <vector>
 #include <boost/property_map/property_map.hpp>
 
@@ -133,7 +133,7 @@ void betweenness_centrality_clustering(MutableGraph& g, Done done,
                 .vertex_index_map(vertex_index));
         std::pair< edge_iterator, edge_iterator > edges_iters = edges(g);
         edge_descriptor e
-            = *max_element(edges_iters.first, edges_iters.second, cmp);
+            = *boost::first_max_element(edges_iters.first, edges_iters.second, cmp);
         is_done = done(get(edge_centrality, e), e, g);
         if (!is_done)
             remove_edge(e, g);

--- a/include/boost/graph/howard_cycle_ratio.hpp
+++ b/include/boost/graph/howard_cycle_ratio.hpp
@@ -21,6 +21,7 @@
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/graph_concepts.hpp>
 #include <boost/concept/assert.hpp>
+#include <boost/algorithm/minmax_element.hpp>
 
 /** @file howard_cycle_ratio.hpp
  * @brief The implementation of the maximum/minimum cycle ratio/mean algorithm.
@@ -240,7 +241,7 @@ namespace detail
             {
                 boost::tie(oei, oeie) = out_edges(*vi, m_g);
                 typename graph_traits< Graph >::out_edge_iterator mei
-                    = std::max_element(oei, oeie,
+                    = boost::first_max_element(oei, oeie,
                         boost::bind(m_cmp,
                             boost::bind(&EdgeWeight1::operator[], m_ew1m, _1),
                             boost::bind(&EdgeWeight1::operator[], m_ew1m, _2)));


### PR DESCRIPTION
1. Replace `std::max_element` with `boost::first_max_element` in `include/boost/graph/bc_clustering.hpp` as described in #175.
2. Additionally, `include/boost/graph/howard_cycle_ratio.hpp` has the same issue and is patched similarly in b9c3b14d3918e2beb25d2b8b4b735fc9c142cf7d.

I ran the basic tests. Everything compiles with Xcode 11.1 running on macOS 10.14.6 and it looks like nothing failed, but I'm not sure. I did have to remove `disjoint_sets.hpp` from `include/boost/pending` and `include/boost/pending/detail` for `b2` to work with the `develop` branch.

The testing is how I found the problem with `include/boost/graph/howard_cycle_ratio.hpp`. There is also a `std::max_element` in `include/boost/graph/planar_detail/bucket_sort.hpp`, but it looks like the arguments are acceptable iterators.
```
git clone https://github.com/boostorg/boost
cd boost
git submodule update --init

<change files in lib/graph>

./bootstrap.sh            <- compile b2
./b2 headers              <- just installs headers
./b2                      <- build compiled components

../../../b2               <- run all tests in lib/graph/test
```
Let me know if anything else is needed. Thanks!
