### PR TITLE
Optionally specify a maximum circuit length in Hawick circuits algorithm

### DIFF
--- a/doc/hawick_circuits.html
+++ b/doc/hawick_circuits.html
@@ -13,13 +13,13 @@
 <h1 id="hawick_circuits"><code>hawick_circuits</code></h1>
 
 <pre><code>template &lt;typename Graph, typename Visitor, typename VertexIndexMap&gt;
-void hawick_circuits(Graph const&amp; graph, Visitor visitor, VertexIndexMap const&amp; vim = get(vertex_index, graph));
+void hawick_circuits(Graph const&amp; graph, Visitor visitor, VertexIndexMap const&amp; vim = get(vertex_index, graph), unsigned int const maxLength = 0);
 
 template &lt;typename Graph, typename Visitor, typename VertexIndexMap&gt;
-void hawick_unique_circuits(Graph const&amp; graph, Visitor visitor, VertexIndexMap const&amp; vim = get(vertex_index, graph));
+void hawick_unique_circuits(Graph const&amp; graph, Visitor visitor, VertexIndexMap const&amp; vim = get(vertex_index, graph), unsigned int const maxLength = 0);
 </code></pre>
 
-<p>Enumerate all the elementary circuits in a directed multigraph. Specifically,
+<p>Enumerate all the elementary circuits (of length &le; <code>maxLength</code>, if nonzero) in a directed multigraph. Specifically,
 self-loops and redundant circuits caused by parallel edges are enumerated too.
 <code>hawick_unique_circuits</code> may be used if redundant circuits caused by parallel
 edges are not desired.</p>
@@ -57,6 +57,12 @@ edges are not desired.</p>
   <p>A model of the <code>ReadablePropertyMap</code> concept mapping each <code>vertex_descriptor</code>
   to an integer in the range <code>[0, num_vertices(graph))</code>. It defaults to using
   the vertex index map provided by the <code>graph</code>.</p>
+</blockquote>
+
+<p><strong>IN:</strong> <code>unsigned int const maxLength = 0</code></p>
+
+<blockquote>
+  <p>The maximum circuit length to consider. Beyond this it truncates the depth-first search, reducing the computation time by ignoring longer circuits. The default value of <code>maxLength = 0</code> implies no maximum.</p>
 </blockquote>
 
 <hr />

--- a/doc/hawick_circuits.html
+++ b/doc/hawick_circuits.html
@@ -13,10 +13,10 @@
 <h1 id="hawick_circuits"><code>hawick_circuits</code></h1>
 
 <pre><code>template &lt;typename Graph, typename Visitor, typename VertexIndexMap&gt;
-void hawick_circuits(Graph const&amp; graph, Visitor visitor, VertexIndexMap const&amp; vim = get(vertex_index, graph), unsigned int const max_length = 0);
+void hawick_circuits(Graph const&amp; graph, Visitor visitor, VertexIndexMap const&amp; vim = get(vertex_index, graph), unsigned int max_length = 0);
 
 template &lt;typename Graph, typename Visitor, typename VertexIndexMap&gt;
-void hawick_unique_circuits(Graph const&amp; graph, Visitor visitor, VertexIndexMap const&amp; vim = get(vertex_index, graph), unsigned int const max_length = 0);
+void hawick_unique_circuits(Graph const&amp; graph, Visitor visitor, VertexIndexMap const&amp; vim = get(vertex_index, graph), unsigned int max_length = 0);
 </code></pre>
 
 <p>Enumerate all the elementary circuits (of length &le; <code>max_length</code>, if nonzero) in a directed multigraph. Specifically,
@@ -59,7 +59,7 @@ edges are not desired.</p>
   the vertex index map provided by the <code>graph</code>.</p>
 </blockquote>
 
-<p><strong>IN:</strong> <code>unsigned int const max_length = 0</code></p>
+<p><strong>IN:</strong> <code>unsigned int max_length = 0</code></p>
 
 <blockquote>
   <p>The maximum circuit length to consider. Beyond this it truncates the depth-first search, reducing the computation time by ignoring longer circuits. The default value of <code>max_length = 0</code> implies no maximum.</p>

--- a/doc/hawick_circuits.html
+++ b/doc/hawick_circuits.html
@@ -13,13 +13,13 @@
 <h1 id="hawick_circuits"><code>hawick_circuits</code></h1>
 
 <pre><code>template &lt;typename Graph, typename Visitor, typename VertexIndexMap&gt;
-void hawick_circuits(Graph const&amp; graph, Visitor visitor, VertexIndexMap const&amp; vim = get(vertex_index, graph), unsigned int const maxLength = 0);
+void hawick_circuits(Graph const&amp; graph, Visitor visitor, VertexIndexMap const&amp; vim = get(vertex_index, graph), unsigned int const max_length = 0);
 
 template &lt;typename Graph, typename Visitor, typename VertexIndexMap&gt;
-void hawick_unique_circuits(Graph const&amp; graph, Visitor visitor, VertexIndexMap const&amp; vim = get(vertex_index, graph), unsigned int const maxLength = 0);
+void hawick_unique_circuits(Graph const&amp; graph, Visitor visitor, VertexIndexMap const&amp; vim = get(vertex_index, graph), unsigned int const max_length = 0);
 </code></pre>
 
-<p>Enumerate all the elementary circuits (of length &le; <code>maxLength</code>, if nonzero) in a directed multigraph. Specifically,
+<p>Enumerate all the elementary circuits (of length &le; <code>max_length</code>, if nonzero) in a directed multigraph. Specifically,
 self-loops and redundant circuits caused by parallel edges are enumerated too.
 <code>hawick_unique_circuits</code> may be used if redundant circuits caused by parallel
 edges are not desired.</p>
@@ -59,10 +59,10 @@ edges are not desired.</p>
   the vertex index map provided by the <code>graph</code>.</p>
 </blockquote>
 
-<p><strong>IN:</strong> <code>unsigned int const maxLength = 0</code></p>
+<p><strong>IN:</strong> <code>unsigned int const max_length = 0</code></p>
 
 <blockquote>
-  <p>The maximum circuit length to consider. Beyond this it truncates the depth-first search, reducing the computation time by ignoring longer circuits. The default value of <code>maxLength = 0</code> implies no maximum.</p>
+  <p>The maximum circuit length to consider. Beyond this it truncates the depth-first search, reducing the computation time by ignoring longer circuits. The default value of <code>max_length = 0</code> implies no maximum.</p>
 </blockquote>
 
 <hr />

--- a/example/hawick_circuits.cpp
+++ b/example/hawick_circuits.cpp
@@ -78,7 +78,7 @@ int main(int argc, char const* argv[])
 {
     if (argc < 2)
     {
-        std::cout << "usage: " << argv[0] << " num_vertices < input\n";
+        std::cout << "usage: " << argv[0] << " <num_vertices> <max_length (optional)>\n";
         return EXIT_FAILURE;
     }
 
@@ -88,7 +88,12 @@ int main(int argc, char const* argv[])
     build_graph(graph, num_vertices, first_vertex, last_vertex);
 
     cycle_printer< std::ostream > visitor(std::cout);
-    boost::hawick_circuits(graph, visitor);
+    if (argc == 2) {
+        boost::hawick_circuits(graph, visitor);
+    } else {
+        unsigned int max_length = boost::lexical_cast< unsigned int >(argv[2]);
+        boost::hawick_circuits(graph, visitor, max_length);
+    }
 
     return EXIT_SUCCESS;
 }

--- a/example/hawick_circuits.cpp
+++ b/example/hawick_circuits.cpp
@@ -78,7 +78,8 @@ int main(int argc, char const* argv[])
 {
     if (argc < 2)
     {
-        std::cout << "usage: " << argv[0] << " <num_vertices> <max_length (optional)>\n";
+        std::cout << "usage: " << argv[0] << " <num_vertices>";
+        std::cout << " <max_length (optional)>\n";
         return EXIT_FAILURE;
     }
 

--- a/include/boost/graph/hawick_circuits.hpp
+++ b/include/boost/graph/hawick_circuits.hpp
@@ -153,7 +153,7 @@ namespace hawick_circuits_detail
     public:
         hawick_circuits_from(Graph const& graph, Visitor& visitor,
             VertexIndexMap const& vim, Stack& stack, ClosedMatrix& closed,
-            VerticesSize n_vertices, unsigned int const max_length)
+            VerticesSize n_vertices, unsigned int max_length)
         : graph_(graph)
         , visitor_(visitor)
         , vim_(vim)
@@ -298,14 +298,14 @@ namespace hawick_circuits_detail
         Stack& stack_;
         ClosedMatrix& closed_;
         BlockedMap blocked_;
-        unsigned int const max_length_;
+        unsigned int max_length_;
     };
 
     template < typename GetAdjacentVertices, typename Graph, typename Visitor,
         typename VertexIndexMap >
     void call_hawick_circuits(Graph const& graph,
         Visitor /* by value */ visitor, VertexIndexMap const& vertex_index_map,
-        unsigned int const max_length)
+        unsigned int max_length)
     {
         typedef graph_traits< Graph > Traits;
         typedef typename Traits::vertex_descriptor Vertex;
@@ -348,7 +348,7 @@ namespace hawick_circuits_detail
     template < typename GetAdjacentVertices, typename Graph, typename Visitor >
     void call_hawick_circuits(
         Graph const& graph, BOOST_FWD_REF(Visitor) visitor,
-        unsigned int const max_length)
+        unsigned int max_length)
     {
         call_hawick_circuits< GetAdjacentVertices >(graph,
             boost::forward< Visitor >(visitor), get(vertex_index, graph),
@@ -360,7 +360,7 @@ namespace hawick_circuits_detail
 template < typename Graph, typename Visitor, typename VertexIndexMap >
 void hawick_circuits(BOOST_FWD_REF(Graph) graph, BOOST_FWD_REF(Visitor) visitor,
     BOOST_FWD_REF(VertexIndexMap) vertex_index_map,
-    unsigned int const max_length = 0)
+    unsigned int max_length = 0)
 {
     hawick_circuits_detail::call_hawick_circuits<
         hawick_circuits_detail::get_all_adjacent_vertices >(
@@ -370,7 +370,7 @@ void hawick_circuits(BOOST_FWD_REF(Graph) graph, BOOST_FWD_REF(Visitor) visitor,
 
 template < typename Graph, typename Visitor >
 void hawick_circuits(BOOST_FWD_REF(Graph) graph, BOOST_FWD_REF(Visitor) visitor,
-    unsigned int const max_length = 0)
+    unsigned int max_length = 0)
 {
     hawick_circuits_detail::call_hawick_circuits<
         hawick_circuits_detail::get_all_adjacent_vertices >(
@@ -386,7 +386,7 @@ template < typename Graph, typename Visitor, typename VertexIndexMap >
 void hawick_unique_circuits(BOOST_FWD_REF(Graph) graph,
     BOOST_FWD_REF(Visitor) visitor,
     BOOST_FWD_REF(VertexIndexMap) vertex_index_map,
-    unsigned int const max_length = 0)
+    unsigned int max_length = 0)
 {
     hawick_circuits_detail::call_hawick_circuits<
         hawick_circuits_detail::get_unique_adjacent_vertices >(
@@ -397,7 +397,7 @@ void hawick_unique_circuits(BOOST_FWD_REF(Graph) graph,
 template < typename Graph, typename Visitor >
 void hawick_unique_circuits(
     BOOST_FWD_REF(Graph) graph, BOOST_FWD_REF(Visitor) visitor,
-    unsigned int const max_length = 0)
+    unsigned int max_length = 0)
 {
     hawick_circuits_detail::call_hawick_circuits<
         hawick_circuits_detail::get_unique_adjacent_vertices >(

--- a/include/boost/graph/hawick_circuits.hpp
+++ b/include/boost/graph/hawick_circuits.hpp
@@ -153,14 +153,14 @@ namespace hawick_circuits_detail
     public:
         hawick_circuits_from(Graph const& graph, Visitor& visitor,
             VertexIndexMap const& vim, Stack& stack, ClosedMatrix& closed,
-            VerticesSize n_vertices, unsigned int const maxLength)
+            VerticesSize n_vertices, unsigned int const max_length)
         : graph_(graph)
         , visitor_(visitor)
         , vim_(vim)
         , stack_(stack)
         , closed_(closed)
         , blocked_(n_vertices, vim_)
-        , maxLength_(maxLength)
+        , max_length_(max_length)
         {
             BOOST_ASSERT(blocked_map_starts_all_unblocked());
 
@@ -225,9 +225,9 @@ namespace hawick_circuits_detail
             stack_.push_back(v);
             block(v);
 
-            // Truncate the search if any circuits would exceed maxLength_.
+            // Truncate the search if any circuits would exceed max_length_.
             bool const truncate_search =
-                (maxLength_ > 0 && stack_.size() >= maxLength_);
+                (max_length_ > 0 && stack_.size() >= max_length_);
 
             // Cache some values that are used more than once in the function.
             VertexIndex const index_of_start = index_of(start);
@@ -298,14 +298,14 @@ namespace hawick_circuits_detail
         Stack& stack_;
         ClosedMatrix& closed_;
         BlockedMap blocked_;
-        unsigned int const maxLength_;
+        unsigned int const max_length_;
     };
 
     template < typename GetAdjacentVertices, typename Graph, typename Visitor,
         typename VertexIndexMap >
     void call_hawick_circuits(Graph const& graph,
         Visitor /* by value */ visitor, VertexIndexMap const& vertex_index_map,
-        unsigned int const maxLength)
+        unsigned int const max_length)
     {
         typedef graph_traits< Graph > Traits;
         typedef typename Traits::vertex_descriptor Vertex;
@@ -336,7 +336,7 @@ namespace hawick_circuits_detail
             // member variables of the sub algorithm.
             SubAlgorithm sub_algo(
                 graph, visitor, vertex_index_map, stack, closed, n_vertices,
-                maxLength);
+                max_length);
             sub_algo(*start);
             stack.clear();
             typename ClosedMatrix::iterator row, last_row = closed.end();
@@ -348,11 +348,11 @@ namespace hawick_circuits_detail
     template < typename GetAdjacentVertices, typename Graph, typename Visitor >
     void call_hawick_circuits(
         Graph const& graph, BOOST_FWD_REF(Visitor) visitor,
-        unsigned int const maxLength)
+        unsigned int const max_length)
     {
         call_hawick_circuits< GetAdjacentVertices >(graph,
             boost::forward< Visitor >(visitor), get(vertex_index, graph),
-            maxLength);
+            max_length);
     }
 } // end namespace hawick_circuits_detail
 
@@ -360,22 +360,22 @@ namespace hawick_circuits_detail
 template < typename Graph, typename Visitor, typename VertexIndexMap >
 void hawick_circuits(BOOST_FWD_REF(Graph) graph, BOOST_FWD_REF(Visitor) visitor,
     BOOST_FWD_REF(VertexIndexMap) vertex_index_map,
-    unsigned int const maxLength = 0)
+    unsigned int const max_length = 0)
 {
     hawick_circuits_detail::call_hawick_circuits<
         hawick_circuits_detail::get_all_adjacent_vertices >(
         boost::forward< Graph >(graph), boost::forward< Visitor >(visitor),
-        boost::forward< VertexIndexMap >(vertex_index_map), maxLength);
+        boost::forward< VertexIndexMap >(vertex_index_map), max_length);
 }
 
 template < typename Graph, typename Visitor >
 void hawick_circuits(BOOST_FWD_REF(Graph) graph, BOOST_FWD_REF(Visitor) visitor,
-    unsigned int const maxLength = 0)
+    unsigned int const max_length = 0)
 {
     hawick_circuits_detail::call_hawick_circuits<
         hawick_circuits_detail::get_all_adjacent_vertices >(
         boost::forward< Graph >(graph), boost::forward< Visitor >(visitor),
-        maxLength);
+        max_length);
 }
 
 /*!
@@ -386,23 +386,23 @@ template < typename Graph, typename Visitor, typename VertexIndexMap >
 void hawick_unique_circuits(BOOST_FWD_REF(Graph) graph,
     BOOST_FWD_REF(Visitor) visitor,
     BOOST_FWD_REF(VertexIndexMap) vertex_index_map,
-    unsigned int const maxLength = 0)
+    unsigned int const max_length = 0)
 {
     hawick_circuits_detail::call_hawick_circuits<
         hawick_circuits_detail::get_unique_adjacent_vertices >(
         boost::forward< Graph >(graph), boost::forward< Visitor >(visitor),
-        boost::forward< VertexIndexMap >(vertex_index_map), maxLength);
+        boost::forward< VertexIndexMap >(vertex_index_map), max_length);
 }
 
 template < typename Graph, typename Visitor >
 void hawick_unique_circuits(
     BOOST_FWD_REF(Graph) graph, BOOST_FWD_REF(Visitor) visitor,
-    unsigned int const maxLength = 0)
+    unsigned int const max_length = 0)
 {
     hawick_circuits_detail::call_hawick_circuits<
         hawick_circuits_detail::get_unique_adjacent_vertices >(
         boost::forward< Graph >(graph), boost::forward< Visitor >(visitor),
-        maxLength);
+        max_length);
 }
 } // end namespace boost
 

--- a/include/boost/graph/hawick_circuits.hpp
+++ b/include/boost/graph/hawick_circuits.hpp
@@ -153,13 +153,14 @@ namespace hawick_circuits_detail
     public:
         hawick_circuits_from(Graph const& graph, Visitor& visitor,
             VertexIndexMap const& vim, Stack& stack, ClosedMatrix& closed,
-            VerticesSize n_vertices)
+            VerticesSize n_vertices, unsigned int const maxLength)
         : graph_(graph)
         , visitor_(visitor)
         , vim_(vim)
         , stack_(stack)
         , closed_(closed)
         , blocked_(n_vertices, vim_)
+        , maxLength_(maxLength)
         {
             BOOST_ASSERT(blocked_map_starts_all_unblocked());
 
@@ -224,6 +225,10 @@ namespace hawick_circuits_detail
             stack_.push_back(v);
             block(v);
 
+            // Truncate the search if any circuits would exceed maxLength_.
+            bool const truncate_search =
+                (maxLength_ > 0 && stack_.size() >= maxLength_);
+
             // Cache some values that are used more than once in the function.
             VertexIndex const index_of_start = index_of(start);
             AdjacentVertices const adj_vertices
@@ -249,13 +254,19 @@ namespace hawick_circuits_detail
                     found_circuit = true;
                 }
 
+                // If required, truncate the search before the subsequent
+                // recursive call to circuit().
+                else if (truncate_search)
+                    continue;
+
                 // If `w` is not blocked, we continue searching further down the
                 // same path for a cycle with `w` in it.
                 else if (!is_blocked(w) && circuit(start, w))
                     found_circuit = true;
             }
 
-            if (found_circuit)
+            bool const finish_circuit = (found_circuit || truncate_search);
+            if (finish_circuit)
                 unblock(v);
             else
                 for (AdjacencyIterator w_it = boost::begin(adj_vertices);
@@ -274,7 +285,7 @@ namespace hawick_circuits_detail
 
             BOOST_ASSERT(v == stack_.back());
             stack_.pop_back();
-            return found_circuit;
+            return finish_circuit;
         }
 
     public:
@@ -287,12 +298,14 @@ namespace hawick_circuits_detail
         Stack& stack_;
         ClosedMatrix& closed_;
         BlockedMap blocked_;
+        unsigned int const maxLength_;
     };
 
     template < typename GetAdjacentVertices, typename Graph, typename Visitor,
         typename VertexIndexMap >
     void call_hawick_circuits(Graph const& graph,
-        Visitor /* by value */ visitor, VertexIndexMap const& vertex_index_map)
+        Visitor /* by value */ visitor, VertexIndexMap const& vertex_index_map,
+        unsigned int const maxLength)
     {
         typedef graph_traits< Graph > Traits;
         typedef typename Traits::vertex_descriptor Vertex;
@@ -322,7 +335,8 @@ namespace hawick_circuits_detail
             // construction. It would be strictly equivalent to have these as
             // member variables of the sub algorithm.
             SubAlgorithm sub_algo(
-                graph, visitor, vertex_index_map, stack, closed, n_vertices);
+                graph, visitor, vertex_index_map, stack, closed, n_vertices,
+                maxLength);
             sub_algo(*start);
             stack.clear();
             typename ClosedMatrix::iterator row, last_row = closed.end();
@@ -333,30 +347,35 @@ namespace hawick_circuits_detail
 
     template < typename GetAdjacentVertices, typename Graph, typename Visitor >
     void call_hawick_circuits(
-        Graph const& graph, BOOST_FWD_REF(Visitor) visitor)
+        Graph const& graph, BOOST_FWD_REF(Visitor) visitor,
+        unsigned int const maxLength)
     {
         call_hawick_circuits< GetAdjacentVertices >(graph,
-            boost::forward< Visitor >(visitor), get(vertex_index, graph));
+            boost::forward< Visitor >(visitor), get(vertex_index, graph),
+            maxLength);
     }
 } // end namespace hawick_circuits_detail
 
 //! Enumerate all the elementary circuits in a directed multigraph.
 template < typename Graph, typename Visitor, typename VertexIndexMap >
 void hawick_circuits(BOOST_FWD_REF(Graph) graph, BOOST_FWD_REF(Visitor) visitor,
-    BOOST_FWD_REF(VertexIndexMap) vertex_index_map)
+    BOOST_FWD_REF(VertexIndexMap) vertex_index_map,
+    unsigned int const maxLength = 0)
 {
     hawick_circuits_detail::call_hawick_circuits<
         hawick_circuits_detail::get_all_adjacent_vertices >(
         boost::forward< Graph >(graph), boost::forward< Visitor >(visitor),
-        boost::forward< VertexIndexMap >(vertex_index_map));
+        boost::forward< VertexIndexMap >(vertex_index_map), maxLength);
 }
 
 template < typename Graph, typename Visitor >
-void hawick_circuits(BOOST_FWD_REF(Graph) graph, BOOST_FWD_REF(Visitor) visitor)
+void hawick_circuits(BOOST_FWD_REF(Graph) graph, BOOST_FWD_REF(Visitor) visitor,
+    unsigned int const maxLength = 0)
 {
     hawick_circuits_detail::call_hawick_circuits<
         hawick_circuits_detail::get_all_adjacent_vertices >(
-        boost::forward< Graph >(graph), boost::forward< Visitor >(visitor));
+        boost::forward< Graph >(graph), boost::forward< Visitor >(visitor),
+        maxLength);
 }
 
 /*!
@@ -366,21 +385,24 @@ void hawick_circuits(BOOST_FWD_REF(Graph) graph, BOOST_FWD_REF(Visitor) visitor)
 template < typename Graph, typename Visitor, typename VertexIndexMap >
 void hawick_unique_circuits(BOOST_FWD_REF(Graph) graph,
     BOOST_FWD_REF(Visitor) visitor,
-    BOOST_FWD_REF(VertexIndexMap) vertex_index_map)
+    BOOST_FWD_REF(VertexIndexMap) vertex_index_map,
+    unsigned int const maxLength = 0)
 {
     hawick_circuits_detail::call_hawick_circuits<
         hawick_circuits_detail::get_unique_adjacent_vertices >(
         boost::forward< Graph >(graph), boost::forward< Visitor >(visitor),
-        boost::forward< VertexIndexMap >(vertex_index_map));
+        boost::forward< VertexIndexMap >(vertex_index_map), maxLength);
 }
 
 template < typename Graph, typename Visitor >
 void hawick_unique_circuits(
-    BOOST_FWD_REF(Graph) graph, BOOST_FWD_REF(Visitor) visitor)
+    BOOST_FWD_REF(Graph) graph, BOOST_FWD_REF(Visitor) visitor,
+    unsigned int const maxLength = 0)
 {
     hawick_circuits_detail::call_hawick_circuits<
         hawick_circuits_detail::get_unique_adjacent_vertices >(
-        boost::forward< Graph >(graph), boost::forward< Visitor >(visitor));
+        boost::forward< Graph >(graph), boost::forward< Visitor >(visitor),
+        maxLength);
 }
 } // end namespace boost
 

--- a/test/cycle_test.hpp
+++ b/test/cycle_test.hpp
@@ -10,6 +10,7 @@
 #define BOOST_GRAPH_TEST_CYCLE_TEST_HPP
 
 #include <boost/assert.hpp>
+#include <boost/core/lightweight_test.hpp>
 #include <boost/graph/directed_graph.hpp>
 #include <boost/graph/erdos_renyi_generator.hpp>
 #include <boost/graph/graph_traits.hpp>
@@ -52,7 +53,7 @@ struct cycle_validator
 };
 
 template < typename Graph, typename Algorithm >
-void test_one(Algorithm algorithm)
+void test_one(Algorithm algorithm, std::size_t num_cycles_expected)
 {
     typedef erdos_renyi_iterator< minstd_rand, Graph > er;
 
@@ -70,16 +71,22 @@ void test_one(Algorithm algorithm)
     cycle_validator vis(cycles);
     algorithm(g, vis);
     std::cout << "# cycles: " << vis.cycles << "\n";
+
+    BOOST_TEST(vis.cycles == num_cycles_expected);
 }
 } // end namespace cycle_test_detail
 
-template < typename Algorithm > void cycle_test(Algorithm const& algorithm)
+template < typename Algorithm > void cycle_test(Algorithm const& algorithm,
+  std::size_t num_cycles_expected_undirected,
+  std::size_t num_cycles_expected_directed)
 {
     std::cout << "*** undirected ***\n";
-    cycle_test_detail::test_one< boost::undirected_graph<> >(algorithm);
+    cycle_test_detail::test_one< boost::undirected_graph<> >(algorithm,
+      num_cycles_expected_undirected);
 
     std::cout << "*** directed ***\n";
-    cycle_test_detail::test_one< boost::directed_graph<> >(algorithm);
+    cycle_test_detail::test_one< boost::directed_graph<> >(algorithm,
+      num_cycles_expected_directed);
 }
 
 #endif // !BOOST_GRAPH_TEST_CYCLE_TEST_HPP

--- a/test/hawick_circuits.cpp
+++ b/test/hawick_circuits.cpp
@@ -34,15 +34,21 @@ struct call_hawick_unique_circuits
 
 int main()
 {
+    // The last two arguments to cycle_test() are the expected (correct)
+    // number of circuits in the undirected and directed test graphs.
+
     std::cout << "---------hawick_circuits---------\n";
-    cycle_test(call_hawick_circuits());
+    cycle_test(call_hawick_circuits(), 30, 31);
 
     std::cout << "\n\n---------hawick_unique_circuits---------\n";
-    cycle_test(call_hawick_unique_circuits());
+    cycle_test(call_hawick_unique_circuits(), 27, 24);
 
     std::cout << "\n\n---------hawick_circuits(max_length = 4)---------\n";
-    cycle_test(call_hawick_circuits(4));
+    cycle_test(call_hawick_circuits(4), 28, 13);
 
     std::cout << "\n\n---------hawick_unique_circuits(max_length = 4)---------\n";
-    cycle_test(call_hawick_unique_circuits(4));
+    cycle_test(call_hawick_unique_circuits(4), 25, 10);
+
+    std::cout << "\n\n";
+    return boost::report_errors();
 }

--- a/test/hawick_circuits.cpp
+++ b/test/hawick_circuits.cpp
@@ -43,11 +43,24 @@ int main()
     std::cout << "\n\n---------hawick_unique_circuits---------\n";
     cycle_test(call_hawick_unique_circuits(), 27, 24);
 
-    std::cout << "\n\n---------hawick_circuits(max_length = 4)---------\n";
-    cycle_test(call_hawick_circuits(4), 28, 13);
+    // Correct values for max_length = 0 to 10
+    // undirected
+    std::size_t nc1[] = { 30, 0, 22, 26, 28, 30, 30, 30, 30, 30, 30 };
+    // directed
+    std::size_t nc2[] = { 31, 0,  3,  7, 13, 17, 22, 24, 27, 30, 31 };
+    // undirected, unique
+    std::size_t nc3[] = { 27, 0, 19, 23, 25, 27, 27, 27, 27, 27, 27 };
+    // directed, unique
+    std::size_t nc4[] = { 24, 0,  3,  6, 10, 13, 17, 19, 21, 23, 24 };
+    for (unsigned int ml = 0; ml <= 10; ++ml) {
+        std::cout << "\n\n---------hawick_circuits(max_length = " << ml;
+        std::cout << ")---------\n";
+        cycle_test(call_hawick_circuits(ml), nc1[ml], nc2[ml]);
 
-    std::cout << "\n\n---------hawick_unique_circuits(max_length = 4)---------\n";
-    cycle_test(call_hawick_unique_circuits(4), 25, 10);
+        std::cout << "\n\n---------hawick_unique_circuits(max_length = " << ml;
+        std::cout << ")---------\n";
+        cycle_test(call_hawick_unique_circuits(ml), nc3[ml], nc4[ml]);
+    }
 
     std::cout << "\n\n";
     return boost::report_errors();

--- a/test/hawick_circuits.cpp
+++ b/test/hawick_circuits.cpp
@@ -10,19 +10,25 @@
 
 struct call_hawick_circuits
 {
+    unsigned int max_length;
+    call_hawick_circuits(unsigned int ml = 0) : max_length(ml) {}
+
     template < typename Graph, typename Visitor >
     void operator()(Graph const& g, Visitor const& v) const
     {
-        boost::hawick_circuits(g, v);
+        boost::hawick_circuits(g, v, max_length);
     }
 };
 
 struct call_hawick_unique_circuits
 {
+    unsigned int max_length;
+    call_hawick_unique_circuits(unsigned int ml = 0) : max_length(ml) {}
+
     template < typename Graph, typename Visitor >
     void operator()(Graph const& g, Visitor const& v) const
     {
-        boost::hawick_unique_circuits(g, v);
+        boost::hawick_unique_circuits(g, v, max_length);
     }
 };
 
@@ -33,4 +39,10 @@ int main()
 
     std::cout << "\n\n---------hawick_unique_circuits---------\n";
     cycle_test(call_hawick_unique_circuits());
+
+    std::cout << "\n\n---------hawick_circuits(max_length = 4)---------\n";
+    cycle_test(call_hawick_circuits(4));
+
+    std::cout << "\n\n---------hawick_unique_circuits(max_length = 4)---------\n";
+    cycle_test(call_hawick_unique_circuits(4));
 }


### PR DESCRIPTION
The number of circuits grows rapidly for larger graphs, so this is a way to reduce the computation time and still obtain useful partial results.