### PR TITLE
Add missing include

### DIFF
--- a/include/boost/graph/astar_search.hpp
+++ b/include/boost/graph/astar_search.hpp
@@ -15,6 +15,7 @@
 
 #include <functional>
 #include <vector>
+#include <boost/locale/definitions.hpp>
 #include <boost/limits.hpp>
 #include <boost/throw_exception.hpp>
 #include <boost/graph/named_function_params.hpp>


### PR DESCRIPTION
This patch makes the header able to be built standalone, making possible C++ clang modules builds.@vgvassilev