### PR TITLE
Fix #274: Typo in Boykov-Kolmogorov Max-Flow

### DIFF
--- a/include/boost/graph/boykov_kolmogorov_max_flow.hpp
+++ b/include/boost/graph/boykov_kolmogorov_max_flow.hpp
@@ -977,7 +977,7 @@ boykov_kolmogorov_max_flow(Graph& g, CapacityEdgeMap cap,
 }
 
 /**
- * non-named-parameter version, given capacity, residucal_capacity,
+ * non-named-parameter version, given capacity, residual_capacity,
  * reverse_edges, and an index map.
  */
 template < class Graph, class CapacityEdgeMap, class ResidualCapacityEdgeMap,


### PR DESCRIPTION
Redundant letter `c` in a comment.