### PR TITLE
Fix conversion warning

### DIFF
--- a/include/boost/graph/transitive_closure.hpp
+++ b/include/boost/graph/transitive_closure.hpp
@@ -107,12 +107,11 @@ void transitive_closure(const Graph& g, GraphTC& tc,
             }
         }
         std::sort(adj.begin(), adj.end());
-        typename std::vector< cg_vertex >::iterator di
+        const typename std::vector< cg_vertex >::iterator di
             = std::unique(adj.begin(), adj.end());
-        if (di != adj.end())
-            adj.erase(di, adj.end());
+
         for (typename std::vector< cg_vertex >::const_iterator i = adj.begin();
-             i != adj.end(); ++i)
+             i != di; ++i)
         {
             add_edge(s, *i, CG);
         }

--- a/include/boost/graph/transitive_closure.hpp
+++ b/include/boost/graph/transitive_closure.hpp
@@ -82,7 +82,7 @@ void transitive_closure(const Graph& g, GraphTC& tc,
     iterator_property_map< cg_vertex*, VertexIndexMap, cg_vertex, cg_vertex& >
         component_number(&component_number_vec[0], index_map);
 
-    int num_scc
+    const cg_vertex num_scc
         = strong_components(g, component_number, vertex_index_map(index_map));
 
     std::vector< std::vector< vertex > > components;


### PR DESCRIPTION
Fixes #293 

Replaces `int` with the type returned by `strong_components` which is the value type of the provided component map.
Also removes unneeded `erase` call.