### PR TITLE
Isomorphism: Map disconnected vertices

### DIFF
--- a/doc/isomorphism.html
+++ b/doc/isomorphism.html
@@ -92,9 +92,8 @@ href="./VertexListGraph.html">Vertex List Graph</a>.
 
 OUT: <tt>isomorphism_map(IsoMap f)</tt>
 <blockquote>
-The mapping from vertices in graph 1 to vertices in graph 2. May contain <a
-href="Graph.h">null vertices</a> if both graphs contain single-vertex
-components. <tt>IsoMap</tt> must be a <a href="../../property_map/doc/ReadWritePropertyMap.html">Read/Write
+The mapping from vertices in graph 1 to vertices in graph 2. <tt>IsoMap</tt>
+must be a <a href="../../property_map/doc/ReadWritePropertyMap.html">Read/Write 
 Property Map</a>.<br> <b>Default:</b> an <a
 href="../../property_map/doc/iterator_property_map.html"><tt>iterator_property_map</tt></a>
 constructed from a <tt>std::vector</tt> of graph 2's vertex

--- a/include/boost/graph/isomorphism.hpp
+++ b/include/boost/graph/isomorphism.hpp
@@ -368,6 +368,8 @@ namespace detail
             {
             return_point_true:
                 {
+                    // At this point, there may still be null vertices in the 
+                    // mapping for disconnected vertices
                     std::vector< vertex1_t > unmatched_g1_vertices;
                     BGL_FORALL_VERTICES_T(v, G1, Graph1)
                     {
@@ -377,13 +379,13 @@ namespace detail
                     }
 
                     if(!unmatched_g1_vertices.empty()) {
-                        typedef unordered_multimap< invar2_value, vertex2_t > g2_invar_vertex_multimap;
-                        typedef typename g2_invar_vertex_multimap::iterator multimap_iter;
-                        g2_invar_vertex_multimap unmatched_invar_multimap;
+                        typedef unordered_multimap< invar2_value, vertex2_t > g2_invariant_vertex_multimap;
+                        typedef typename g2_invariant_vertex_multimap::iterator multimap_iter;
+                        g2_invariant_vertex_multimap unmatched_invariants;
                         BGL_FORALL_VERTICES_T(v, G2, Graph2)
                         {
                             if(!in_S[v]) {
-                                unmatched_invar_multimap.emplace(invariant2(v), v);
+                                unmatched_invariants.emplace(invariant2(v), v);
                             }
                         }
 
@@ -392,10 +394,10 @@ namespace detail
                         for(v1_iter iter = unmatched_g1_vertices.begin(); iter != end; ++iter)
                         {
                             invar1_value unmatched_g1_vertex_invariant = invariant1(*iter);
-                            multimap_iter matching_invar = unmatched_invar_multimap.find(unmatched_g1_vertex_invariant);
-                            BOOST_ASSERT(matching_invar != unmatched_invar_multimap.end());
-                            f[*iter] = matching_invar->second;
-                            unmatched_invar_multimap.erase(matching_invar);
+                            multimap_iter matching_invariant = unmatched_invariants.find(unmatched_g1_vertex_invariant);
+                            BOOST_ASSERT(matching_invariant != unmatched_invariants.end());
+                            f[*iter] = matching_invariant->second;
+                            unmatched_invariants.erase(matching_invariant);
                         }
                     }
                     return true;

--- a/include/boost/graph/isomorphism.hpp
+++ b/include/boost/graph/isomorphism.hpp
@@ -369,10 +369,8 @@ namespace detail
             return_point_true:
                 // At this point, there may still be null vertices in the 
                 // mapping for disconnected vertices
-                {
-                    map_disconnected_vertices();
-                    return true;
-                }
+                map_disconnected_vertices();
+                return true;
 
             return_point_false:
                 if (k.empty())

--- a/include/boost/graph/isomorphism.hpp
+++ b/include/boost/graph/isomorphism.hpp
@@ -367,39 +367,10 @@ namespace detail
 
             {
             return_point_true:
+                // At this point, there may still be null vertices in the 
+                // mapping for disconnected vertices
                 {
-                    // At this point, there may still be null vertices in the 
-                    // mapping for disconnected vertices
-                    std::vector< vertex1_t > unmatched_g1_vertices;
-                    BGL_FORALL_VERTICES_T(v, G1, Graph1)
-                    {
-                        if(f[v] == graph_traits< Graph2 >::null_vertex()) {
-                            unmatched_g1_vertices.push_back(v);
-                        }
-                    }
-
-                    if(!unmatched_g1_vertices.empty()) {
-                        typedef unordered_multimap< invar2_value, vertex2_t > g2_invariant_vertex_multimap;
-                        typedef typename g2_invariant_vertex_multimap::iterator multimap_iter;
-                        g2_invariant_vertex_multimap unmatched_invariants;
-                        BGL_FORALL_VERTICES_T(v, G2, Graph2)
-                        {
-                            if(!in_S[v]) {
-                                unmatched_invariants.emplace(invariant2(v), v);
-                            }
-                        }
-
-                        typedef typename std::vector< vertex1_t >::iterator v1_iter;
-                        const v1_iter end = unmatched_g1_vertices.end();
-                        for(v1_iter iter = unmatched_g1_vertices.begin(); iter != end; ++iter)
-                        {
-                            invar1_value unmatched_g1_vertex_invariant = invariant1(*iter);
-                            multimap_iter matching_invariant = unmatched_invariants.find(unmatched_g1_vertex_invariant);
-                            BOOST_ASSERT(matching_invariant != unmatched_invariants.end());
-                            f[*iter] = matching_invariant->second;
-                            unmatched_invariants.erase(matching_invariant);
-                        }
-                    }
+                    map_disconnected_vertices();
                     return true;
                 }
 
@@ -445,6 +416,40 @@ namespace detail
                     abort();
 #endif
                 }
+                }
+            }
+        }
+
+        void map_disconnected_vertices()
+        {
+            std::vector< vertex1_t > unmatched_g1_vertices;
+            BGL_FORALL_VERTICES_T(v, G1, Graph1)
+            {
+                if(f[v] == graph_traits< Graph2 >::null_vertex()) {
+                    unmatched_g1_vertices.push_back(v);
+                }
+            }
+
+            if(!unmatched_g1_vertices.empty()) {
+                typedef unordered_multimap< invar2_value, vertex2_t > g2_invariant_vertex_multimap;
+                typedef typename g2_invariant_vertex_multimap::iterator multimap_iter;
+                g2_invariant_vertex_multimap unmatched_invariants;
+                BGL_FORALL_VERTICES_T(v, G2, Graph2)
+                {
+                    if(!in_S[v]) {
+                        unmatched_invariants.emplace(invariant2(v), v);
+                    }
+                }
+
+                typedef typename std::vector< vertex1_t >::iterator v1_iter;
+                const v1_iter end = unmatched_g1_vertices.end();
+                for(v1_iter iter = unmatched_g1_vertices.begin(); iter != end; ++iter)
+                {
+                    invar1_value unmatched_g1_vertex_invariant = invariant1(*iter);
+                    multimap_iter matching_invariant = unmatched_invariants.find(unmatched_g1_vertex_invariant);
+                    BOOST_ASSERT(matching_invariant != unmatched_invariants.end());
+                    f[*iter] = matching_invariant->second;
+                    unmatched_invariants.erase(matching_invariant);
                 }
             }
         }

--- a/test/isomorphism.cpp
+++ b/test/isomorphism.cpp
@@ -57,7 +57,11 @@ template < typename Generator > struct random_functor
 #endif
 
 template < typename Graph1, typename Graph2 >
-void randomly_permute_graph(const Graph1& g1, Graph2& g2)
+std::map<
+    typename graph_traits< Graph1 >::vertex_descriptor,
+    typename graph_traits< Graph2 >::vertex_descriptor
+>
+randomly_permute_graph(const Graph1& g1, Graph2& g2)
 {
     // Need a clean graph to start with
     BOOST_TEST(num_vertices(g2) == 0);
@@ -93,6 +97,8 @@ void randomly_permute_graph(const Graph1& g1, Graph2& g2)
     {
         add_edge(vertex_map[source(*e, g1)], vertex_map[target(*e, g1)], g2);
     }
+
+    return vertex_map;
 }
 
 template < typename Graph >
@@ -243,11 +249,167 @@ void test_isomorphism(int n, double edge_probability)
     }
 }
 
+template<typename Graph>
+struct ColorFunctor {
+    typedef typename graph_traits< Graph >::vertex_descriptor argument_type;
+    typedef int result_type;
+
+    ColorFunctor(const Graph& g) : graph(g) {}
+
+    inline result_type operator() (argument_type v) const {
+        return get(vertex_color_t(), graph)(v);
+    }
+
+    inline result_type max() const {
+      result_type max_result = std::numeric_limits<result_type>::lowest();
+      typedef typename graph_traits< Graph >::vertex_iterator vertex_iter;
+      for(vertex_iter iter = vertices(graph).first; iter != vertices(graph).second; ++iter) {
+        max_result = std::max(max_result, this->operator()(*iter));
+      }
+      return max_result + 1;
+    }
+
+    const Graph& graph;
+};
+
+void test_colored_isomorphism(int n, double edge_probability)
+{
+    using namespace boost::graph::keywords;
+    typedef adjacency_list< vecS, vecS, bidirectionalS, property< vertex_color_t, int > > graph1;
+    typedef adjacency_list< listS, listS, bidirectionalS,
+        property< vertex_index_t, int, property< vertex_color_t, int >
+        >
+    > graph2;
+
+    typedef graph_traits< graph1 >::vertex_descriptor vertex1_t;
+    typedef graph_traits< graph2 >::vertex_descriptor vertex2_t;
+    typedef std::map< vertex1_t, vertex2_t > vertex_map_t;
+
+    graph1 g1(n);
+    generate_random_digraph(g1, edge_probability);
+
+    graph2 g2;
+    vertex_map_t vertex_map = randomly_permute_graph(g1, g2);
+
+    std::vector< int > colors(n);
+    typedef std::vector< int >::iterator colors_iter;
+    colors_iter midpoint = colors.begin() + n / 2;
+    std::fill(colors.begin(), midpoint, 0);
+    std::fill(midpoint, colors.end(), 1);
+
+    random_generator_type gen;
+
+#ifndef BOOST_NO_CXX98_RANDOM_SHUFFLE
+    random_functor< random_generator_type > rand_fun(gen);
+    std::random_shuffle(colors.begin(), colors.end(), rand_fun);
+#else
+    std::shuffle(colors.begin(), colors.end(), gen);
+#endif
+
+    int v_idx = 0;
+    for (graph1::vertex_iterator v = vertices(g1).first;
+         v != vertices(g1).second; ++v)
+    {
+        put(get(vertex_color_t(), g1), *v, colors[v_idx]);
+        put(get(vertex_color_t(), g2), vertex_map[*v], colors[v_idx]);
+        v_idx += 1;
+    }
+
+    v_idx = 0;
+    for (graph2::vertex_iterator v = vertices(g2).first;
+         v != vertices(g2).second; ++v)
+    {
+        put(get(vertex_index_t(), g2), *v, v_idx);
+        v_idx += 1;
+    }
+
+    typedef std::map< graph1::vertex_descriptor, graph2::vertex_descriptor > iso_map;
+    iso_map mapping;
+
+    bool isomorphism_correct;
+    clock_t start = clock();
+    BOOST_TEST(
+        isomorphism_correct = isomorphism(
+            g1,
+            g2,
+            isomorphism_map(make_assoc_property_map(mapping))
+            .vertex_invariant1(ColorFunctor<graph1>(g1))
+            .vertex_invariant2(ColorFunctor<graph2>(g2))
+        )
+    );
+    clock_t end = clock();
+
+    std::cout << "Elapsed time (clock cycles): " << (end - start) << std::endl;
+
+    bool verify_correct;
+    BOOST_TEST(verify_correct
+        = verify_isomorphism(g1, g2, make_assoc_property_map(mapping)));
+
+    if (!isomorphism_correct || !verify_correct)
+    {
+        // Output graph 1
+        {
+            std::ofstream out("colored_isomorphism_failure.bg1");
+            out << num_vertices(g1) << std::endl;
+            for (graph1::edge_iterator e = edges(g1).first;
+                 e != edges(g1).second; ++e)
+            {
+                out << get(vertex_index_t(), g1, source(*e, g1)) << ' '
+                    << get(vertex_index_t(), g1, target(*e, g1)) << std::endl;
+            }
+        }
+
+        // Output graph 2
+        {
+            std::ofstream out("colored_isomorphism_failure.bg2");
+            out << num_vertices(g2) << std::endl;
+            for (graph2::edge_iterator e = edges(g2).first;
+                 e != edges(g2).second; ++e)
+            {
+                out << get(vertex_index_t(), g2, source(*e, g2)) << ' '
+                    << get(vertex_index_t(), g2, target(*e, g2)) << std::endl;
+            }
+        }
+    }
+
+    bool map_contains_null_vertices = false;
+    {
+        typedef graph_traits< graph2 >::vertex_descriptor vertex2_t;
+        const vertex2_t g2_null_vertex = graph2::null_vertex();
+
+        typedef iso_map::iterator map_iter;
+        const map_iter end = mapping.end();
+        for(map_iter iter = mapping.begin(); iter != end; ++iter) {
+            if(iter->second == g2_null_vertex) {
+                map_contains_null_vertices = true;
+                break;
+            }
+        }
+    }
+
+    BOOST_TEST(!map_contains_null_vertices);
+
+    // Map is bijective if each vertex of the second graph occurs only once
+    {
+      typedef graph_traits< graph2 >::vertex_descriptor vertex2_t;
+      std::set< vertex2_t > vertex_set;
+
+      typedef iso_map::iterator map_iter;
+      const map_iter end = mapping.end();
+      for(map_iter iter = mapping.begin(); iter != end; ++iter) {
+        vertex_set.insert(iter->second);
+      }
+
+      BOOST_TEST(vertex_set.size() == mapping.size());
+    }
+}
+
 int main(int argc, char* argv[])
 {
     int n = argc < 3 ? 30 : boost::lexical_cast< int >(argv[1]);
     double edge_prob = argc < 3 ? 0.45 : boost::lexical_cast< double >(argv[2]);
     test_isomorphism(n, edge_prob);
+    test_colored_isomorphism(n, edge_prob);
 
     return boost::report_errors();
 }

--- a/test/isomorphism.cpp
+++ b/test/isomorphism.cpp
@@ -261,7 +261,7 @@ struct ColorFunctor {
     }
 
     inline result_type max() const {
-      result_type max_result = std::numeric_limits<result_type>::lowest();
+      result_type max_result = std::numeric_limits<result_type>::min();
       typedef typename graph_traits< Graph >::vertex_iterator vertex_iter;
       for(vertex_iter iter = vertices(graph).first; iter != vertices(graph).second; ++iter) {
         max_result = std::max(max_result, this->operator()(*iter));


### PR DESCRIPTION
Isomorphism: Map disconnected vertices
- Adds O(V) algorithm at `return_point_true` to match disconnected
  vertices in the isomorphism map
- Adds colored isomorphism test ensuring no null vertices are in the
  isomorphism map

Related to #203 