### PR TITLE
Fix hyperlink for disjoint sets in "Challenge and To-Do Items"

### DIFF
--- a/doc/challenge.html
+++ b/doc/challenge.html
@@ -37,7 +37,7 @@ review. The pending items are:</li>
      <tt>mutable_queue.hpp</tt>, <tt>fibonacci_heap.hpp</tt>.
       Somehow merge implementation with Dietmer's heaps and queues.</li>
 
-   <li><tt>disjoint_sets</tt> (see <a href="disjoint_sets.html">)</li>
+   <li><tt>disjoint_sets</tt> (see <a href="disjoint_sets.html">Disjoint Sets</a>)</li>
   </ul>
 
 <li>Construct a set of planar graph algorithms.</li>


### PR DESCRIPTION
The link text was messed up because the tag isn't closed.