### PR TITLE
Isomorphism docs: AdaptableUnaryFn, null vertices

### DIFF
--- a/doc/isomorphism.html
+++ b/doc/isomorphism.html
@@ -92,8 +92,9 @@ href="./VertexListGraph.html">Vertex List Graph</a>.
 
 OUT: <tt>isomorphism_map(IsoMap f)</tt>
 <blockquote>
-The mapping from vertices in graph 1 to vertices in graph 2. This must
-be a <a href="../../property_map/doc/ReadWritePropertyMap.html">Read/Write
+The mapping from vertices in graph 1 to vertices in graph 2. May contain <a
+href="Graph.h">null vertices</a> if both graphs contain single-vertex
+components. <tt>IsoMap</tt> must be a <a href="../../property_map/doc/ReadWritePropertyMap.html">Read/Write
 Property Map</a>.<br> <b>Default:</b> an <a
 href="../../property_map/doc/iterator_property_map.html"><tt>iterator_property_map</tt></a>
 constructed from a <tt>std::vector</tt> of graph 2's vertex
@@ -111,8 +112,8 @@ This mapping can be used either to speed up the search (as is done by the
 default value, which requires that the degrees of <i>v1</i> and <i>v2</i> are
 equal) or to impose extra conditions on the result.  The
 <tt>VertexInvariant1</tt> and <tt>VertexInvariant2</tt> types must model <a
-href="http://www.boost.org/sgi/stl/UnaryFunction.html">UnaryFunction</a>, with
-the argument type of <tt>vertex_invariant1</tt> being <tt>Graph1</tt>'s vertex
+href="http://www.boost.org/sgi/stl/AdaptableUnaryFunction.html">AdaptableUnaryFunction</a>,
+with the argument type of <tt>vertex_invariant1</tt> being <tt>Graph1</tt>'s vertex
 descriptor type, the argument type of <tt>vertex_invariant2</tt> being
 <tt>Graph2</tt>'s vertex descriptor type, and both functions having integral
 result types.  The values returned by these two functions must be in the range


### PR DESCRIPTION
Isomorphism docs
- The expected concept for invariant functors is AdaptableUnaryFunction,
  not UnaryFunction
- Null vertices can appear in the isomorphism map output if both graphs
  contain disconnected vertices, add a note to that parameter's
  documentation

Related to #203 