### PR TITLE
Add pgRouting to Boost Graph Library Users

### DIFF
--- a/doc/users.html
+++ b/doc/users.html
@@ -40,6 +40,7 @@ or form.</p>
   <li><a href="http://www.vrjuggler.org/">VR Juggler: Virtual Reality Tools</a></li>
   <li><a href="http://hyperworx.org">Hyperworx Platform Project</a></li>
   <li><a href="http://www.opencog.org/">OpenCog, an open source Artificial General Intelligence framework</a></li>
+  <li><a href="https://www.pgRouting.org/">pgRouting extends the PostGIS/PostgreSQL geospatial database to provide geospatial routing functionality.</a></li>
 </ul>
 
 </body>


### PR DESCRIPTION
First of all, I want to congratulate you for the amazing job you are doing.

I am the main developer of pgRouting, and the project is part of the OSGeo
Foundation [2] community projects.

pgRouting extends the PostGIS / PostgreSQL geospatial database to provide
geospatial routing functionality.

I would like pgRouting [1] to be added on the list of
"Boost Graph Library Users"
The Boost license is on the projects repository [3] and we document when a
boost graph function is used for example in [4]

[1] https://pgrouting.org/
[2] https://www.osgeo.org
[3] https://github.com/pgRouting/pgrouting
[4] https://docs.pgrouting.org/latest/en/pgr_aStar.html