### PR TITLE
Add missing include

### DIFF
--- a/include/boost/graph/exception.hpp
+++ b/include/boost/graph/exception.hpp
@@ -12,6 +12,7 @@
 
 #include <stdexcept>
 #include <string>
+#include <boost/config.hpp>
 
 namespace boost
 {


### PR DESCRIPTION
This patch makes the header able to be built standalone, making possible C++ clang modules builds.@vgvassilev