### PR TITLE
Fix compilation on C++20 mode

### DIFF
--- a/include/boost/graph/transitive_closure.hpp
+++ b/include/boost/graph/transitive_closure.hpp
@@ -158,9 +158,16 @@ void transitive_closure(const Graph& g, GraphTC& tc,
                 {
                     chain.push_back(v);
                     in_a_chain[v] = true;
+
                     typename std::vector< cg_vertex >::const_iterator next
+                    #ifdef __cpp_lib_not_fn
                         = std::find_if(CG_vec[v].begin(), CG_vec[v].end(),
-                            std::not1(detail::subscript(in_a_chain)));
+                                       std::not_fn(detail::subscript(in_a_chain)));
+                    #else
+                        = std::find_if(CG_vec[v].begin(), CG_vec[v].end(),
+                                       std::not1(detail::subscript(in_a_chain)));
+                    #endif
+
                     if (next != CG_vec[v].end())
                         v = *next;
                     else


### PR DESCRIPTION
MSVC standard library has removed std::not1, thus use the boost alternative.