### PR TITLE
Add missing include on boost/config.hpp

### DIFF
--- a/include/boost/graph/exception.hpp
+++ b/include/boost/graph/exception.hpp
@@ -13,6 +13,8 @@
 #include <stdexcept>
 #include <string>
 
+#include <boost/config.hpp>
+
 namespace boost
 {
 


### PR DESCRIPTION
exception.hpp uses BOOST_SYMBOL_VISIBLE, which is defined in boost/config.hpp. Without this, compiling just exception.hpp is broken.