### PR TITLE
Typo fix in graph edge_coloring docs

### DIFF
--- a/doc/edge_coloring.html
+++ b/doc/edge_coloring.html
@@ -52,7 +52,7 @@ colors c<sub>1</sub>, c<sub>2</sub>, ..., c<sub>n</sub> in a way
 that no vertex connects with 2 edges of the same color. Furthermore
 at most m + 1 colors are used.
 
-<!-- King, I.P. An automatic reordering scheme for simultaneous equations derived from network analysis. Int. J. Numer. Methods Engrg. 2 (1970), 523-533 -->
+<!-- Misra, J., & Gries, D. (1992). A constructive proof of Vizing's theorem. In Information Processing Letters. -->
 
 <h3>Where defined</h3>
 <a href="../../../boost/graph/edge_coloring.hpp"><tt>boost/graph/edge_coloring.hpp</tt></a>
@@ -80,7 +80,7 @@ OUT: <tt>ColorMap color</tt>
 <h3>Example</h3>
 
 See <A
-href="../example/edge_coloring.cpp"><tt>example/king_ordering.cpp</tt></A>.
+href="../example/edge_coloring.cpp"><tt>example/edge_coloring.cpp</tt></A>.
 
 <h3>See Also</h3>
 


### PR DESCRIPTION
Closes #208 by:

* Changing `See example/king_ordering.cpp` to `See example/edge_coloring.cpp` in the **Example** section of the docs.
* Changing the comment `<!-- King, I.P. An automatic reordering scheme for simultaneous equations derived from network analysis. Int. J. Numer. Methods Engrg. 2 (1970), 523-533 -->` in  the HTML of the docs to `<!-- Misra, J., & Gries, D. (1992). A constructive proof of Vizing's theorem. In Information Processing Letters. -->`