### PR TITLE
Clarify docs on what traversal category allowed

### DIFF
--- a/doc/Graph.html
+++ b/doc/Graph.html
@@ -87,7 +87,8 @@ This describes the ways in which the vertices and edges of the
 graph can be visited. The choices are <TT>incidence_graph_tag</TT>,
 <TT>adjacency_graph_tag</TT>, <TT>bidirectional_graph_tag</TT>,
 <TT>vertex_list_graph_tag</TT>, <TT>edge_list_graph_tag</TT>, and
-<TT>adjacency_matrix_tag</TT>.
+<TT>adjacency_matrix_tag</TT>. You can also create your own
+tag which should inherit from one or more of the above.
 </td>
 </tr>
 

--- a/doc/graph_traits.html
+++ b/doc/graph_traits.html
@@ -200,9 +200,9 @@ The ways in which the vertices in the graph can be traversed.
 The traversal category tags are:
 <tt>incidence_graph_tag, adjacency_graph_tag,
 bidirectional_graph_tag, vertex_list_graph_tag,
-edge_list_graph_tag, vertex_and_edge_list_graph_tag,
+edge_list_graph_tag,
 adjacency_matrix_tag</tt>. You can also create your own
-tag which should inherit from one of the above.
+tag which should inherit from one or more of the above.
 </td>
 </tr>
 


### PR DESCRIPTION
Thanks to @sebrockm  for clarifying for me that the traversal category can inherit from more than one tag. In case anyone has the same question as me in the future (#301), I've updated the docs to make this explicit. 

Also, as noted in #301 I couldn't find any reference to `vertex_and_edge_list_tag`, so I've removed it from the documentation. 