### PR TITLE
depth_first_search.hpp: align code to documentation

### DIFF
--- a/include/boost/graph/depth_first_search.hpp
+++ b/include/boost/graph/depth_first_search.hpp
@@ -411,7 +411,7 @@ BOOST_GRAPH_MAKE_OLD_STYLE_PARAMETER_FUNCTION(depth_first_search, 1)
 template < class IncidenceGraph, class DFSVisitor, class ColorMap >
 void depth_first_visit(const IncidenceGraph& g,
     typename graph_traits< IncidenceGraph >::vertex_descriptor u,
-    DFSVisitor vis, ColorMap color)
+    DFSVisitor& vis, ColorMap color)
 {
     vis.start_vertex(u, g);
     detail::depth_first_visit_impl(g, u, vis, color, detail::nontruth2());
@@ -421,7 +421,7 @@ template < class IncidenceGraph, class DFSVisitor, class ColorMap,
     class TerminatorFunc >
 void depth_first_visit(const IncidenceGraph& g,
     typename graph_traits< IncidenceGraph >::vertex_descriptor u,
-    DFSVisitor vis, ColorMap color, TerminatorFunc func = TerminatorFunc())
+    DFSVisitor& vis, ColorMap color, TerminatorFunc func = TerminatorFunc())
 {
     vis.start_vertex(u, g);
     detail::depth_first_visit_impl(g, u, vis, color, func);


### PR DESCRIPTION
In the documentation the `DFSVisitor` is taken by reference: https://www.boost.org/doc/libs/1_80_0/libs/graph/doc/depth_first_visit.html , while in the actual header it is taken by copy.
I assume the code in the header is by mistake and I would actually like it to take the visitor by reference for my usecase.

As far as I can tell this mismatch existed already from the beginning: https://github.com/boostorg/graph/commit/121bb31837075fe98dfc44b00edc6c382ec394b8