### PR TITLE
Use BOOST_OVERRIDE

### DIFF
--- a/include/boost/graph/graphml.hpp
+++ b/include/boost/graph/graphml.hpp
@@ -18,7 +18,6 @@
 #include <boost/type_traits/is_convertible.hpp>
 #include <boost/graph/dll_import_export.hpp>
 #include <boost/graph/graphviz.hpp> // for exceptions
-#include <typeinfo>
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/vector.hpp>
 #include <boost/mpl/find.hpp>
@@ -27,6 +26,7 @@
 #include <boost/throw_exception.hpp>
 #include <exception>
 #include <sstream>
+#include <typeinfo>
 
 namespace boost
 {
@@ -41,8 +41,8 @@ struct BOOST_SYMBOL_VISIBLE parse_error : public graph_exception
         error = err;
         statement = "parse error: " + error;
     }
-    virtual ~parse_error() throw() {}
-    virtual const char* what() const throw() { return statement.c_str(); }
+    ~parse_error() throw() BOOST_OVERRIDE {}
+    const char* what() const throw() BOOST_OVERRIDE { return statement.c_str(); }
     std::string statement;
     std::string error;
 };
@@ -84,16 +84,16 @@ public:
     {
     }
 
-    bool is_directed() const
+    bool is_directed() const BOOST_OVERRIDE
     {
         return is_convertible<
             typename graph_traits< MutableGraph >::directed_category,
             directed_tag >::value;
     }
 
-    virtual any do_add_vertex() { return any(add_vertex(m_g)); }
+    any do_add_vertex() BOOST_OVERRIDE { return any(add_vertex(m_g)); }
 
-    virtual std::pair< any, bool > do_add_edge(any source, any target)
+    std::pair< any, bool > do_add_edge(any source, any target) BOOST_OVERRIDE
     {
         std::pair< edge_descriptor, bool > retval
             = add_edge(any_cast< vertex_descriptor >(source),
@@ -101,8 +101,8 @@ public:
         return std::make_pair(any(retval.first), retval.second);
     }
 
-    virtual void set_graph_property(const std::string& name,
-        const std::string& value, const std::string& value_type)
+    void set_graph_property(const std::string& name,
+        const std::string& value, const std::string& value_type) BOOST_OVERRIDE
     {
         bool type_found = false;
         try
@@ -123,8 +123,8 @@ public:
         }
     }
 
-    virtual void set_vertex_property(const std::string& name, any vertex,
-        const std::string& value, const std::string& value_type)
+    void set_vertex_property(const std::string& name, any vertex,
+        const std::string& value, const std::string& value_type) BOOST_OVERRIDE
     {
         bool type_found = false;
         try
@@ -146,8 +146,8 @@ public:
         }
     }
 
-    virtual void set_edge_property(const std::string& name, any edge,
-        const std::string& value, const std::string& value_type)
+    void set_edge_property(const std::string& name, any edge,
+        const std::string& value, const std::string& value_type) BOOST_OVERRIDE
     {
         bool type_found = false;
         try

--- a/include/boost/graph/graphviz.hpp
+++ b/include/boost/graph/graphviz.hpp
@@ -11,11 +11,11 @@
 #define BOOST_GRAPHVIZ_HPP
 
 #include <boost/config.hpp>
-#include <string>
-#include <map>
-#include <iostream>
+#include <cstdio> // for FILE
 #include <fstream>
-#include <stdio.h> // for FILE
+#include <iostream>
+#include <map>
+#include <string>
 #include <boost/property_map/property_map.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/graph/graph_traits.hpp>
@@ -651,8 +651,8 @@ void write_graphviz_dp(std::ostream& out, const Graph& g,
 /////////////////////////////////////////////////////////////////////////////
 struct BOOST_SYMBOL_VISIBLE graph_exception : public std::exception
 {
-    virtual ~graph_exception() throw() {}
-    virtual const char* what() const throw() = 0;
+    ~graph_exception() throw() BOOST_OVERRIDE {}
+    const char* what() const throw() BOOST_OVERRIDE = 0;
 };
 
 struct BOOST_SYMBOL_VISIBLE bad_parallel_edge : public graph_exception
@@ -665,8 +665,8 @@ struct BOOST_SYMBOL_VISIBLE bad_parallel_edge : public graph_exception
     {
     }
 
-    virtual ~bad_parallel_edge() throw() {}
-    const char* what() const throw()
+    ~bad_parallel_edge() throw() BOOST_OVERRIDE {}
+    const char* what() const throw() BOOST_OVERRIDE
     {
         if (statement.empty())
             statement = std::string("Failed to add parallel edge: (") + from
@@ -678,8 +678,8 @@ struct BOOST_SYMBOL_VISIBLE bad_parallel_edge : public graph_exception
 
 struct BOOST_SYMBOL_VISIBLE directed_graph_error : public graph_exception
 {
-    virtual ~directed_graph_error() throw() {}
-    virtual const char* what() const throw()
+    ~directed_graph_error() throw() BOOST_OVERRIDE {}
+    const char* what() const throw() BOOST_OVERRIDE
     {
         return "read_graphviz: "
                "Tried to read a directed graph into an undirected graph.";
@@ -688,8 +688,8 @@ struct BOOST_SYMBOL_VISIBLE directed_graph_error : public graph_exception
 
 struct BOOST_SYMBOL_VISIBLE undirected_graph_error : public graph_exception
 {
-    virtual ~undirected_graph_error() throw() {}
-    virtual const char* what() const throw()
+    ~undirected_graph_error() throw() BOOST_OVERRIDE {}
+    const char* what() const throw() BOOST_OVERRIDE
     {
         return "read_graphviz: "
                "Tried to read an undirected graph into a directed graph.";
@@ -700,8 +700,8 @@ struct BOOST_SYMBOL_VISIBLE bad_graphviz_syntax : public graph_exception
 {
     std::string errmsg;
     bad_graphviz_syntax(const std::string& errmsg) : errmsg(errmsg) {}
-    const char* what() const throw() { return errmsg.c_str(); }
-    ~bad_graphviz_syntax() throw() {};
+    const char* what() const throw() BOOST_OVERRIDE { return errmsg.c_str(); }
+    ~bad_graphviz_syntax() throw() BOOST_OVERRIDE {}
 };
 
 namespace detail
@@ -723,7 +723,7 @@ namespace detail
             {
                 static int idx = 0;
                 return edge_t(idx++);
-            };
+            }
 
             bool operator==(const edge_t& rhs) const
             {
@@ -774,9 +774,9 @@ namespace detail
             {
             }
 
-            ~mutate_graph_impl() {}
+            ~mutate_graph_impl() BOOST_OVERRIDE {}
 
-            bool is_directed() const
+            bool is_directed() const BOOST_OVERRIDE
             {
                 return boost::is_convertible<
                     typename boost::graph_traits<
@@ -784,7 +784,7 @@ namespace detail
                     boost::directed_tag >::value;
             }
 
-            virtual void do_add_vertex(const node_t& node)
+            void do_add_vertex(const node_t& node) BOOST_OVERRIDE
             {
                 // Add the node to the graph.
                 bgl_vertex_t v = add_vertex(graph_);
@@ -797,8 +797,8 @@ namespace detail
                 put(node_id_prop_, dp_, v, node);
             }
 
-            void do_add_edge(
-                const edge_t& edge, const node_t& source, const node_t& target)
+            void do_add_edge(const edge_t& edge, const node_t& source,
+                const node_t& target) BOOST_OVERRIDE
             {
                 std::pair< bgl_edge_t, bool > result
                     = add_edge(bgl_nodes[source], bgl_nodes[target], graph_);
@@ -814,25 +814,26 @@ namespace detail
                 }
             }
 
-            void set_node_property(
-                const id_t& key, const node_t& node, const id_t& value)
+            void set_node_property(const id_t& key, const node_t& node,
+                const id_t& value) BOOST_OVERRIDE
             {
                 put(key, dp_, bgl_nodes[node], value);
             }
 
-            void set_edge_property(
-                const id_t& key, const edge_t& edge, const id_t& value)
+            void set_edge_property(const id_t& key, const edge_t& edge,
+                const id_t& value) BOOST_OVERRIDE
             {
                 put(key, dp_, bgl_edges[edge], value);
             }
 
-            void set_graph_property(const id_t& key, const id_t& value)
+            void set_graph_property(const id_t& key,
+                const id_t& value) BOOST_OVERRIDE
             {
                 /* RG: pointer to graph prevents copying */
                 put(key, dp_, &graph_, value);
             }
 
-            void finish_building_graph() {}
+            void finish_building_graph() BOOST_OVERRIDE {}
 
         protected:
             MutableGraph& graph_;
@@ -869,9 +870,9 @@ namespace detail
             {
             }
 
-            ~mutate_graph_impl() {}
+            ~mutate_graph_impl() BOOST_OVERRIDE {}
 
-            void finish_building_graph()
+            void finish_building_graph() BOOST_OVERRIDE
             {
                 typedef compressed_sparse_row_graph< directedS, no_property,
                     bgl_edge_t, GraphProperty, Vertex, EdgeIndex >
@@ -902,14 +903,14 @@ namespace detail
                 }
             }
 
-            bool is_directed() const
+            bool is_directed() const BOOST_OVERRIDE
             {
                 return boost::is_convertible<
                     typename boost::graph_traits< CSRGraph >::directed_category,
                     boost::directed_tag >::value;
             }
 
-            virtual void do_add_vertex(const node_t& node)
+            void do_add_vertex(const node_t& node) BOOST_OVERRIDE
             {
                 // Add the node to the graph.
                 bgl_vertex_t v = vertex_count++;
@@ -923,8 +924,8 @@ namespace detail
                     boost::make_tuple(node_id_prop_, v, node));
             }
 
-            void do_add_edge(
-                const edge_t& edge, const node_t& source, const node_t& target)
+            void do_add_edge(const edge_t& edge, const node_t& source,
+                const node_t& target) BOOST_OVERRIDE
             {
                 bgl_edge_t result = edges_to_add.size();
                 edges_to_add.push_back(
@@ -932,21 +933,22 @@ namespace detail
                 bgl_edges.insert(std::make_pair(edge, result));
             }
 
-            void set_node_property(
-                const id_t& key, const node_t& node, const id_t& value)
+            void set_node_property(const id_t& key, const node_t& node,
+                const id_t& value) BOOST_OVERRIDE
             {
                 vertex_props.push_back(
                     boost::make_tuple(key, bgl_nodes[node], value));
             }
 
-            void set_edge_property(
-                const id_t& key, const edge_t& edge, const id_t& value)
+            void set_edge_property(const id_t& key, const edge_t& edge,
+                const id_t& value) BOOST_OVERRIDE
             {
                 edge_props.push_back(
                     boost::make_tuple(key, bgl_edges[edge], value));
             }
 
-            void set_graph_property(const id_t& key, const id_t& value)
+            void set_graph_property(const id_t& key,
+                const id_t& value) BOOST_OVERRIDE
             {
                 /* RG: pointer to graph prevents copying */
                 put(key, dp_, &graph_, value);

--- a/src/graphml.cpp
+++ b/src/graphml.cpp
@@ -18,6 +18,9 @@
 #include <boost/graph/dll_import_export.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/xml_parser.hpp>
+#include <map>
+#include <string>
+#include <vector>
 
 using namespace boost;
 
@@ -162,8 +165,8 @@ public:
                 std::string local_directed
                     = edge.second.get(path("<xmlattr>/directed"), "");
                 bool is_directed
-                    = (local_directed == "" ? default_directed
-                                            : local_directed == "true");
+                    = (local_directed.empty() ? default_directed
+                                              : local_directed == "true");
                 if (is_directed != m_g.is_directed())
                 {
                     if (is_directed)

--- a/src/read_graphviz_new.cpp
+++ b/src/read_graphviz_new.cpp
@@ -33,15 +33,15 @@
 #include <boost/graph/graph_traits.hpp>
 #include <boost/detail/workaround.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
+#include <cstdlib>
 #include <algorithm>
 #include <exception> // for std::exception
+#include <iostream>
+#include <map>
+#include <set>
 #include <string>
 #include <vector>
-#include <set>
 #include <utility>
-#include <map>
-#include <iostream>
-#include <cstdlib>
 #include <boost/throw_exception.hpp>
 #include <boost/regex.hpp>
 #include <boost/function.hpp>
@@ -827,7 +827,7 @@ namespace read_graphviz_detail
                 get();
                 if (peek().type != token::identifier)
                     error("Wanted identifier as port angle");
-                if (id.angle != "")
+                if (!id.angle.empty())
                     error("Duplicate port angle");
                 id.angle = get().normalized_value;
                 goto parse_more;


### PR DESCRIPTION
Use BOOST_OVERRIDE to fix GCC -Wsuggest-override and Clang-tidy modernize-use-override warnings.
Also fix Clang extra-semi, Clang-tidy modernize-deprecated-headers and readability-container-size-empty warnings.
Alphabetical order of C++ headers.