### PR TITLE
Convert the few remaining tests to use the header-only Lightweight Test

### DIFF
--- a/example/graphviz.cpp
+++ b/example/graphviz.cpp
@@ -7,7 +7,7 @@
 // Author: Douglas Gregor
 #include <boost/graph/graphviz.hpp>
 #include <boost/graph/adjacency_list.hpp>
-#include <boost/test/minimal.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <string>
 #include <fstream>
 #include <boost/graph/iteration_macros.hpp>
@@ -25,16 +25,18 @@ typedef boost::adjacency_list< vecS, vecS, undirectedS,
 void test_graph_read_write(const std::string& filename)
 {
     std::ifstream in(filename.c_str());
-    BOOST_REQUIRE(in);
+    if (!BOOST_TEST(in)) {
+        return;
+    }
 
     Graph g;
     dynamic_properties dp;
     dp.property("id", get(vertex_name, g));
     dp.property("weight", get(edge_weight, g));
-    BOOST_CHECK(read_graphviz(in, g, dp, "id"));
+    BOOST_TEST(read_graphviz(in, g, dp, "id"));
 
-    BOOST_CHECK(num_vertices(g) == 4);
-    BOOST_CHECK(num_edges(g) == 4);
+    BOOST_TEST(num_vertices(g) == 4);
+    BOOST_TEST(num_edges(g) == 4);
 
     typedef graph_traits< Graph >::vertex_descriptor Vertex;
 
@@ -43,27 +45,27 @@ void test_graph_read_write(const std::string& filename)
     name_to_vertex[get(vertex_name, g, v)] = v;
 
     // Check vertices
-    BOOST_CHECK(name_to_vertex.find("0") != name_to_vertex.end());
-    BOOST_CHECK(name_to_vertex.find("1") != name_to_vertex.end());
-    BOOST_CHECK(name_to_vertex.find("foo") != name_to_vertex.end());
-    BOOST_CHECK(name_to_vertex.find("bar") != name_to_vertex.end());
+    BOOST_TEST(name_to_vertex.find("0") != name_to_vertex.end());
+    BOOST_TEST(name_to_vertex.find("1") != name_to_vertex.end());
+    BOOST_TEST(name_to_vertex.find("foo") != name_to_vertex.end());
+    BOOST_TEST(name_to_vertex.find("bar") != name_to_vertex.end());
 
     // Check edges
-    BOOST_CHECK(edge(name_to_vertex["0"], name_to_vertex["1"], g).second);
-    BOOST_CHECK(edge(name_to_vertex["1"], name_to_vertex["foo"], g).second);
-    BOOST_CHECK(edge(name_to_vertex["foo"], name_to_vertex["bar"], g).second);
-    BOOST_CHECK(edge(name_to_vertex["1"], name_to_vertex["bar"], g).second);
+    BOOST_TEST(edge(name_to_vertex["0"], name_to_vertex["1"], g).second);
+    BOOST_TEST(edge(name_to_vertex["1"], name_to_vertex["foo"], g).second);
+    BOOST_TEST(edge(name_to_vertex["foo"], name_to_vertex["bar"], g).second);
+    BOOST_TEST(edge(name_to_vertex["1"], name_to_vertex["bar"], g).second);
 
-    BOOST_CHECK(get(edge_weight, g,
+    BOOST_TEST(get(edge_weight, g,
                     edge(name_to_vertex["0"], name_to_vertex["1"], g).first)
         == 3.14159);
-    BOOST_CHECK(get(edge_weight, g,
+    BOOST_TEST(get(edge_weight, g,
                     edge(name_to_vertex["1"], name_to_vertex["foo"], g).first)
         == 2.71828);
-    BOOST_CHECK(get(edge_weight, g,
+    BOOST_TEST(get(edge_weight, g,
                     edge(name_to_vertex["foo"], name_to_vertex["bar"], g).first)
         == 10.0);
-    BOOST_CHECK(get(edge_weight, g,
+    BOOST_TEST(get(edge_weight, g,
                     edge(name_to_vertex["1"], name_to_vertex["bar"], g).first)
         == 10.0);
 
@@ -71,9 +73,9 @@ void test_graph_read_write(const std::string& filename)
     write_graphviz_dp(std::cout, g, dp, std::string("id"));
 }
 
-int test_main(int argc, char* argv[])
+int main(int argc, char* argv[])
 {
     test_graph_read_write(argc >= 2 ? argv[1] : "graphviz_example.dot");
 
-    return 0;
+    return boost::report_errors();
 }

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -70,7 +70,6 @@ alias graph_test_regular :
     [ run graph.cpp : : : <define>TEST=9 : graph_9 ]
     [ compile graph_concepts.cpp ]
     [ run graphviz_test.cpp
-            /boost/test//boost_test_exec_monitor/<link>static
             ../build//boost_graph
             ../../regex/build//boost_regex : --log_level=all ]
     [ run metis_test.cpp : $(METIS_INPUT_FILE) ]
@@ -87,7 +86,7 @@ alias graph_test_regular :
     # TODO: Merge these into a single test framework.
     [ run subgraph.cpp ]
     [ run subgraph_bundled.cpp ]
-    [ run subgraph_add.cpp ../../test/build//boost_unit_test_framework/<link>static : $(TEST_DIR) ]
+    [ run subgraph_add.cpp : $(TEST_DIR) ]
     [ run subgraph_props.cpp ]
 
     [ run isomorphism.cpp ]
@@ -143,17 +142,17 @@ alias graph_test_regular :
     [ run random_spanning_tree_test.cpp ../build//boost_graph ]
     [ run random_matching_test.cpp : 1000 1020 ]
     [ run graphml_test.cpp ../build//boost_graph : : "graphml_test.xml" ]
-    [ run mas_test.cpp ../../test/build//boost_unit_test_framework/<link>static : $(TEST_DIR) ]
-    [ run stoer_wagner_test.cpp ../../test/build//boost_unit_test_framework/<link>static : $(TEST_DIR) ]
+    [ run mas_test.cpp : $(TEST_DIR) ]
+    [ run stoer_wagner_test.cpp : $(TEST_DIR) ]
     [ compile filtered_graph_properties_dijkstra.cpp ]
     [ run vf2_sub_graph_iso_test.cpp ]
     [ run vf2_sub_graph_iso_test_2.cpp ]
     [ run hawick_circuits.cpp ]
-    [ run successive_shortest_path_nonnegative_weights_test.cpp ../../test/build//boost_unit_test_framework/<link>static ]
-    [ run cycle_canceling_test.cpp ../../test/build//boost_unit_test_framework/<link>static ]
+    [ run successive_shortest_path_nonnegative_weights_test.cpp ]
+    [ run cycle_canceling_test.cpp ]
     [ run strong_components_test.cpp ]
-    [ run find_flow_cost_bundled_properties_and_named_params_test.cpp ../../test/build//boost_unit_test_framework/<link>static ]
-    [ run max_flow_algorithms_bundled_properties_and_named_params.cpp ../../test/build//boost_unit_test_framework/<link>static ]
+    [ run find_flow_cost_bundled_properties_and_named_params_test.cpp ]
+    [ run max_flow_algorithms_bundled_properties_and_named_params.cpp ]
     [ run delete_edge.cpp ]
     [ run johnson-test.cpp ]
     [ run lvalue_pmap.cpp ]

--- a/test/cycle_canceling_test.cpp
+++ b/test/cycle_canceling_test.cpp
@@ -7,16 +7,14 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 //=======================================================================
 
-#define BOOST_TEST_MODULE cycle_canceling_test
-
-#include <boost/test/unit_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #include <boost/graph/cycle_canceling.hpp>
 #include <boost/graph/edmonds_karp_max_flow.hpp>
 
 #include "min_cost_max_flow_utils.hpp"
 
-BOOST_AUTO_TEST_CASE(cycle_canceling_def_test)
+void cycle_canceling_def_test()
 {
     boost::SampleGraph::vertex_descriptor s, t;
     boost::SampleGraph::Graph g;
@@ -26,10 +24,10 @@ BOOST_AUTO_TEST_CASE(cycle_canceling_def_test)
     boost::cycle_canceling(g);
 
     int cost = boost::find_flow_cost(g);
-    BOOST_CHECK_EQUAL(cost, 29);
+    BOOST_TEST_EQ(cost, 29);
 }
 
-BOOST_AUTO_TEST_CASE(path_augmentation_def_test2)
+void path_augmentation_def_test2()
 {
     boost::SampleGraph::vertex_descriptor s, t;
     boost::SampleGraph::Graph g;
@@ -39,10 +37,10 @@ BOOST_AUTO_TEST_CASE(path_augmentation_def_test2)
     boost::cycle_canceling(g);
 
     int cost = boost::find_flow_cost(g);
-    BOOST_CHECK_EQUAL(cost, 7);
+    BOOST_TEST_EQ(cost, 7);
 }
 
-BOOST_AUTO_TEST_CASE(cycle_canceling_test)
+void cycle_canceling_test()
 {
     boost::SampleGraph::vertex_descriptor s, t;
     typedef boost::SampleGraph::Graph Graph;
@@ -66,5 +64,13 @@ BOOST_AUTO_TEST_CASE(cycle_canceling_test)
             .vertex_index_map(idx));
 
     int cost = boost::find_flow_cost(g);
-    BOOST_CHECK_EQUAL(cost, 29);
+    BOOST_TEST_EQ(cost, 29);
+}
+
+int main()
+{
+    cycle_canceling_def_test();
+    path_augmentation_def_test2();
+    cycle_canceling_test();
+    return boost::report_errors();
 }

--- a/test/find_flow_cost_bundled_properties_and_named_params_test.cpp
+++ b/test/find_flow_cost_bundled_properties_and_named_params_test.cpp
@@ -1,7 +1,4 @@
-#define BOOST_TEST_MODULE \
-    find_flow_cost_bundled_properties_and_named_params_test
-
-#include <boost/test/unit_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/graph/successive_shortest_path_nonnegative_weights.hpp>
 #include <boost/graph/find_flow_cost.hpp>
 #include "min_cost_max_flow_utils.hpp"
@@ -29,7 +26,7 @@ typedef boost::adjacency_list< boost::listS, boost::vecS, boost::directedS,
 
 // Unit test written in order to fails (at compile time) if the find_flow_cost()
 // is not properly handling bundled properties
-BOOST_AUTO_TEST_CASE(using_bundled_properties_with_find_max_flow_test)
+void using_bundled_properties_with_find_max_flow_test()
 {
     Graph g;
     traits::vertex_descriptor s, t;
@@ -59,13 +56,12 @@ BOOST_AUTO_TEST_CASE(using_bundled_properties_with_find_max_flow_test)
 
     // The "bundled properties" version (producing errors)
     int flow_cost = boost::find_flow_cost(g, capacity, residual_capacity, cost);
-    BOOST_CHECK_EQUAL(flow_cost, 29);
+    BOOST_TEST_EQ(flow_cost, 29);
 }
 
 // Unit test written in order to fails (at compile time) if the find_flow_cost()
 // is not properly handling bundled properties
-BOOST_AUTO_TEST_CASE(
-    using_named_params_and_bundled_properties_with_find_max_flow_test)
+void using_named_params_and_bundled_properties_with_find_max_flow_test()
 {
     Graph g;
     traits::vertex_descriptor s, t;
@@ -99,5 +95,12 @@ BOOST_AUTO_TEST_CASE(
         boost::capacity_map(capacity)
             .residual_capacity_map(residual_capacity)
             .weight_map(cost));
-    BOOST_CHECK_EQUAL(flow_cost, 29);
+    BOOST_TEST_EQ(flow_cost, 29);
+}
+
+int main()
+{
+    using_bundled_properties_with_find_max_flow_test();
+    using_named_params_and_bundled_properties_with_find_max_flow_test();
+    return boost::report_errors();
 }

--- a/test/graphviz_test.cpp
+++ b/test/graphviz_test.cpp
@@ -12,7 +12,6 @@
 // Author: Ronald Garcia
 
 #define BOOST_GRAPHVIZ_USE_ISTREAM
-#define BOOST_TEST_MODULE TestGraphviz
 #include <boost/regex.hpp>
 #include <boost/graph/graphviz.hpp>
 #include <boost/assign/std/map.hpp>
@@ -21,15 +20,29 @@
 #include <boost/graph/graph_traits.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/property_map/dynamic_property_map.hpp>
-#include <boost/test/test_tools.hpp>
-#include <boost/test/unit_test.hpp>
-#include <boost/test/floating_point_comparison.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <algorithm>
 #include <string>
 #include <iostream>
 #include <iterator>
 #include <map>
 #include <utility>
+#include <cmath>
+
+template<class T>
+class close_to {
+public:
+    explicit close_to(T f)
+        : f_(f) { }
+
+    bool operator()(T l, T r) const {
+        return std::abs(l - r) <=
+            (std::max)(f_ * (std::max)(std::abs(l), std::abs(r)), T());
+    }
+
+private:
+    T f_;
+};
 
 using namespace std;
 using namespace boost;
@@ -92,7 +105,7 @@ bool test_graph(std::istream& dotfile, graph_t& graph,
     {
 #endif
         // check correct vertex count
-        BOOST_CHECK_EQUAL(num_vertices(graph), correct_num_vertices);
+        BOOST_TEST_EQ(num_vertices(graph), correct_num_vertices);
         // check masses
         if (!masses.empty())
         {
@@ -105,10 +118,10 @@ bool test_graph(std::istream& dotfile, graph_t& graph,
                 std::string node_name = get(name, *i);
                 //  - get its mass
                 float node_mass = get(mass, *i);
-                BOOST_CHECK(masses.find(node_name) != masses.end());
+                BOOST_TEST(masses.find(node_name) != masses.end());
                 float ref_mass = masses.find(node_name)->second;
                 //  - compare the mass to the result in the table
-                BOOST_CHECK_CLOSE(node_mass, ref_mass, 0.01f);
+                BOOST_TEST_WITH(node_mass, ref_mass, close_to<float>(0.01f));
             }
         }
         // check weights
@@ -124,16 +137,16 @@ bool test_graph(std::istream& dotfile, graph_t& graph,
                     get(name, source(*i, graph)), get(name, target(*i, graph)));
                 // - get its weight
                 double edge_weight = get(weight, *i);
-                BOOST_CHECK(weights.find(edge_name) != weights.end());
+                BOOST_TEST(weights.find(edge_name) != weights.end());
                 double ref_weight = weights.find(edge_name)->second;
                 // - compare the weight to teh result in the table
-                BOOST_CHECK_CLOSE(edge_weight, ref_weight, 0.01);
+                BOOST_TEST_WITH(edge_weight, ref_weight, close_to<double>(0.01));
             }
         }
         if (!g_name.empty())
         {
             std::string parsed_name = get_property(graph, graph_name);
-            BOOST_CHECK(parsed_name == g_name);
+            BOOST_TEST(parsed_name == g_name);
         }
     }
     else
@@ -166,27 +179,27 @@ struct edge_p_bundled
 };
 
 // Basic directed graph tests
-BOOST_AUTO_TEST_CASE(basic_directed_graph_1)
+void test_basic_directed_graph_1()
 {
     mass_map_t masses;
     insert(masses)("a", 0.0f)("c", 7.7f)("e", 6.66f);
     gs_t gs("digraph { a  node [mass = 7.7] c e [mass = 6.66] }");
     typedef adjacency_list< vecS, vecS, directedS, vertex_p, edge_p, graph_p >
         graph_t;
-    BOOST_CHECK((test_graph< graph_t >(gs, 3, masses, weight_map_t())));
+    BOOST_TEST((test_graph< graph_t >(gs, 3, masses, weight_map_t())));
 }
 
-BOOST_AUTO_TEST_CASE(basic_directed_graph_2)
+void test_basic_directed_graph_2()
 {
     mass_map_t masses;
     insert(masses)("a", 0.0f)("e", 6.66f);
     gs_t gs("digraph { a  node [mass = 7.7] \"a\" e [mass = 6.66] }");
     typedef adjacency_list< vecS, vecS, directedS, vertex_p, edge_p, graph_p >
         graph_t;
-    BOOST_CHECK((test_graph< graph_t >(gs, 2, masses, weight_map_t())));
+    BOOST_TEST((test_graph< graph_t >(gs, 2, masses, weight_map_t())));
 }
 
-BOOST_AUTO_TEST_CASE(basic_directed_graph_3)
+void test_basic_directed_graph_3()
 {
     weight_map_t weights;
     insert(weights)(make_pair("a", "b"), 0.0)(make_pair("c", "d"), 7.7)(
@@ -197,33 +210,33 @@ BOOST_AUTO_TEST_CASE(basic_directed_graph_3)
             "d ->e->a [weight=.5]}");
     typedef adjacency_list< vecS, vecS, directedS, vertex_p, edge_p, graph_p >
         graph_t;
-    BOOST_CHECK((test_graph< graph_t >(gs, 6, mass_map_t(), weights)));
+    BOOST_TEST((test_graph< graph_t >(gs, 6, mass_map_t(), weights)));
 }
 
 // undirected graph with alternate node_id property name
-BOOST_AUTO_TEST_CASE(undirected_graph_alternate_node_id)
+void test_undirected_graph_alternate_node_id()
 {
     mass_map_t masses;
     insert(masses)("a", 0.0f)("c", 7.7f)("e", 6.66f);
     gs_t gs("graph { a  node [mass = 7.7] c e [mass = 6.66] }");
     typedef adjacency_list< vecS, vecS, undirectedS, vertex_p, edge_p, graph_p >
         graph_t;
-    BOOST_CHECK(
+    BOOST_TEST(
         (test_graph< graph_t >(gs, 3, masses, weight_map_t(), "nodenames")));
 }
 
 // Basic undirected graph tests
-BOOST_AUTO_TEST_CASE(basic_undirected_graph_1)
+void test_basic_undirected_graph_1()
 {
     mass_map_t masses;
     insert(masses)("a", 0.0f)("c", 7.7f)("e", 6.66f);
     gs_t gs("graph { a  node [mass = 7.7] c e [mass =\\\n6.66] }");
     typedef adjacency_list< vecS, vecS, undirectedS, vertex_p, edge_p, graph_p >
         graph_t;
-    BOOST_CHECK((test_graph< graph_t >(gs, 3, masses, weight_map_t())));
+    BOOST_TEST((test_graph< graph_t >(gs, 3, masses, weight_map_t())));
 }
 
-BOOST_AUTO_TEST_CASE(basic_undirected_graph_2)
+void test_basic_undirected_graph_2()
 {
     weight_map_t weights;
     insert(weights)(make_pair("a", "b"), 0.0)(make_pair("c", "d"), 7.7)(
@@ -232,11 +245,11 @@ BOOST_AUTO_TEST_CASE(basic_undirected_graph_2)
             "c -- d e -- f [weight = 6.66] }");
     typedef adjacency_list< vecS, vecS, undirectedS, vertex_p, edge_p, graph_p >
         graph_t;
-    BOOST_CHECK((test_graph< graph_t >(gs, 6, mass_map_t(), weights)));
+    BOOST_TEST((test_graph< graph_t >(gs, 6, mass_map_t(), weights)));
 }
 
 // Mismatch directed graph test
-BOOST_AUTO_TEST_CASE(mismatch_directed_graph)
+void test_mismatch_directed_graph()
 {
     mass_map_t masses;
     insert(masses)("a", 0.0f)("c", 7.7f)("e", 6.66f);
@@ -260,7 +273,7 @@ BOOST_AUTO_TEST_CASE(mismatch_directed_graph)
 }
 
 // Mismatch undirected graph test
-BOOST_AUTO_TEST_CASE(mismatch_undirected_graph)
+void test_mismatch_undirected_graph()
 {
     mass_map_t masses;
     insert(masses)("a", 0.0f)("c", 7.7f)("e", 6.66f);
@@ -279,9 +292,8 @@ BOOST_AUTO_TEST_CASE(mismatch_undirected_graph)
 }
 
 // Complain about parallel edges
-BOOST_AUTO_TEST_CASE(complain_about_parallel_edges)
+void test_complain_about_parallel_edges()
 {
-    BOOST_TEST_CHECKPOINT("Complain about parallel edges");
     weight_map_t weights;
     insert(weights)(make_pair("a", "b"), 7.7);
     gs_t gs("diGraph { a -> b [weight = 7.7]  a -> b [weight = 7.7] }");
@@ -299,18 +311,18 @@ BOOST_AUTO_TEST_CASE(complain_about_parallel_edges)
 }
 
 // Handle parallel edges gracefully
-BOOST_AUTO_TEST_CASE(handle_parallel_edges_gracefully)
+void test_handle_parallel_edges_gracefully()
 {
     weight_map_t weights;
     insert(weights)(make_pair("a", "b"), 7.7);
     gs_t gs("digraph { a -> b [weight = 7.7]  a -> b [weight = 7.7] }");
     typedef adjacency_list< vecS, vecS, directedS, vertex_p, edge_p, graph_p >
         graph_t;
-    BOOST_CHECK((test_graph< graph_t >(gs, 2, mass_map_t(), weights)));
+    BOOST_TEST((test_graph< graph_t >(gs, 2, mass_map_t(), weights)));
 }
 
 // Graph Property Test 1
-BOOST_AUTO_TEST_CASE(graph_property_test_1)
+void test_graph_property_test_1()
 {
     mass_map_t masses;
     insert(masses)("a", 0.0f)("c", 0.0f)("e", 6.66f);
@@ -319,12 +331,12 @@ BOOST_AUTO_TEST_CASE(graph_property_test_1)
     std::string graph_name("foo \"escaped\"");
     typedef adjacency_list< vecS, vecS, directedS, vertex_p, edge_p, graph_p >
         graph_t;
-    BOOST_CHECK(
+    BOOST_TEST(
         (test_graph< graph_t >(gs, 3, masses, weight_map_t(), "", graph_name)));
 }
 
 // Graph Property Test 2
-BOOST_AUTO_TEST_CASE(graph_property_test_2)
+void test_graph_property_test_2()
 {
     mass_map_t masses;
     insert(masses)("a", 0.0f)("c", 0.0f)("e", 6.66f);
@@ -332,12 +344,12 @@ BOOST_AUTO_TEST_CASE(graph_property_test_2)
     std::string graph_name("foo");
     typedef adjacency_list< vecS, vecS, directedS, vertex_p, edge_p, graph_p >
         graph_t;
-    BOOST_CHECK(
+    BOOST_TEST(
         (test_graph< graph_t >(gs, 3, masses, weight_map_t(), "", graph_name)));
 }
 
 // Graph Property Test 3 (HTML)
-BOOST_AUTO_TEST_CASE(graph_property_test_3)
+void test_graph_property_test_3()
 {
     mass_map_t masses;
     insert(masses)("a", 0.0f)("c", 0.0f)("e", 6.66f);
@@ -347,12 +359,12 @@ BOOST_AUTO_TEST_CASE(graph_property_test_3)
     gs_t gs("digraph { name=" + graph_name + "  a  c e [mass = 6.66] }");
     typedef adjacency_list< vecS, vecS, directedS, vertex_p, edge_p, graph_p >
         graph_t;
-    BOOST_CHECK(
+    BOOST_TEST(
         (test_graph< graph_t >(gs, 3, masses, weight_map_t(), "", graph_name)));
 }
 
 // Comments embedded in strings
-BOOST_AUTO_TEST_CASE(comments_embedded_in_strings)
+void test_comments_embedded_in_strings()
 {
     gs_t gs("digraph { "
             "a0 [ label = \"//depot/path/to/file_14#4\" ];"
@@ -361,11 +373,11 @@ BOOST_AUTO_TEST_CASE(comments_embedded_in_strings)
             "}");
     typedef adjacency_list< vecS, vecS, directedS, vertex_p, edge_p, graph_p >
         graph_t;
-    BOOST_CHECK((test_graph< graph_t >(gs, 2, mass_map_t(), weight_map_t())));
+    BOOST_TEST((test_graph< graph_t >(gs, 2, mass_map_t(), weight_map_t())));
 }
 
 #if 0 // Currently broken
-  BOOST_AUTO_TEST_CASE (basic_csr_directed_graph) {
+  void test_basic_csr_directed_graph() {
     weight_map_t weights;
     insert( weights )(make_pair("a","b"),0.0)
       (make_pair("c","d"),7.7)(make_pair("e","f"),6.66)
@@ -374,11 +386,11 @@ BOOST_AUTO_TEST_CASE(comments_embedded_in_strings)
             "c -> d e-> f [weight = 6.66] "
             "d ->e->a [weight=.5]}");
     typedef compressed_sparse_row_graph<directedS, vertex_p_bundled, edge_p_bundled, graph_p > graph_t;
-    BOOST_CHECK((test_graph<graph_t>(gs,6,mass_map_t(),weights,"node_id","",&vertex_p_bundled::name,&vertex_p_bundled::color,&edge_p_bundled::weight)));
+    BOOST_TEST((test_graph<graph_t>(gs,6,mass_map_t(),weights,"node_id","",&vertex_p_bundled::name,&vertex_p_bundled::color,&edge_p_bundled::weight)));
   }
 #endif
 
-BOOST_AUTO_TEST_CASE(basic_csr_directed_graph_ext_props)
+void test_basic_csr_directed_graph_ext_props()
 {
     weight_map_t weights;
     insert(weights)(make_pair("a", "b"), 0.0)(make_pair("c", "d"), 7.7)(
@@ -400,9 +412,26 @@ BOOST_AUTO_TEST_CASE(basic_csr_directed_graph_ext_props)
     vector_property_map< double,
         property_map< graph_t, edge_index_t >::const_type >
         edge_weight(get(edge_index, g));
-    BOOST_CHECK((test_graph(gs, g, 6, mass_map_t(), weights, "node_id", "",
+    BOOST_TEST((test_graph(gs, g, 6, mass_map_t(), weights, "node_id", "",
         vertex_name, vertex_color, edge_weight)));
 }
 
-// return 0;
-// }
+int main()
+{
+    test_basic_directed_graph_1();
+    test_basic_directed_graph_2();
+    test_basic_directed_graph_3();
+    test_undirected_graph_alternate_node_id();
+    test_basic_undirected_graph_1();
+    test_basic_undirected_graph_2();
+    test_mismatch_directed_graph();
+    test_mismatch_undirected_graph();
+    test_complain_about_parallel_edges();
+    test_handle_parallel_edges_gracefully();
+    test_graph_property_test_1();
+    test_graph_property_test_2();
+    test_graph_property_test_3();
+    test_comments_embedded_in_strings();
+    test_basic_csr_directed_graph_ext_props();
+    return boost::report_errors();
+}

--- a/test/mas_test.cpp
+++ b/test/mas_test.cpp
@@ -18,7 +18,7 @@
 #include <boost/graph/visitors.hpp>
 #include <boost/graph/property_maps/constant_property_map.hpp>
 #include <boost/property_map/property_map.hpp>
-#include <boost/test/unit_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/tuple/tuple_comparison.hpp>
 #include <boost/tuple/tuple_io.hpp>
@@ -36,19 +36,6 @@ typedef boost::adjacency_list< boost::vecS, boost::vecS, boost::undirectedS >
     undirected_unweighted_graph;
 
 std::string test_dir;
-
-boost::unit_test::test_suite* init_unit_test_suite(int argc, char* argv[])
-{
-    if (argc != 2)
-    {
-        std::cerr << "Usage: " << argv[0] << " path-to-libs-graph-test"
-                  << std::endl;
-        throw boost::unit_test::framework::setup_error(
-            "Invalid command line arguments");
-    }
-    test_dir = argv[1];
-    return 0;
-}
 
 struct edge_t
 {
@@ -111,7 +98,7 @@ private:
 // Check various implementations of the ArgPack where
 // the weights are provided in it, and one case where
 // they are not.
-BOOST_AUTO_TEST_CASE(test0)
+void test0()
 {
     typedef boost::graph_traits< undirected_graph >::vertex_descriptor
         vertex_descriptor;
@@ -159,9 +146,9 @@ BOOST_AUTO_TEST_CASE(test0)
             .vertex_assignment_map(assignments)
             .max_priority_queue(pq));
 
-    BOOST_CHECK_EQUAL(test_vis.curr(), vertex_descriptor(7));
-    BOOST_CHECK_EQUAL(test_vis.prev(), vertex_descriptor(6));
-    BOOST_CHECK_EQUAL(test_vis.reach_weight(), 5);
+    BOOST_TEST_EQ(test_vis.curr(), vertex_descriptor(7));
+    BOOST_TEST_EQ(test_vis.prev(), vertex_descriptor(6));
+    BOOST_TEST_EQ(test_vis.reach_weight(), 5);
 
     test_vis.clear();
     boost::maximum_adjacency_search(g,
@@ -170,17 +157,17 @@ BOOST_AUTO_TEST_CASE(test0)
             .root_vertex(*vertices(g).first)
             .max_priority_queue(pq));
 
-    BOOST_CHECK_EQUAL(test_vis.curr(), vertex_descriptor(7));
-    BOOST_CHECK_EQUAL(test_vis.prev(), vertex_descriptor(6));
-    BOOST_CHECK_EQUAL(test_vis.reach_weight(), 5);
+    BOOST_TEST_EQ(test_vis.curr(), vertex_descriptor(7));
+    BOOST_TEST_EQ(test_vis.prev(), vertex_descriptor(6));
+    BOOST_TEST_EQ(test_vis.reach_weight(), 5);
 
     test_vis.clear();
     boost::maximum_adjacency_search(
         g, boost::weight_map(weights).visitor(test_vis).max_priority_queue(pq));
 
-    BOOST_CHECK_EQUAL(test_vis.curr(), vertex_descriptor(7));
-    BOOST_CHECK_EQUAL(test_vis.prev(), vertex_descriptor(6));
-    BOOST_CHECK_EQUAL(test_vis.reach_weight(), 5);
+    BOOST_TEST_EQ(test_vis.curr(), vertex_descriptor(7));
+    BOOST_TEST_EQ(test_vis.prev(), vertex_descriptor(6));
+    BOOST_TEST_EQ(test_vis.reach_weight(), 5);
 
     boost::maximum_adjacency_search(g,
         boost::weight_map(weights).visitor(
@@ -196,14 +183,14 @@ BOOST_AUTO_TEST_CASE(test0)
             boost::make_constant_property< edge_descriptor >(weight_type(1)))
             .visitor(test_vis)
             .max_priority_queue(pq));
-    BOOST_CHECK_EQUAL(test_vis.curr(), vertex_descriptor(7));
-    BOOST_CHECK_EQUAL(test_vis.prev(), vertex_descriptor(3));
-    BOOST_CHECK_EQUAL(test_vis.reach_weight(), 2);
+    BOOST_TEST_EQ(test_vis.curr(), vertex_descriptor(7));
+    BOOST_TEST_EQ(test_vis.prev(), vertex_descriptor(3));
+    BOOST_TEST_EQ(test_vis.reach_weight(), 2);
 }
 
 // Check the unweighted case
 // with and without providing a weight_map
-BOOST_AUTO_TEST_CASE(test1)
+void test1()
 {
     typedef boost::graph_traits<
         undirected_unweighted_graph >::vertex_descriptor vertex_descriptor;
@@ -248,9 +235,9 @@ BOOST_AUTO_TEST_CASE(test1)
             .visitor(test_vis)
             .max_priority_queue(pq));
 
-    BOOST_CHECK_EQUAL(test_vis.curr(), vertex_descriptor(7));
-    BOOST_CHECK_EQUAL(test_vis.prev(), vertex_descriptor(3));
-    BOOST_CHECK_EQUAL(test_vis.reach_weight(), weight_type(2));
+    BOOST_TEST_EQ(test_vis.curr(), vertex_descriptor(7));
+    BOOST_TEST_EQ(test_vis.prev(), vertex_descriptor(3));
+    BOOST_TEST_EQ(test_vis.reach_weight(), weight_type(2));
 
     weight_type ws[] = { 2, 3, 4, 3, 2, 2, 2, 2, 2, 3, 1, 3 };
     std::map< edge_descriptor, weight_type > wm;
@@ -266,9 +253,19 @@ BOOST_AUTO_TEST_CASE(test1)
 
     boost::maximum_adjacency_search(
         g, boost::weight_map(ws_map).visitor(test_vis).max_priority_queue(pq));
-    BOOST_CHECK_EQUAL(test_vis.curr(), vertex_descriptor(7));
-    BOOST_CHECK_EQUAL(test_vis.prev(), vertex_descriptor(6));
-    BOOST_CHECK_EQUAL(test_vis.reach_weight(), weight_type(5));
+    BOOST_TEST_EQ(test_vis.curr(), vertex_descriptor(7));
+    BOOST_TEST_EQ(test_vis.prev(), vertex_descriptor(6));
+    BOOST_TEST_EQ(test_vis.reach_weight(), weight_type(5));
 }
 
 #include <boost/graph/iteration_macros_undef.hpp>
+
+int main(int argc, char* argv[])
+{
+    if (BOOST_TEST(argc == 2)) {
+        test_dir = argv[1];
+        test0();
+        test1();
+    }
+    return boost::report_errors();
+}

--- a/test/max_flow_algorithms_bundled_properties_and_named_params.cpp
+++ b/test/max_flow_algorithms_bundled_properties_and_named_params.cpp
@@ -1,8 +1,5 @@
-#define BOOST_TEST_MODULE \
-    max_flow_algorithms_named_parameters_and_bundled_params_test
-
 #include <boost/graph/adjacency_list.hpp>
-#include <boost/test/unit_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/graph/edmonds_karp_max_flow.hpp>
 
 #include "min_cost_max_flow_utils.hpp"
@@ -29,8 +26,7 @@ typedef boost::adjacency_list< boost::listS, boost::vecS, boost::directedS,
     node_t, edge_t >
     Graph;
 
-BOOST_AUTO_TEST_CASE(
-    using_named_parameters_and_bundled_params_on_edmonds_karp_max_flow_test)
+void using_named_parameters_and_bundled_params_on_edmonds_karp_max_flow_test()
 {
     Graph g;
     traits::vertex_descriptor s, t;
@@ -60,5 +56,11 @@ BOOST_AUTO_TEST_CASE(
             .color_map(col)
             .predecessor_map(pred));
 
-    BOOST_CHECK_EQUAL(flow_value, 4);
+    BOOST_TEST_EQ(flow_value, 4);
+}
+
+int main()
+{
+    using_named_parameters_and_bundled_params_on_edmonds_karp_max_flow_test();
+    return boost::report_errors();
 }

--- a/test/stoer_wagner_test.cpp
+++ b/test/stoer_wagner_test.cpp
@@ -20,7 +20,7 @@
 #include <boost/graph/stoer_wagner_min_cut.hpp>
 #include <boost/graph/property_maps/constant_property_map.hpp>
 #include <boost/property_map/property_map.hpp>
-#include <boost/test/unit_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/tuple/tuple.hpp>
 
 typedef boost::adjacency_list< boost::vecS, boost::vecS, boost::undirectedS,
@@ -35,19 +35,6 @@ typedef boost::adjacency_list< boost::vecS, boost::vecS, boost::undirectedS >
 
 std::string test_dir;
 
-boost::unit_test::test_suite* init_unit_test_suite(int argc, char* argv[])
-{
-    if (argc != 2)
-    {
-        std::cerr << "Usage: " << argv[0] << " path-to-libs-graph-test"
-                  << std::endl;
-        throw boost::unit_test::framework::setup_error(
-            "Invalid command line arguments");
-    }
-    test_dir = argv[1];
-    return 0;
-}
-
 struct edge_t
 {
     unsigned long first;
@@ -55,7 +42,7 @@ struct edge_t
 };
 
 // the example from Stoer & Wagner (1997)
-BOOST_AUTO_TEST_CASE(test0)
+void test0()
 {
     edge_t edges[] = { { 0, 1 }, { 1, 2 }, { 2, 3 }, { 0, 4 }, { 1, 4 },
         { 1, 5 }, { 2, 6 }, { 3, 6 }, { 3, 7 }, { 4, 5 }, { 5, 6 }, { 6, 7 } };
@@ -67,25 +54,25 @@ BOOST_AUTO_TEST_CASE(test0)
     boost::associative_property_map< std::map< int, bool > > parities(parity);
     int w
         = boost::stoer_wagner_min_cut(g, weights, boost::parity_map(parities));
-    BOOST_CHECK_EQUAL(w, 4);
+    BOOST_TEST_EQ(w, 4);
     const bool parity0 = get(parities, 0);
-    BOOST_CHECK_EQUAL(parity0, get(parities, 1));
-    BOOST_CHECK_EQUAL(parity0, get(parities, 4));
-    BOOST_CHECK_EQUAL(parity0, get(parities, 5));
+    BOOST_TEST_EQ(parity0, get(parities, 1));
+    BOOST_TEST_EQ(parity0, get(parities, 4));
+    BOOST_TEST_EQ(parity0, get(parities, 5));
     const bool parity2 = get(parities, 2);
-    BOOST_CHECK_NE(parity0, parity2);
-    BOOST_CHECK_EQUAL(parity2, get(parities, 3));
-    BOOST_CHECK_EQUAL(parity2, get(parities, 6));
-    BOOST_CHECK_EQUAL(parity2, get(parities, 7));
+    BOOST_TEST_NE(parity0, parity2);
+    BOOST_TEST_EQ(parity2, get(parities, 3));
+    BOOST_TEST_EQ(parity2, get(parities, 6));
+    BOOST_TEST_EQ(parity2, get(parities, 7));
 }
 
-BOOST_AUTO_TEST_CASE(test1)
+void test1()
 {
     { // if only one vertex, can't run `boost::stoer_wagner_min_cut`
         undirected_graph g;
         add_vertex(g);
 
-        BOOST_CHECK_THROW(
+        BOOST_TEST_THROWS(
             boost::stoer_wagner_min_cut(g, get(boost::edge_weight, g)),
             boost::bad_graph);
     }
@@ -107,15 +94,15 @@ BOOST_AUTO_TEST_CASE(test1)
             assignments(assignment);
         int w = boost::stoer_wagner_min_cut(g, weights,
             boost::parity_map(parities).vertex_assignment_map(assignments));
-        BOOST_CHECK_EQUAL(w, 3);
+        BOOST_TEST_EQ(w, 3);
         const bool parity2 = get(parities, 2), parity0 = get(parities, 0);
-        BOOST_CHECK_NE(parity2, parity0);
-        BOOST_CHECK_EQUAL(parity0, get(parities, 1));
+        BOOST_TEST_NE(parity2, parity0);
+        BOOST_TEST_EQ(parity0, get(parities, 1));
     }
 }
 
 // example by Daniel Trebbien
-BOOST_AUTO_TEST_CASE(test2)
+void test2()
 {
     edge_t edges[] = { { 5, 2 }, { 0, 6 }, { 5, 6 }, { 3, 1 }, { 0, 1 },
         { 6, 3 }, { 4, 6 }, { 2, 4 }, { 5, 3 } };
@@ -126,19 +113,19 @@ BOOST_AUTO_TEST_CASE(test2)
     boost::associative_property_map< std::map< int, bool > > parities(parity);
     int w = boost::stoer_wagner_min_cut(
         g, get(boost::edge_weight, g), boost::parity_map(parities));
-    BOOST_CHECK_EQUAL(w, 3);
+    BOOST_TEST_EQ(w, 3);
     const bool parity2 = get(parities, 2);
-    BOOST_CHECK_EQUAL(parity2, get(parities, 4));
+    BOOST_TEST_EQ(parity2, get(parities, 4));
     const bool parity5 = get(parities, 5);
-    BOOST_CHECK_NE(parity2, parity5);
-    BOOST_CHECK_EQUAL(parity5, get(parities, 3));
-    BOOST_CHECK_EQUAL(parity5, get(parities, 6));
-    BOOST_CHECK_EQUAL(parity5, get(parities, 1));
-    BOOST_CHECK_EQUAL(parity5, get(parities, 0));
+    BOOST_TEST_NE(parity2, parity5);
+    BOOST_TEST_EQ(parity5, get(parities, 3));
+    BOOST_TEST_EQ(parity5, get(parities, 6));
+    BOOST_TEST_EQ(parity5, get(parities, 1));
+    BOOST_TEST_EQ(parity5, get(parities, 0));
 }
 
 // example by Daniel Trebbien
-BOOST_AUTO_TEST_CASE(test3)
+void test3()
 {
     edge_t edges[] = { { 3, 4 }, { 3, 6 }, { 3, 5 }, { 0, 4 }, { 0, 1 },
         { 0, 6 }, { 0, 7 }, { 0, 5 }, { 0, 2 }, { 4, 1 }, { 1, 6 }, { 1, 5 },
@@ -151,19 +138,19 @@ BOOST_AUTO_TEST_CASE(test3)
     boost::associative_property_map< std::map< int, bool > > parities(parity);
     int w
         = boost::stoer_wagner_min_cut(g, weights, boost::parity_map(parities));
-    BOOST_CHECK_EQUAL(w, 7);
+    BOOST_TEST_EQ(w, 7);
     const bool parity1 = get(parities, 1);
-    BOOST_CHECK_EQUAL(parity1, get(parities, 5));
+    BOOST_TEST_EQ(parity1, get(parities, 5));
     const bool parity0 = get(parities, 0);
-    BOOST_CHECK_NE(parity1, parity0);
-    BOOST_CHECK_EQUAL(parity0, get(parities, 2));
-    BOOST_CHECK_EQUAL(parity0, get(parities, 3));
-    BOOST_CHECK_EQUAL(parity0, get(parities, 4));
-    BOOST_CHECK_EQUAL(parity0, get(parities, 6));
-    BOOST_CHECK_EQUAL(parity0, get(parities, 7));
+    BOOST_TEST_NE(parity1, parity0);
+    BOOST_TEST_EQ(parity0, get(parities, 2));
+    BOOST_TEST_EQ(parity0, get(parities, 3));
+    BOOST_TEST_EQ(parity0, get(parities, 4));
+    BOOST_TEST_EQ(parity0, get(parities, 6));
+    BOOST_TEST_EQ(parity0, get(parities, 7));
 }
 
-BOOST_AUTO_TEST_CASE(test4)
+void test4()
 {
     typedef boost::graph_traits<
         undirected_unweighted_graph >::vertex_descriptor vertex_descriptor;
@@ -185,16 +172,16 @@ BOOST_AUTO_TEST_CASE(test4)
     int w = boost::stoer_wagner_min_cut(g,
         boost::make_constant_property< edge_descriptor >(weight_type(1)),
         boost::vertex_assignment_map(assignments).parity_map(parities));
-    BOOST_CHECK_EQUAL(w, 2);
+    BOOST_TEST_EQ(w, 2);
     const bool parity0 = get(parities, 0);
-    BOOST_CHECK_EQUAL(parity0, get(parities, 1));
-    BOOST_CHECK_EQUAL(parity0, get(parities, 4));
-    BOOST_CHECK_EQUAL(parity0, get(parities, 5));
+    BOOST_TEST_EQ(parity0, get(parities, 1));
+    BOOST_TEST_EQ(parity0, get(parities, 4));
+    BOOST_TEST_EQ(parity0, get(parities, 5));
     const bool parity2 = get(parities, 2);
-    BOOST_CHECK_NE(parity0, parity2);
-    BOOST_CHECK_EQUAL(parity2, get(parities, 3));
-    BOOST_CHECK_EQUAL(parity2, get(parities, 6));
-    BOOST_CHECK_EQUAL(parity2, get(parities, 7));
+    BOOST_TEST_NE(parity0, parity2);
+    BOOST_TEST_EQ(parity2, get(parities, 3));
+    BOOST_TEST_EQ(parity2, get(parities, 6));
+    BOOST_TEST_EQ(parity2, get(parities, 7));
 }
 
 // The input for the `test_prgen` family of tests comes from a program, named
@@ -210,7 +197,7 @@ BOOST_AUTO_TEST_CASE(test4)
 // weight of the min-cut is verified.
 
 // 3 min-cuts
-BOOST_AUTO_TEST_CASE(test_prgen_20_70_2)
+void test_prgen_20_70_2()
 {
     typedef boost::graph_traits< undirected_graph >::vertex_descriptor
         vertex_descriptor;
@@ -225,7 +212,7 @@ BOOST_AUTO_TEST_CASE(test_prgen_20_70_2)
     boost::associative_property_map<
         std::map< vertex_descriptor, std::size_t > >
         components(component);
-    BOOST_CHECK_EQUAL(boost::connected_components(g, components),
+    BOOST_TEST_EQ(boost::connected_components(g, components),
         1U); // verify the connectedness assumption
 
     typedef boost::shared_array_property_map< weight_type,
@@ -247,11 +234,11 @@ BOOST_AUTO_TEST_CASE(test_prgen_20_70_2)
 
     int w = boost::stoer_wagner_min_cut(
         g, get(boost::edge_weight, g), boost::max_priority_queue(pq));
-    BOOST_CHECK_EQUAL(w, 3407);
+    BOOST_TEST_EQ(w, 3407);
 }
 
 // 7 min-cuts
-BOOST_AUTO_TEST_CASE(test_prgen_50_40_2)
+void test_prgen_50_40_2()
 {
     typedef boost::graph_traits< undirected_graph >::vertex_descriptor
         vertex_descriptor;
@@ -266,15 +253,15 @@ BOOST_AUTO_TEST_CASE(test_prgen_50_40_2)
     boost::associative_property_map<
         std::map< vertex_descriptor, std::size_t > >
         components(component);
-    BOOST_CHECK_EQUAL(boost::connected_components(g, components),
+    BOOST_TEST_EQ(boost::connected_components(g, components),
         1U); // verify the connectedness assumption
 
     int w = boost::stoer_wagner_min_cut(g, get(boost::edge_weight, g));
-    BOOST_CHECK_EQUAL(w, 10056);
+    BOOST_TEST_EQ(w, 10056);
 }
 
 // 6 min-cuts
-BOOST_AUTO_TEST_CASE(test_prgen_50_70_2)
+void test_prgen_50_70_2()
 {
     typedef boost::graph_traits< undirected_graph >::vertex_descriptor
         vertex_descriptor;
@@ -289,9 +276,24 @@ BOOST_AUTO_TEST_CASE(test_prgen_50_70_2)
     boost::associative_property_map<
         std::map< vertex_descriptor, std::size_t > >
         components(component);
-    BOOST_CHECK_EQUAL(boost::connected_components(g, components),
+    BOOST_TEST_EQ(boost::connected_components(g, components),
         1U); // verify the connectedness assumption
 
     int w = boost::stoer_wagner_min_cut(g, get(boost::edge_weight, g));
-    BOOST_CHECK_EQUAL(w, 21755);
+    BOOST_TEST_EQ(w, 21755);
+}
+
+int main(int argc, char* argv[])
+{
+    if (BOOST_TEST(argc == 2)) {
+        test_dir = argv[1];
+        test0();
+        test1();
+        test2();
+        test3();
+        test4();
+        test_prgen_20_70_2();
+        test_prgen_50_70_2();
+    }
+    return boost::report_errors();
 }

--- a/test/subgraph_add.cpp
+++ b/test/subgraph_add.cpp
@@ -10,13 +10,11 @@
  *
  */
 
-#define BOOST_TEST_MODULE subgraph_add
-
 // std lib includes
 #include <iostream>
 
 // include boost components
-#include <boost/test/unit_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/iteration_macros.hpp>
 
@@ -25,11 +23,8 @@
 
 using namespace boost;
 
-BOOST_AUTO_TEST_CASE(simpleGraph)
+void simpleGraphTest()
 {
-
-    BOOST_TEST_MESSAGE("simple subgraph");
-
     typedef subgraph< adjacency_list< vecS, vecS, directedS, no_property,
         property< edge_index_t, int > > >
         Graph;
@@ -50,8 +45,8 @@ BOOST_AUTO_TEST_CASE(simpleGraph)
     Graph& G1 = G0.create_subgraph();
     Graph& G2 = G1.create_subgraph();
 
-    BOOST_CHECK(&G1.parent() == &G0);
-    BOOST_CHECK(&G2.parent() == &G1);
+    BOOST_TEST(&G1.parent() == &G0);
+    BOOST_TEST(&G2.parent() == &G1);
 
     enum
     {
@@ -73,10 +68,10 @@ BOOST_AUTO_TEST_CASE(simpleGraph)
     add_vertex(C, G2); // global vertex C becomes local A2 for G2
     add_vertex(E, G2); // global vertex E becomes local B2 for G2
 
-    BOOST_CHECK(num_vertices(G0) == 6);
-    BOOST_CHECK(num_vertices(G1) == 3);
+    BOOST_TEST(num_vertices(G0) == 6);
+    BOOST_TEST(num_vertices(G1) == 3);
     std::cerr << num_vertices(G1) << std::endl;
-    BOOST_CHECK(num_vertices(G2) == 2);
+    BOOST_TEST(num_vertices(G2) == 2);
 
     // add edges to root graph
     add_edge(A, B, G0);
@@ -84,26 +79,23 @@ BOOST_AUTO_TEST_CASE(simpleGraph)
     add_edge(B, D, G0);
     add_edge(E, F, G0);
 
-    BOOST_CHECK(num_edges(G0) == 4);
-    BOOST_CHECK(num_edges(G1) == 1);
-    BOOST_CHECK(num_edges(G2) == 0);
+    BOOST_TEST(num_edges(G0) == 4);
+    BOOST_TEST(num_edges(G1) == 1);
+    BOOST_TEST(num_edges(G2) == 0);
 
     // add edges to G1
     add_edge(A1, B1, G1);
-    BOOST_CHECK(num_edges(G0) == 5);
-    BOOST_CHECK(num_edges(G1) == 2);
-    BOOST_CHECK(num_edges(G2) == 1);
+    BOOST_TEST(num_edges(G0) == 5);
+    BOOST_TEST(num_edges(G1) == 2);
+    BOOST_TEST(num_edges(G2) == 1);
     // num_vertices stays the same
-    BOOST_CHECK(num_vertices(G0) == 6);
-    BOOST_CHECK(num_vertices(G1) == 3);
-    BOOST_CHECK(num_vertices(G2) == 2);
+    BOOST_TEST(num_vertices(G0) == 6);
+    BOOST_TEST(num_vertices(G1) == 3);
+    BOOST_TEST(num_vertices(G2) == 2);
 }
 
-BOOST_AUTO_TEST_CASE(addVertices)
+void addVerticesTest()
 {
-
-    BOOST_TEST_MESSAGE("subgraph add edges");
-
     typedef subgraph< adjacency_list< vecS, vecS, directedS, no_property,
         property< edge_index_t, int > > >
         Graph;
@@ -114,8 +106,8 @@ BOOST_AUTO_TEST_CASE(addVertices)
     Graph& G1 = G0.create_subgraph();
     Graph& G2 = G1.create_subgraph();
 
-    BOOST_CHECK(&G1.parent() == &G0);
-    BOOST_CHECK(&G2.parent() == &G1);
+    BOOST_TEST(&G1.parent() == &G0);
+    BOOST_TEST(&G2.parent() == &G1);
 
     // add vertices to G2
     Vertex n1 = add_vertex(0, G2);
@@ -123,7 +115,7 @@ BOOST_AUTO_TEST_CASE(addVertices)
     // check if the global vertex 2 is equal to the returned local vertex
     if (G2.find_vertex(0).second)
     {
-        BOOST_CHECK(G2.find_vertex(0).first == n1);
+        BOOST_TEST(G2.find_vertex(0).first == n1);
     }
     else
     {
@@ -131,7 +123,7 @@ BOOST_AUTO_TEST_CASE(addVertices)
     }
     if (G2.find_vertex(1).second)
     {
-        BOOST_CHECK(G2.find_vertex(1).first == n2);
+        BOOST_TEST(G2.find_vertex(1).first == n2);
     }
     else
     {
@@ -140,7 +132,7 @@ BOOST_AUTO_TEST_CASE(addVertices)
     // and check if this vertex is also present in G1
     if (G1.find_vertex(0).second)
     {
-        BOOST_CHECK(G1.local_to_global(G1.find_vertex(0).first) == 0);
+        BOOST_TEST(G1.local_to_global(G1.find_vertex(0).first) == 0);
     }
     else
     {
@@ -148,7 +140,7 @@ BOOST_AUTO_TEST_CASE(addVertices)
     }
     if (G1.find_vertex(0).second)
     {
-        BOOST_CHECK(G1.local_to_global(G1.find_vertex(1).first) == 1);
+        BOOST_TEST(G1.local_to_global(G1.find_vertex(1).first) == 1);
     }
     else
     {
@@ -156,50 +148,50 @@ BOOST_AUTO_TEST_CASE(addVertices)
     }
 
     // num_vertices stays the same
-    BOOST_CHECK(num_vertices(G0) == 3);
-    BOOST_CHECK(num_vertices(G1) == 2);
-    BOOST_CHECK(num_vertices(G2) == 2);
+    BOOST_TEST(num_vertices(G0) == 3);
+    BOOST_TEST(num_vertices(G1) == 2);
+    BOOST_TEST(num_vertices(G2) == 2);
 
     // add vertices to G1
     Vertex n3 = add_vertex(2, G1);
     // check if the global vertex 2 is equal to the returned local vertex
     if (G1.find_vertex(2).second)
     {
-        BOOST_CHECK(G1.find_vertex(2).first == n3);
+        BOOST_TEST(G1.find_vertex(2).first == n3);
     }
     else
     {
         BOOST_ERROR("vertex not found!");
     }
     // num_vertices stays the same
-    BOOST_CHECK(num_vertices(G0) == 3);
-    BOOST_CHECK(num_vertices(G1) == 3);
-    BOOST_CHECK(num_vertices(G2) == 2);
+    BOOST_TEST(num_vertices(G0) == 3);
+    BOOST_TEST(num_vertices(G1) == 3);
+    BOOST_TEST(num_vertices(G2) == 2);
 
     // add vertices to G1
     Vertex n4 = add_vertex(G1);
 
     // check if the new local vertex is also in the global graph
-    BOOST_CHECK(G0.find_vertex(G1.local_to_global(n4)).second);
+    BOOST_TEST(G0.find_vertex(G1.local_to_global(n4)).second);
     // check if the new local vertex is not in the subgraphs
-    BOOST_CHECK(!G2.find_vertex(n4).second);
+    BOOST_TEST(!G2.find_vertex(n4).second);
 
     // num_vertices stays the same
-    BOOST_CHECK(num_vertices(G0) == 4);
-    BOOST_CHECK(num_vertices(G1) == 4);
-    BOOST_CHECK(num_vertices(G2) == 2);
+    BOOST_TEST(num_vertices(G0) == 4);
+    BOOST_TEST(num_vertices(G1) == 4);
+    BOOST_TEST(num_vertices(G2) == 2);
 
     // add vertices to G0
     Vertex n5 = add_vertex(G0);
 
     // check if the new local vertex is not in the subgraphs
-    BOOST_CHECK(!G1.find_vertex(n5).second);
-    BOOST_CHECK(!G2.find_vertex(n5).second);
+    BOOST_TEST(!G1.find_vertex(n5).second);
+    BOOST_TEST(!G2.find_vertex(n5).second);
 
     // num_vertices stays the same
-    BOOST_CHECK(num_vertices(G0) == 5);
-    BOOST_CHECK(num_vertices(G1) == 4);
-    BOOST_CHECK(num_vertices(G2) == 2);
+    BOOST_TEST(num_vertices(G0) == 5);
+    BOOST_TEST(num_vertices(G1) == 4);
+    BOOST_TEST(num_vertices(G2) == 2);
 
     typedef std::map< graph_traits< Graph::graph_type >::vertex_descriptor,
         graph_traits< Graph::graph_type >::vertex_descriptor >::iterator v_itr;
@@ -221,11 +213,8 @@ BOOST_AUTO_TEST_CASE(addVertices)
     }
 }
 
-BOOST_AUTO_TEST_CASE(addEdge)
+void addEdgeTest()
 {
-
-    BOOST_TEST_MESSAGE("subgraph add edges");
-
     typedef subgraph< adjacency_list< vecS, vecS, directedS, no_property,
         property< edge_index_t, int > > >
         Graph;
@@ -236,59 +225,59 @@ BOOST_AUTO_TEST_CASE(addEdge)
     Graph& G1 = G0.create_subgraph();
     Graph& G2 = G1.create_subgraph();
 
-    BOOST_CHECK(&G1.parent() == &G0);
-    BOOST_CHECK(&G2.parent() == &G1);
+    BOOST_TEST(&G1.parent() == &G0);
+    BOOST_TEST(&G2.parent() == &G1);
 
     // add vertices
     add_vertex(0, G2);
     add_vertex(1, G2);
-    BOOST_CHECK(num_vertices(G1) == 2);
-    BOOST_CHECK(num_vertices(G2) == 2);
+    BOOST_TEST(num_vertices(G1) == 2);
+    BOOST_TEST(num_vertices(G2) == 2);
 
     // add edge to G0 which needs propagation
     add_edge(0, 1, G0);
 
-    BOOST_CHECK(num_edges(G0) == 1);
-    BOOST_CHECK(num_edges(G1) == 1);
-    BOOST_CHECK(num_edges(G2) == 1);
+    BOOST_TEST(num_edges(G0) == 1);
+    BOOST_TEST(num_edges(G1) == 1);
+    BOOST_TEST(num_edges(G2) == 1);
     // num_vertices stays the same
-    BOOST_CHECK(num_vertices(G0) == 3);
-    BOOST_CHECK(num_vertices(G1) == 2);
-    BOOST_CHECK(num_vertices(G2) == 2);
+    BOOST_TEST(num_vertices(G0) == 3);
+    BOOST_TEST(num_vertices(G1) == 2);
+    BOOST_TEST(num_vertices(G2) == 2);
 
     // add edge to G0 without propagation
     add_edge(1, 2, G0);
 
-    BOOST_CHECK(num_edges(G0) == 2);
-    BOOST_CHECK(num_edges(G1) == 1);
-    BOOST_CHECK(num_edges(G2) == 1);
+    BOOST_TEST(num_edges(G0) == 2);
+    BOOST_TEST(num_edges(G1) == 1);
+    BOOST_TEST(num_edges(G2) == 1);
     // num_vertices stays the same
-    BOOST_CHECK(num_vertices(G0) == 3);
-    BOOST_CHECK(num_vertices(G1) == 2);
-    BOOST_CHECK(num_vertices(G2) == 2);
+    BOOST_TEST(num_vertices(G0) == 3);
+    BOOST_TEST(num_vertices(G1) == 2);
+    BOOST_TEST(num_vertices(G2) == 2);
 
     // add vertex 2 to G2/G1 with edge propagation
     Vertex n = add_vertex(2, G2);
-    BOOST_CHECK(G2.local_to_global(n) == 2);
+    BOOST_TEST(G2.local_to_global(n) == 2);
 
-    BOOST_CHECK(num_edges(G0) == 2);
-    BOOST_CHECK(num_edges(G1) == 2);
-    BOOST_CHECK(num_edges(G2) == 2);
+    BOOST_TEST(num_edges(G0) == 2);
+    BOOST_TEST(num_edges(G1) == 2);
+    BOOST_TEST(num_edges(G2) == 2);
     // num_vertices stays the same
-    BOOST_CHECK(num_vertices(G0) == 3);
-    BOOST_CHECK(num_vertices(G1) == 3);
-    BOOST_CHECK(num_vertices(G2) == 3);
+    BOOST_TEST(num_vertices(G0) == 3);
+    BOOST_TEST(num_vertices(G1) == 3);
+    BOOST_TEST(num_vertices(G2) == 3);
 
     // add edge to G2 with propagation upwards
     add_edge(0, 2, G2);
 
-    BOOST_CHECK(num_edges(G0) == 3);
-    BOOST_CHECK(num_edges(G1) == 3);
-    BOOST_CHECK(num_edges(G2) == 3);
+    BOOST_TEST(num_edges(G0) == 3);
+    BOOST_TEST(num_edges(G1) == 3);
+    BOOST_TEST(num_edges(G2) == 3);
     // num_vertices stays the same
-    BOOST_CHECK(num_vertices(G0) == 3);
-    BOOST_CHECK(num_vertices(G1) == 3);
-    BOOST_CHECK(num_vertices(G2) == 3);
+    BOOST_TEST(num_vertices(G0) == 3);
+    BOOST_TEST(num_vertices(G1) == 3);
+    BOOST_TEST(num_vertices(G2) == 3);
 
     typedef std::map< graph_traits< Graph::graph_type >::vertex_descriptor,
         graph_traits< Graph::graph_type >::vertex_descriptor >::iterator v_itr;
@@ -323,4 +312,12 @@ BOOST_AUTO_TEST_CASE(addEdge)
     {
         std::cerr << source(e, G2) << "->" << target(e, G2) << std::endl;
     }
+}
+
+int main()
+{
+    simpleGraphTest();
+    addVerticesTest();
+    addEdgeTest();
+    return boost::report_errors();
 }

--- a/test/successive_shortest_path_nonnegative_weights_test.cpp
+++ b/test/successive_shortest_path_nonnegative_weights_test.cpp
@@ -7,16 +7,14 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 //=======================================================================
 
-#define BOOST_TEST_MODULE successive_shortest_path_nonnegative_weights_test
-
-#include <boost/test/unit_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #include <boost/graph/successive_shortest_path_nonnegative_weights.hpp>
 #include <boost/graph/find_flow_cost.hpp>
 
 #include "min_cost_max_flow_utils.hpp"
 
-BOOST_AUTO_TEST_CASE(path_augmentation_def_test)
+void path_augmentation_def_test()
 {
     boost::SampleGraph::vertex_descriptor s, t;
     boost::SampleGraph::Graph g;
@@ -25,10 +23,10 @@ BOOST_AUTO_TEST_CASE(path_augmentation_def_test)
     boost::successive_shortest_path_nonnegative_weights(g, s, t);
 
     int cost = boost::find_flow_cost(g);
-    BOOST_CHECK_EQUAL(cost, 29);
+    BOOST_TEST_EQ(cost, 29);
 }
 
-BOOST_AUTO_TEST_CASE(path_augmentation_def_test2)
+void path_augmentation_def_test2()
 {
     boost::SampleGraph::vertex_descriptor s, t;
     boost::SampleGraph::Graph g;
@@ -37,10 +35,10 @@ BOOST_AUTO_TEST_CASE(path_augmentation_def_test2)
     boost::successive_shortest_path_nonnegative_weights(g, s, t);
 
     int cost = boost::find_flow_cost(g);
-    BOOST_CHECK_EQUAL(cost, 7);
+    BOOST_TEST_EQ(cost, 7);
 }
 
-BOOST_AUTO_TEST_CASE(path_augmentation_test)
+void path_augmentation_test()
 {
     boost::SampleGraph::vertex_descriptor s, t;
     typedef boost::SampleGraph::Graph Graph;
@@ -66,5 +64,13 @@ BOOST_AUTO_TEST_CASE(path_augmentation_test)
             .vertex_index_map(idx));
 
     int cost = boost::find_flow_cost(g);
-    BOOST_CHECK_EQUAL(cost, 29);
+    BOOST_TEST_EQ(cost, 29);
+}
+
+int main()
+{
+    path_augmentation_def_test();
+    path_augmentation_def_test2();
+    path_augmentation_test();
+    return boost::report_errors();
 }


### PR DESCRIPTION
Most of the tests in Graph already use LWT; this just converts the handful that don't.