### PR TITLE
[hawick] Support passing std::reference_wrapper to boost::hawick_circuits

### DIFF
--- a/doc/hawick_circuits.html
+++ b/doc/hawick_circuits.html
@@ -49,6 +49,10 @@ edges are not desired.</p>
 
   <p>For example, if a circuit <code>u -&gt; v -&gt; w -&gt; u</code> exists in the graph, the
   visitor will be called with a sequence consisting of <code>(u, v, w)</code>.</p>
+
+  Note that if <code>visitor</code> is a <code>std::reference_wrapper</code>,
+  it will be unwrapped before the <code>.cycle</code> method being called on it.
+  This allows passing a visitor that shouldn't be copied.
 </blockquote>
 
 <p><strong>IN:</strong> <code>VertexIndexMap const&amp; vim = get(vertex_index, graph)</code></p>

--- a/include/boost/graph/hawick_circuits.hpp
+++ b/include/boost/graph/hawick_circuits.hpp
@@ -21,6 +21,7 @@
 #include <boost/tuple/tuple.hpp> // for boost::tie
 #include <boost/type_traits/remove_reference.hpp>
 #include <boost/utility/result_of.hpp>
+#include <functional> // for std::reference_wrapper
 #include <set>
 #include <utility> // for std::pair
 #include <vector>
@@ -88,6 +89,18 @@ namespace hawick_circuits_detail
     {
         return std::find(boost::begin(c), boost::end(c), v) != boost::end(c);
     }
+
+    template < typename T >
+    struct unwrap_reference_wrapper {
+        typedef T type;
+    };
+
+#if __cplusplus >= 201103L
+    template < typename T >
+    struct unwrap_reference_wrapper<std::reference_wrapper<T> > {
+        typedef T& type;
+    };
+#endif
 
     /*!
      * @internal
@@ -301,8 +314,9 @@ namespace hawick_circuits_detail
 
         typedef std::vector< Vertex > Stack;
         typedef std::vector< std::vector< Vertex > > ClosedMatrix;
+        typedef typename unwrap_reference_wrapper<Visitor>::type VisitorNoRef;
 
-        typedef hawick_circuits_from< Graph, Visitor, VertexIndexMap, Stack,
+        typedef hawick_circuits_from< Graph, VisitorNoRef, VertexIndexMap, Stack,
             ClosedMatrix, GetAdjacentVertices >
             SubAlgorithm;
 


### PR DESCRIPTION
Reported as ldionne/hawick_circuits#1.