### PR TITLE
Serialized and deserialized types must match

### DIFF
--- a/include/boost/graph/adj_list_serialize.hpp
+++ b/include/boost/graph/adj_list_serialize.hpp
@@ -46,8 +46,8 @@ namespace serialization
         typedef adjacency_list< OEL, VL, D, VP, EP, GP, EL > Graph;
         typedef typename graph_traits< Graph >::vertex_descriptor Vertex;
 
-        int V = num_vertices(graph);
-        int E = num_edges(graph);
+        unsigned int V = num_vertices(graph);
+        unsigned int E = num_edges(graph);
         ar << BOOST_SERIALIZATION_NVP(V);
         ar << BOOST_SERIALIZATION_NVP(E);
 


### PR DESCRIPTION
In our project at work we use custom boost archive for serialization and deserialization, and unsigned integers are serialized in a non-trivial way, which does not match with serialization of signed integer. This causes some troubles.

I guess it is fine to change this serialization method in upstream project.