### PR TITLE
Isomorphism improvements

### DIFF
--- a/doc/isomorphism.html
+++ b/doc/isomorphism.html
@@ -92,8 +92,9 @@ href="./VertexListGraph.html">Vertex List Graph</a>.
 
 OUT: <tt>isomorphism_map(IsoMap f)</tt>
 <blockquote>
-The mapping from vertices in graph 1 to vertices in graph 2. This must
-be a <a href="../../property_map/doc/ReadWritePropertyMap.html">Read/Write
+The mapping from vertices in graph 1 to vertices in graph 2. May contain <a
+href="Graph.h">null vertices</a> if both graphs contain single-vertex
+components. This must be a <a href="../../property_map/doc/ReadWritePropertyMap.html">Read/Write
 Property Map</a>.<br> <b>Default:</b> an <a
 href="../../property_map/doc/iterator_property_map.html"><tt>iterator_property_map</tt></a>
 constructed from a <tt>std::vector</tt> of graph 2's vertex
@@ -111,12 +112,12 @@ This mapping can be used either to speed up the search (as is done by the
 default value, which requires that the degrees of <i>v1</i> and <i>v2</i> are
 equal) or to impose extra conditions on the result.  The
 <tt>VertexInvariant1</tt> and <tt>VertexInvariant2</tt> types must model <a
-href="http://www.boost.org/sgi/stl/UnaryFunction.html">UnaryFunction</a>, with
-the argument type of <tt>vertex_invariant1</tt> being <tt>Graph1</tt>'s vertex
+href="http://www.boost.org/sgi/stl/AdaptableUnaryFunction.html">AdaptableUnaryFunction</a>,
+with the argument type of <tt>vertex_invariant1</tt> being <tt>Graph1</tt>'s vertex
 descriptor type, the argument type of <tt>vertex_invariant2</tt> being
 <tt>Graph2</tt>'s vertex descriptor type, and both functions having integral
-result types.  The values returned by these two functions must be in the range
-[0, <tt>vertex_max_invariant</tt>).
+result types.  The values returned by these two functions must have a low upper
+bound. 
 <br>
 <b>Default:</b> <tt>degree_vertex_invariant</tt> for both arguments<br>
 <b>Python</b>: Unsupported parameter.
@@ -124,14 +125,7 @@ result types.  The values returned by these two functions must be in the range
 
 IN: <tt>vertex_max_invariant(std::size_t max_invariant)</tt>
 <blockquote>
-An upper bound on the possible values returned from either
-vertex_invariant1 or vertex_invariant2.
-<br>
-<b>Default:</b> <tt>vertex_invariant2.max()</tt>. The default
-<tt>vertex_invariant2</tt> parameter, an instance of
-<tt>degree_vertex_invariant</tt>, defines this function to
-return <tt>num_vertices(g2) * (num_vertices(g2)+1)</tt>.<br>
-<b>Python</b>: Unsupported parameter.
+This parameter is ignored.
 </blockquote>
 
 IN: <tt>vertex_index1_map(VertexIndex1Map i1_map)</tt>

--- a/doc/isomorphism.html
+++ b/doc/isomorphism.html
@@ -115,9 +115,8 @@ equal) or to impose extra conditions on the result.  The
 href="http://www.boost.org/sgi/stl/AdaptableUnaryFunction.html">AdaptableUnaryFunction</a>,
 with the argument type of <tt>vertex_invariant1</tt> being <tt>Graph1</tt>'s vertex
 descriptor type, the argument type of <tt>vertex_invariant2</tt> being
-<tt>Graph2</tt>'s vertex descriptor type, and both functions having integral
-result types.  The values returned by these two functions must have a low upper
-bound. 
+<tt>Graph2</tt>'s vertex descriptor type, and both functions sharing a 
+result type that is totally ordered and hashable such as an integer.
 <br>
 <b>Default:</b> <tt>degree_vertex_invariant</tt> for both arguments<br>
 <b>Python</b>: Unsupported parameter.

--- a/doc/isomorphism.html
+++ b/doc/isomorphism.html
@@ -92,14 +92,13 @@ href="./VertexListGraph.html">Vertex List Graph</a>.
 
 OUT: <tt>isomorphism_map(IsoMap f)</tt>
 <blockquote>
-The mapping from vertices in graph 1 to vertices in graph 2. May contain <a
-href="Graph.h">null vertices</a> if both graphs contain single-vertex
-components. This must be a <a href="../../property_map/doc/ReadWritePropertyMap.html">Read/Write
-Property Map</a>.<br> <b>Default:</b> an <a
+The mapping from vertices in graph 1 to vertices in graph 2. This must be a 
+<a href="../../property_map/doc/ReadWritePropertyMap.html">Read/Write Property
+Map</a>.<br> <b>Default:</b> an <a
 href="../../property_map/doc/iterator_property_map.html"><tt>iterator_property_map</tt></a>
-constructed from a <tt>std::vector</tt> of graph 2's vertex
-descriptor type and the vertex index map for graph 1.<br>
-<b>Python</b>: Must be a <tt>vertex_vertex_map</tt> for the first graph.
+constructed from a <tt>std::vector</tt> of graph 2's vertex descriptor type and
+the vertex index map for graph 1.<br> <b>Python</b>: Must be a
+<tt>vertex_vertex_map</tt> for the first graph.
 </blockquote>
 
 IN: <tt>vertex_invariant1(VertexInvariant1 i1)</tt>

--- a/include/boost/graph/isomorphism.hpp
+++ b/include/boost/graph/isomorphism.hpp
@@ -46,7 +46,6 @@ namespace detail
         IsoMapping f;
         Invariant1 invariant1;
         Invariant2 invariant2;
-        std::size_t max_invariant;
         IndexMap1 index_map1;
         IndexMap2 index_map2;
 
@@ -138,14 +137,13 @@ namespace detail
     public:
         isomorphism_algo(const Graph1& G1, const Graph2& G2, IsoMapping f,
             Invariant1 invariant1, Invariant2 invariant2,
-            std::size_t max_invariant, IndexMap1 index_map1,
+            std::size_t /* max_invariant */, IndexMap1 index_map1,
             IndexMap2 index_map2)
         : G1(G1)
         , G2(G2)
         , f(f)
         , invariant1(invariant1)
         , invariant2(invariant2)
-        , max_invariant(max_invariant)
         , index_map1(index_map1)
         , index_map2(index_map2)
         {
@@ -165,18 +163,23 @@ namespace detail
             BGL_FORALL_VERTICES_T(v, G1, Graph1)
             f[v] = graph_traits< Graph2 >::null_vertex();
 
+            std::size_t max_invariant;
             {
                 std::vector< invar1_value > invar1_array;
+                invar1_array.reserve(num_vertices(G1));
                 BGL_FORALL_VERTICES_T(v, G1, Graph1)
-                invar1_array.push_back(invariant1(v));
+                  invar1_array.push_back(invariant1(v));
                 sort(invar1_array);
 
                 std::vector< invar2_value > invar2_array;
+                invar2_array.reserve(num_vertices(G2));
                 BGL_FORALL_VERTICES_T(v, G2, Graph2)
-                invar2_array.push_back(invariant2(v));
+                  invar2_array.push_back(invariant2(v));
                 sort(invar2_array);
                 if (!equal(invar1_array, invar2_array))
                     return false;
+
+                max_invariant = std::max(invar1_array.back(), invar2_array.back()) + 1;
             }
 
             std::vector< vertex1_t > V_mult;
@@ -486,7 +489,7 @@ template < typename Graph1, typename Graph2, typename IsoMapping,
     typename Invariant1, typename Invariant2, typename IndexMap1,
     typename IndexMap2 >
 bool isomorphism(const Graph1& G1, const Graph2& G2, IsoMapping f,
-    Invariant1 invariant1, Invariant2 invariant2, std::size_t max_invariant,
+    Invariant1 invariant1, Invariant2 invariant2, std::size_t /* max_invariant */,
     IndexMap1 index_map1, IndexMap2 index_map2)
 
 {
@@ -527,7 +530,7 @@ bool isomorphism(const Graph1& G1, const Graph2& G2, IsoMapping f,
 
     detail::isomorphism_algo< Graph1, Graph2, IsoMapping, Invariant1,
         Invariant2, IndexMap1, IndexMap2 >
-        algo(G1, G2, f, invariant1, invariant2, max_invariant, index_map1,
+        algo(G1, G2, f, invariant1, invariant2, 0, index_map1,
             index_map2);
     return algo.test_isomorphism();
 }
@@ -574,8 +577,7 @@ namespace detail
         return isomorphism(G1, G2, f,
             choose_param(get_param(params, vertex_invariant1_t()), invariant1),
             choose_param(get_param(params, vertex_invariant2_t()), invariant2),
-            choose_param(get_param(params, vertex_max_invariant_t()),
-                (invariant2.max)()),
+            0,
             index_map1, index_map2);
     }
 
@@ -654,7 +656,7 @@ namespace graph
                         make_shared_array_property_map(
                             num_vertices(g1), vertex2_t(), index1_map)),
                     invariant1, invariant2,
-                    arg_pack[_vertex_max_invariant | (invariant2.max)()],
+                    0,
                     index1_map, index2_map);
             }
         };

--- a/include/boost/graph/isomorphism.hpp
+++ b/include/boost/graph/isomorphism.hpp
@@ -15,6 +15,7 @@
 #include <boost/smart_ptr.hpp>
 #include <boost/graph/depth_first_search.hpp>
 #include <boost/detail/algorithm.hpp>
+#include <boost/unordered_map.hpp>
 #include <boost/pending/indirect_cmp.hpp> // for make_indirect_pmap
 #include <boost/concept/assert.hpp>
 
@@ -29,6 +30,37 @@ namespace boost
 namespace detail
 {
 
+    template < typename T >
+    struct HashableConcept {
+        BOOST_CONCEPT_USAGE(HashableConcept)
+        {
+            hash<T> hasher;
+            typedef typename hash<T>::result_type hash_result;
+            hash_result val = hasher(t);
+            boost::ignore_unused_variable_warning(val);
+        }
+
+        T t;
+    };
+
+    template < typename T, typename U >
+    struct HeterogeneousEqualityComparable {
+        BOOST_CONCEPT_USAGE(HeterogeneousEqualityComparable)
+        {
+            bool a = (t == u);
+            a = (u == t);
+            a = (t != u);
+            a = (u != t);
+            boost::ignore_unused_variable_warning(a);
+        }
+
+        T t;
+        U u;
+    };
+
+    template < typename Invariant >
+    struct InvariantConcept : LessThanComparable<Invariant>, EqualityComparable<Invariant>, HashableConcept<Invariant> {};
+
     template < typename Graph1, typename Graph2, typename IsoMapping,
         typename Invariant1, typename Invariant2, typename IndexMap1,
         typename IndexMap2 >
@@ -40,6 +72,7 @@ namespace detail
         typedef typename graph_traits< Graph1 >::vertices_size_type size_type;
         typedef typename Invariant1::result_type invar1_value;
         typedef typename Invariant2::result_type invar2_value;
+        typedef unordered_map< invar1_value, size_type > multiplicity_map;
 
         const Graph1& G1;
         const Graph2& G2;
@@ -80,17 +113,17 @@ namespace detail
         friend struct compare_multiplicity;
         struct compare_multiplicity
         {
-            compare_multiplicity(Invariant1 invariant1, size_type* multiplicity)
+            compare_multiplicity(Invariant1 invariant1, const multiplicity_map& multiplicity)
             : invariant1(invariant1), multiplicity(multiplicity)
             {
             }
             bool operator()(const vertex1_t& x, const vertex1_t& y) const
             {
-                return multiplicity[invariant1(x)]
-                    < multiplicity[invariant1(y)];
+                return multiplicity.at(invariant1(x))
+                    < multiplicity.at(invariant1(y));
             }
             Invariant1 invariant1;
-            size_type* multiplicity;
+            const multiplicity_map& multiplicity;
         };
 
         struct record_dfs_order : default_dfs_visitor
@@ -157,41 +190,64 @@ namespace detail
             );
         }
 
+        multiplicity_map multiplicities(const std::vector< invar1_value >& invariants) {
+          // Assumes invariants are sorted
+          multiplicity_map invar_multiplicity;
+
+          typedef typename std::vector< invar1_value >::const_iterator invar_iter;
+          typedef typename multiplicity_map::iterator invar_map_iter;
+          invar_iter it = invariants.begin();
+          const invar_iter end = invariants.end();
+
+          if(it == end) {
+            return invar_multiplicity;
+          }
+
+          invar1_value invar = *it;
+          invar_map_iter inserted = invar_multiplicity.emplace(invar, 1).first;
+          ++it;
+          for(; it != end; ++it)
+          {
+              if(*it == invar)
+              {
+                  inserted->second += 1;
+              }
+              else
+              {
+                  invar = *it;
+                  inserted = invar_multiplicity.emplace(invar, 1).first;
+              }
+          }
+
+          return invar_multiplicity;
+        }
+
         bool test_isomorphism()
         {
-            // reset isomapping
+            // Initialize IsoMap
             BGL_FORALL_VERTICES_T(v, G1, Graph1)
             f[v] = graph_traits< Graph2 >::null_vertex();
 
-            std::size_t max_invariant;
-            {
-                std::vector< invar1_value > invar1_array;
-                invar1_array.reserve(num_vertices(G1));
-                BGL_FORALL_VERTICES_T(v, G1, Graph1)
-                  invar1_array.push_back(invariant1(v));
-                sort(invar1_array);
+            // Calculate all invariants of G1 and G2, sort and compare
+            std::vector< invar1_value > invar1_array;
+            invar1_array.reserve(num_vertices(G1));
+            BGL_FORALL_VERTICES_T(v, G1, Graph1)
+            invar1_array.push_back(invariant1(v));
+            sort(invar1_array);
 
-                std::vector< invar2_value > invar2_array;
-                invar2_array.reserve(num_vertices(G2));
-                BGL_FORALL_VERTICES_T(v, G2, Graph2)
-                  invar2_array.push_back(invariant2(v));
-                sort(invar2_array);
-                if (!equal(invar1_array, invar2_array))
-                    return false;
+            std::vector< invar2_value > invar2_array;
+            invar2_array.reserve(num_vertices(G2));
+            BGL_FORALL_VERTICES_T(v, G2, Graph2)
+            invar2_array.push_back(invariant2(v));
+            sort(invar2_array);
+            if (!equal(invar1_array, invar2_array))
+                return false;
 
-                max_invariant = std::max(invar1_array.back(), invar2_array.back()) + 1;
-            }
-
+            // Sort vertices by the multiplicity of their invariants
             std::vector< vertex1_t > V_mult;
             BGL_FORALL_VERTICES_T(v, G1, Graph1)
             V_mult.push_back(v);
-            {
-                std::vector< size_type > multiplicity(max_invariant, 0);
-                BGL_FORALL_VERTICES_T(v, G1, Graph1)
-                ++multiplicity.at(invariant1(v));
-                sort(
-                    V_mult, compare_multiplicity(invariant1, &multiplicity[0]));
-            }
+            sort(V_mult, compare_multiplicity(invariant1, multiplicities(invar1_array)));
 
             std::vector< default_color_type > color_vec(num_vertices(G1));
             safe_iterator_property_map<
@@ -503,11 +559,19 @@ bool isomorphism(const Graph1& G1, const Graph2& G2, IsoMapping f,
     typedef typename graph_traits< Graph2 >::vertex_descriptor vertex2_t;
     typedef typename graph_traits< Graph1 >::vertices_size_type size_type;
 
+    typedef typename Invariant1::result_type invar1_t;
+    typedef typename Invariant2::result_type invar2_t;
+
+    BOOST_CONCEPT_ASSERT((detail::InvariantConcept<invar1_t>));
+    BOOST_CONCEPT_ASSERT((detail::InvariantConcept<invar2_t>));
+    BOOST_CONCEPT_ASSERT((detail::HeterogeneousEqualityComparable<invar1_t, invar2_t>));
+
     // Vertex invariant requirement
     BOOST_CONCEPT_ASSERT(
-        (AdaptableUnaryFunctionConcept< Invariant1, size_type, vertex1_t >));
+        (AdaptableUnaryFunctionConcept< Invariant1, invar1_t, vertex1_t >));
     BOOST_CONCEPT_ASSERT(
-        (AdaptableUnaryFunctionConcept< Invariant2, size_type, vertex2_t >));
+        (AdaptableUnaryFunctionConcept< Invariant2, invar2_t, vertex2_t >));
+
 
     // Property map requirements
     BOOST_CONCEPT_ASSERT(

--- a/test/isomorphism.cpp
+++ b/test/isomorphism.cpp
@@ -57,7 +57,11 @@ template < typename Generator > struct random_functor
 #endif
 
 template < typename Graph1, typename Graph2 >
-void randomly_permute_graph(const Graph1& g1, Graph2& g2)
+std::map<
+    typename graph_traits< Graph1 >::vertex_descriptor,
+    typename graph_traits< Graph2 >::vertex_descriptor
+>
+randomly_permute_graph(const Graph1& g1, Graph2& g2)
 {
     // Need a clean graph to start with
     BOOST_TEST(num_vertices(g2) == 0);
@@ -93,6 +97,8 @@ void randomly_permute_graph(const Graph1& g1, Graph2& g2)
     {
         add_edge(vertex_map[source(*e, g1)], vertex_map[target(*e, g1)], g2);
     }
+
+    return vertex_map;
 }
 
 template < typename Graph >
@@ -243,11 +249,125 @@ void test_isomorphism(int n, double edge_probability)
     }
 }
 
+template<typename Graph>
+struct ColorFunctor {
+    typedef typename graph_traits<Graph>::vertex_descriptor argument_type;
+    typedef int result_type;
+
+    ColorFunctor(const Graph& g) : graph(g) {}
+
+    inline result_type operator() (argument_type v) const {
+        return get(vertex_color_t(), graph)(v);
+    }
+
+    const Graph& graph;
+};
+
+void test_colored_isomorphism(int n, double edge_probability)
+{
+    using namespace boost::graph::keywords;
+    typedef adjacency_list< vecS, vecS, bidirectionalS, property< vertex_color_t, int > > graph1;
+    typedef adjacency_list< listS, listS, bidirectionalS,
+        property< vertex_index_t, int, property< vertex_color_t, int >
+        >
+    > graph2;
+
+    typedef typename graph_traits< graph1 >::vertex_descriptor vertex1_t;
+    typedef typename graph_traits< graph2 >::vertex_descriptor vertex2_t;
+    typedef std::map< vertex1_t, vertex2_t > vertex_map_t;
+
+    graph1 g1(n);
+    generate_random_digraph(g1, edge_probability);
+    graph2 g2;
+    vertex_map_t vertex_map = randomly_permute_graph(g1, g2);
+
+    std::vector< int > colors(n);
+    typedef std::vector< int >::iterator colors_iter;
+    colors_iter midpoint = colors.begin() + n / 2;
+    std::fill(colors.begin(), midpoint, -1);
+    std::fill(midpoint, colors.end(), 1);
+
+    random_generator_type gen;
+
+#ifndef BOOST_NO_CXX98_RANDOM_SHUFFLE
+    random_functor< random_generator_type > rand_fun(gen);
+    std::random_shuffle(colors.begin(), colors.end(), rand_fun);
+#else
+    std::shuffle(colors.begin(), colors.end(), gen);
+#endif
+
+    int v_idx = 0;
+    for (graph1::vertex_iterator v = vertices(g1).first;
+         v != vertices(g1).second; ++v)
+    {
+        put(vertex_color_t(), g1, *v, colors[v_idx]);
+        put(vertex_color_t(), g2, vertex_map.at(*v), colors[v_idx]);
+        v_idx += 1;
+    }
+
+    v_idx = 0;
+    for (graph2::vertex_iterator v = vertices(g2).first;
+         v != vertices(g2).second; ++v)
+    {
+        put(vertex_index_t(), g2, *v, v_idx);
+        v_idx += 1;
+    }
+
+    std::map< graph1::vertex_descriptor, graph2::vertex_descriptor > mapping;
+
+    bool isomorphism_correct;
+    clock_t start = clock();
+    BOOST_TEST(
+        isomorphism_correct = isomorphism(
+            g1,
+            g2,
+            isomorphism_map(make_assoc_property_map(mapping))
+            .vertex_invariant1(ColorFunctor<graph1>(g1))
+            .vertex_invariant2(ColorFunctor<graph2>(g2))
+        )
+    );
+    clock_t end = clock();
+
+    std::cout << "Elapsed time (clock cycles): " << (end - start) << std::endl;
+
+    bool verify_correct;
+    BOOST_TEST(verify_correct
+        = verify_isomorphism(g1, g2, make_assoc_property_map(mapping)));
+
+    if (!isomorphism_correct || !verify_correct)
+    {
+        // Output graph 1
+        {
+            std::ofstream out("colored_isomorphism_failure.bg1");
+            out << num_vertices(g1) << std::endl;
+            for (graph1::edge_iterator e = edges(g1).first;
+                 e != edges(g1).second; ++e)
+            {
+                out << get(vertex_index_t(), g1, source(*e, g1)) << ' '
+                    << get(vertex_index_t(), g1, target(*e, g1)) << std::endl;
+            }
+        }
+
+        // Output graph 2
+        {
+            std::ofstream out("colored_isomorphism_failure.bg2");
+            out << num_vertices(g2) << std::endl;
+            for (graph2::edge_iterator e = edges(g2).first;
+                 e != edges(g2).second; ++e)
+            {
+                out << get(vertex_index_t(), g2, source(*e, g2)) << ' '
+                    << get(vertex_index_t(), g2, target(*e, g2)) << std::endl;
+            }
+        }
+    }
+}
+
 int main(int argc, char* argv[])
 {
     int n = argc < 3 ? 30 : boost::lexical_cast< int >(argv[1]);
     double edge_prob = argc < 3 ? 0.45 : boost::lexical_cast< double >(argv[2]);
     test_isomorphism(n, edge_prob);
+    test_colored_isomorphism(n, edge_prob);
 
     return boost::report_errors();
 }

--- a/test/isomorphism.cpp
+++ b/test/isomorphism.cpp
@@ -365,7 +365,7 @@ void test_colored_isomorphism(int n, double edge_probability)
 
     bool map_contains_null_vertices = false;
     {
-        typedef graph2::vertex_descriptor vertex2_t;
+        typedef typename graph_traits< graph2 >::vertex_descriptor vertex2_t;
         const vertex2_t g2_null_vertex = graph2::null_vertex();
 
         typedef iso_map::iterator map_iter;
@@ -379,6 +379,20 @@ void test_colored_isomorphism(int n, double edge_probability)
     }
 
     BOOST_TEST(!map_contains_null_vertices);
+
+    // Map is bijective if each vertex of the second graph occurs only once
+    {
+      typedef typename graph_traits< graph2 >::vertex_descriptor vertex2_t;
+      std::set< vertex2_t > vertex_set;
+
+      typedef iso_map::iterator map_iter;
+      const map_iter end = mapping.end();
+      for(map_iter iter = mapping.begin(); iter != end; ++iter) {
+        vertex_set.insert(iter->second);
+      }
+
+      BOOST_TEST(vertex_set.size() == mapping.size());
+    }
 }
 
 int main(int argc, char* argv[])

--- a/test/isomorphism.cpp
+++ b/test/isomorphism.cpp
@@ -272,8 +272,8 @@ void test_colored_isomorphism(int n, double edge_probability)
         >
     > graph2;
 
-    typedef typename graph_traits< graph1 >::vertex_descriptor vertex1_t;
-    typedef typename graph_traits< graph2 >::vertex_descriptor vertex2_t;
+    typedef graph_traits< graph1 >::vertex_descriptor vertex1_t;
+    typedef graph_traits< graph2 >::vertex_descriptor vertex2_t;
     typedef std::map< vertex1_t, vertex2_t > vertex_map_t;
 
     graph1 g1(n);
@@ -301,8 +301,8 @@ void test_colored_isomorphism(int n, double edge_probability)
     for (graph1::vertex_iterator v = vertices(g1).first;
          v != vertices(g1).second; ++v)
     {
-        put(vertex_color_t(), g1, *v, colors[v_idx]);
-        put(vertex_color_t(), g2, vertex_map.at(*v), colors[v_idx]);
+        put(get(vertex_color_t(), g1), *v, colors[v_idx]);
+        put(get(vertex_color_t(), g2), vertex_map[*v], colors[v_idx]);
         v_idx += 1;
     }
 
@@ -310,7 +310,7 @@ void test_colored_isomorphism(int n, double edge_probability)
     for (graph2::vertex_iterator v = vertices(g2).first;
          v != vertices(g2).second; ++v)
     {
-        put(vertex_index_t(), g2, *v, v_idx);
+        put(get(vertex_index_t(), g2), *v, v_idx);
         v_idx += 1;
     }
 
@@ -365,10 +365,10 @@ void test_colored_isomorphism(int n, double edge_probability)
 
     bool map_contains_null_vertices = false;
     {
-        typedef typename graph2::vertex_descriptor vertex2_t;
+        typedef graph2::vertex_descriptor vertex2_t;
         const vertex2_t g2_null_vertex = graph2::null_vertex();
 
-        typedef typename iso_map::iterator map_iter;
+        typedef iso_map::iterator map_iter;
         const map_iter end = mapping.end();
         for(map_iter iter = mapping.begin(); iter != end; ++iter) {
             if(iter->second == g2_null_vertex) {

--- a/test/isomorphism.cpp
+++ b/test/isomorphism.cpp
@@ -278,6 +278,7 @@ void test_colored_isomorphism(int n, double edge_probability)
 
     graph1 g1(n);
     generate_random_digraph(g1, edge_probability);
+
     graph2 g2;
     vertex_map_t vertex_map = randomly_permute_graph(g1, g2);
 
@@ -313,7 +314,8 @@ void test_colored_isomorphism(int n, double edge_probability)
         v_idx += 1;
     }
 
-    std::map< graph1::vertex_descriptor, graph2::vertex_descriptor > mapping;
+    typedef std::map< graph1::vertex_descriptor, graph2::vertex_descriptor > iso_map;
+    iso_map mapping;
 
     bool isomorphism_correct;
     clock_t start = clock();
@@ -360,6 +362,23 @@ void test_colored_isomorphism(int n, double edge_probability)
             }
         }
     }
+
+    bool map_contains_null_vertices = false;
+    {
+        typedef typename graph2::vertex_descriptor vertex2_t;
+        const vertex2_t g2_null_vertex = graph2::null_vertex();
+
+        typedef typename iso_map::iterator map_iter;
+        const map_iter end = mapping.end();
+        for(map_iter iter = mapping.begin(); iter != end; ++iter) {
+            if(iter->second == g2_null_vertex) {
+                map_contains_null_vertices = true;
+                break;
+            }
+        }
+    }
+
+    BOOST_TEST(!map_contains_null_vertices);
 }
 
 int main(int argc, char* argv[])

--- a/test/isomorphism.cpp
+++ b/test/isomorphism.cpp
@@ -365,7 +365,7 @@ void test_colored_isomorphism(int n, double edge_probability)
 
     bool map_contains_null_vertices = false;
     {
-        typedef typename graph_traits< graph2 >::vertex_descriptor vertex2_t;
+        typedef graph_traits< graph2 >::vertex_descriptor vertex2_t;
         const vertex2_t g2_null_vertex = graph2::null_vertex();
 
         typedef iso_map::iterator map_iter;
@@ -382,7 +382,7 @@ void test_colored_isomorphism(int n, double edge_probability)
 
     // Map is bijective if each vertex of the second graph occurs only once
     {
-      typedef typename graph_traits< graph2 >::vertex_descriptor vertex2_t;
+      typedef graph_traits< graph2 >::vertex_descriptor vertex2_t;
       std::set< vertex2_t > vertex_set;
 
       typedef iso_map::iterator map_iter;


### PR DESCRIPTION
Closes #203 by
- Adding doc regarding null vertices in isomorphism maps when single-vertex components are involved
- Ignoring `max_vertex_invariant` arg and cheaply determining it in `test_isomorphism` (and adapting doc accordingly)
- Corrects `UnaryFunction` concept requirement in doc
- Reserves space in evaluation of all vertex invariants at start of `test_isomorphism`
- Removes range requirements on vertex invariants, determines invariant multiplicities from existing sorted list of all invariants using `unordered_map`
- Adds a colored isomorphism test
- Maps unmapped vertices if isomorphism passes