### PR TITLE
fix graph library user manual links

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -17,7 +17,7 @@
      alt="C++ Boost" width="277" height="86">
 
 <h1>The Boost Graph Library (BGL)
-<a href="http://www.awprofessional.com/title/0201729148">
+<a href="https://www.informit.com/store/boost-graph-library-user-guide-and-reference-manual-9780132651837">
 <img src="bgl-cover.jpg" alt="BGL Book" align="RIGHT"></a>
 </h1>
 

--- a/doc/table_of_contents.html
+++ b/doc/table_of_contents.html
@@ -17,7 +17,7 @@
      ALT="C++ Boost" width="277" height="86">
 
 <h1>Table of Contents: the Boost Graph Library
-<a href="http://www.awprofessional.com/title/0201729148">
+<a href="https://www.informit.com/store/boost-graph-library-user-guide-and-reference-manual-9780132651837">
 <img src="bgl-cover.jpg" ALT="BGL Book" ALIGN="RIGHT"></a>
 </h1>
 


### PR DESCRIPTION
The awprofessional link redirects to a generic page on informit.