### PR TITLE
Isomorphism: Ignore vertex_max_invariant

### DIFF
--- a/doc/isomorphism.html
+++ b/doc/isomorphism.html
@@ -124,7 +124,8 @@ bound.
 
 IN: <tt>vertex_max_invariant(std::size_t max_invariant)</tt>
 <blockquote>
-This parameter is ignored.
+This parameter is ignored as it is no longer necessary, but kept for backwards
+compatibility.
 </blockquote>
 
 IN: <tt>vertex_index1_map(VertexIndex1Map i1_map)</tt>

--- a/doc/isomorphism.html
+++ b/doc/isomorphism.html
@@ -115,8 +115,8 @@ href="http://www.boost.org/sgi/stl/UnaryFunction.html">UnaryFunction</a>, with
 the argument type of <tt>vertex_invariant1</tt> being <tt>Graph1</tt>'s vertex
 descriptor type, the argument type of <tt>vertex_invariant2</tt> being
 <tt>Graph2</tt>'s vertex descriptor type, and both functions having integral
-result types.  The values returned by these two functions must be in the range
-[0, <tt>vertex_max_invariant</tt>).
+result types. The values returned by these two functions must have a low upper
+bound. 
 <br>
 <b>Default:</b> <tt>degree_vertex_invariant</tt> for both arguments<br>
 <b>Python</b>: Unsupported parameter.
@@ -124,14 +124,7 @@ result types.  The values returned by these two functions must be in the range
 
 IN: <tt>vertex_max_invariant(std::size_t max_invariant)</tt>
 <blockquote>
-An upper bound on the possible values returned from either
-vertex_invariant1 or vertex_invariant2.
-<br>
-<b>Default:</b> <tt>vertex_invariant2.max()</tt>. The default
-<tt>vertex_invariant2</tt> parameter, an instance of
-<tt>degree_vertex_invariant</tt>, defines this function to
-return <tt>num_vertices(g2) * (num_vertices(g2)+1)</tt>.<br>
-<b>Python</b>: Unsupported parameter.
+This parameter is ignored.
 </blockquote>
 
 IN: <tt>vertex_index1_map(VertexIndex1Map i1_map)</tt>

--- a/doc/isomorphism.html
+++ b/doc/isomorphism.html
@@ -116,7 +116,7 @@ the argument type of <tt>vertex_invariant1</tt> being <tt>Graph1</tt>'s vertex
 descriptor type, the argument type of <tt>vertex_invariant2</tt> being
 <tt>Graph2</tt>'s vertex descriptor type, and both functions having integral
 result types. The values returned by these two functions must have a low upper
-bound. 
+bound, as memory linear in the maximal invariant value is allocated.
 <br>
 <b>Default:</b> <tt>degree_vertex_invariant</tt> for both arguments<br>
 <b>Python</b>: Unsupported parameter.

--- a/include/boost/graph/isomorphism.hpp
+++ b/include/boost/graph/isomorphism.hpp
@@ -163,7 +163,7 @@ namespace detail
             BGL_FORALL_VERTICES_T(v, G1, Graph1)
             f[v] = graph_traits< Graph2 >::null_vertex();
 
-            std::size_t max_invariant;
+            std::size_t max_invariant = 0;
             {
                 std::vector< invar1_value > invar1_array;
                 invar1_array.reserve(num_vertices(G1));
@@ -179,7 +179,10 @@ namespace detail
                 if (!equal(invar1_array, invar2_array))
                     return false;
 
-                max_invariant = std::max(invar1_array.back(), invar2_array.back()) + 1;
+                if (!invar1_array.empty())
+                    max_invariant = invar1_array.back() + 1;
+                if (!invar2_array.empty())
+                    max_invariant = std::max(max_invariant, invar2_array.back() + 1);
             }
 
             std::vector< vertex1_t > V_mult;

--- a/include/boost/graph/isomorphism.hpp
+++ b/include/boost/graph/isomorphism.hpp
@@ -179,10 +179,9 @@ namespace detail
                 if (!equal(invar1_array, invar2_array))
                     return false;
 
-                if (!invar1_array.empty())
-                    max_invariant = invar1_array.back() + 1;
-                if (!invar2_array.empty())
-                    max_invariant = std::max(max_invariant, invar2_array.back() + 1);
+                // Empty graphs case is covered before test_isomorphism is called,
+                // so the invar?_arrays cannot be empty, so back() is safe
+                max_invariant = std::max(invar1_array.back(), invar2_array.back()) + 1;
             }
 
             std::vector< vertex1_t > V_mult;

--- a/include/boost/graph/isomorphism.hpp
+++ b/include/boost/graph/isomorphism.hpp
@@ -46,7 +46,6 @@ namespace detail
         IsoMapping f;
         Invariant1 invariant1;
         Invariant2 invariant2;
-        std::size_t max_invariant;
         IndexMap1 index_map1;
         IndexMap2 index_map2;
 
@@ -138,14 +137,13 @@ namespace detail
     public:
         isomorphism_algo(const Graph1& G1, const Graph2& G2, IsoMapping f,
             Invariant1 invariant1, Invariant2 invariant2,
-            std::size_t max_invariant, IndexMap1 index_map1,
+            std::size_t /* max_invariant */, IndexMap1 index_map1,
             IndexMap2 index_map2)
         : G1(G1)
         , G2(G2)
         , f(f)
         , invariant1(invariant1)
         , invariant2(invariant2)
-        , max_invariant(max_invariant)
         , index_map1(index_map1)
         , index_map2(index_map2)
         {
@@ -165,18 +163,23 @@ namespace detail
             BGL_FORALL_VERTICES_T(v, G1, Graph1)
             f[v] = graph_traits< Graph2 >::null_vertex();
 
+            std::size_t max_invariant;
             {
                 std::vector< invar1_value > invar1_array;
+                invar1_array.reserve(num_vertices(G1));
                 BGL_FORALL_VERTICES_T(v, G1, Graph1)
-                invar1_array.push_back(invariant1(v));
+                  invar1_array.push_back(invariant1(v));
                 sort(invar1_array);
 
                 std::vector< invar2_value > invar2_array;
+                invar2_array.reserve(num_vertices(G2));
                 BGL_FORALL_VERTICES_T(v, G2, Graph2)
-                invar2_array.push_back(invariant2(v));
+                  invar2_array.push_back(invariant2(v));
                 sort(invar2_array);
                 if (!equal(invar1_array, invar2_array))
                     return false;
+
+                max_invariant = std::max(invar1_array.back(), invar2_array.back()) + 1;
             }
 
             std::vector< vertex1_t > V_mult;
@@ -486,7 +489,7 @@ template < typename Graph1, typename Graph2, typename IsoMapping,
     typename Invariant1, typename Invariant2, typename IndexMap1,
     typename IndexMap2 >
 bool isomorphism(const Graph1& G1, const Graph2& G2, IsoMapping f,
-    Invariant1 invariant1, Invariant2 invariant2, std::size_t max_invariant,
+    Invariant1 invariant1, Invariant2 invariant2, std::size_t /* max_invariant */,
     IndexMap1 index_map1, IndexMap2 index_map2)
 
 {
@@ -527,7 +530,7 @@ bool isomorphism(const Graph1& G1, const Graph2& G2, IsoMapping f,
 
     detail::isomorphism_algo< Graph1, Graph2, IsoMapping, Invariant1,
         Invariant2, IndexMap1, IndexMap2 >
-        algo(G1, G2, f, invariant1, invariant2, max_invariant, index_map1,
+        algo(G1, G2, f, invariant1, invariant2, 0, index_map1,
             index_map2);
     return algo.test_isomorphism();
 }
@@ -574,8 +577,7 @@ namespace detail
         return isomorphism(G1, G2, f,
             choose_param(get_param(params, vertex_invariant1_t()), invariant1),
             choose_param(get_param(params, vertex_invariant2_t()), invariant2),
-            choose_param(get_param(params, vertex_max_invariant_t()),
-                (invariant2.max)()),
+            0,
             index_map1, index_map2);
     }
 
@@ -654,7 +656,7 @@ namespace graph
                         make_shared_array_property_map(
                             num_vertices(g1), vertex2_t(), index1_map)),
                     invariant1, invariant2,
-                    arg_pack[_vertex_max_invariant | (invariant2.max)()],
+                    0,
                     index1_map, index2_map);
             }
         };

--- a/include/boost/graph/isomorphism.hpp
+++ b/include/boost/graph/isomorphism.hpp
@@ -179,9 +179,10 @@ namespace detail
                 if (!equal(invar1_array, invar2_array))
                     return false;
 
-                // Empty graphs case is covered before test_isomorphism is called,
-                // so the invar?_arrays cannot be empty, so back() is safe
-                max_invariant = std::max(invar1_array.back(), invar2_array.back()) + 1;
+                // Empty graphs case is covered before test_isomorphism is
+                // called, so the invar?_arrays cannot be empty, so back() is
+                // safe. Also the two invariant arrays are equal:
+                max_invariant = invar1_array.back() + 1;
             }
 
             std::vector< vertex1_t > V_mult;

--- a/include/boost/graph/isomorphism.hpp
+++ b/include/boost/graph/isomorphism.hpp
@@ -182,7 +182,9 @@ namespace detail
                 // Empty graphs case is covered before test_isomorphism is
                 // called, so the invar?_arrays cannot be empty, so back() is
                 // safe. Also the two invariant arrays are equal:
-                max_invariant = invar1_array.back() + 1;
+                max_invariant = invar1_array.back();
+                assert(max_invariant != std::numeric_limits<std::size_t>::max());
+                max_invariant += 1;
             }
 
             std::vector< vertex1_t > V_mult;


### PR DESCRIPTION
Isomorphism: Ignore `vertex_max_invariant`
- `vertex_max_invariant` and `invariant2.max()` are misnomers since what is
  expected is an upper exclusive bound on the possible invariant values,
  not their maximum value.
- The parameter can be ignored and the upper exclusive bound found
  cheaply at the start of `test_isomorphism`
- Removes the additional requirement of a nullary `max` member function on
  `invariant2`

Related to #203 

If this PR is accepted, then the range requirement on vertex invariants can be removed entirely with another PR.