### PR TITLE
Allow metis_reader to work with non-seekable streams

### DIFF
--- a/include/boost/graph/metis.hpp
+++ b/include/boost/graph/metis.hpp
@@ -290,6 +290,7 @@ namespace graph
     void metis_reader::start()
     {
         in.seekg(0, std::ios::beg);
+        in.clear();
         std::string line;
         while (getline(in, line) && !line.empty() && line[0] == '%')
         {


### PR DESCRIPTION
metis_reader currently unconditionally seeks to the beginning of the stream when it starts, which causes it to fail with a metis_input_exception when reading from streams that are not seekable. For example, in my case I’m trying to read a graph that is piped into my program via stdin, which does not work because of this. Clearing the error state flags of the stream after seeking allows metis_reader to work with non-seekable streams without potentially breaking code that relies on metis_reader seeking to the beginning of (seekable) streams.