### PR TITLE
Prevent fallthrough when assertions are not fatal

### DIFF
--- a/src/read_graphviz_new.cpp
+++ b/src/read_graphviz_new.cpp
@@ -334,6 +334,8 @@ namespace read_graphviz_detail
                         BOOST_ASSERT(!"Definition of punctuation_token does "
                                       "not match switch statement");
                     }
+                    // Prevent static analyzers complaining about fallthrough:
+                    break;
                 }
                 default:
                     BOOST_ASSERT(!"Definition of punctuation_token does not "


### PR DESCRIPTION
When BOOST_DISABLE_ASSERTS or BOOST_ENABLE_ASSERT_HANDLER is defined, the nested switch on `str[1]` can continue past the assert and will fallthrough to the `default` case below.

This can cause warnings with static analysis tools, and if a user-defined `boost::assertion_failed` function that doesn't terminate the process is being used, that function will be called twice because the first assertion falls through to the second.

Inserting a `break` avoids static analysis warnings and avoids potentially calling the assertion handler twice.