### PR TITLE
Don't look for disjoint-sets representatives in link

### DIFF
--- a/include/boost/pending/detail/disjoint_sets.hpp
+++ b/include/boost/pending/detail/disjoint_sets.hpp
@@ -6,6 +6,8 @@
 #ifndef BOOST_DETAIL_DISJOINT_SETS_HPP
 #define BOOST_DETAIL_DISJOINT_SETS_HPP
 
+#include <cassert>
+
 namespace boost
 {
 
@@ -50,13 +52,11 @@ namespace detail
     /* the postcondition of link sets is:
      component_representative(i) == component_representative(j)
      */
-    template < class ParentPA, class RankPA, class Vertex,
-        class ComponentRepresentative >
-    inline void link_sets(ParentPA p, RankPA rank, Vertex i, Vertex j,
-        ComponentRepresentative comp_rep)
+    template < class ParentPA, class RankPA, class Vertex>
+    inline void link_sets(ParentPA p, RankPA rank, Vertex i, Vertex j)
     {
-        i = comp_rep(p, i);
-        j = comp_rep(p, j);
+        assert(i == get(p, i));
+        assert(j == get(p, j));
         if (i == j)
             return;
         if (get(rank, i) > get(rank, j))

--- a/include/boost/pending/disjoint_sets.hpp
+++ b/include/boost/pending/disjoint_sets.hpp
@@ -72,7 +72,7 @@ public:
     // Link - union the two sets represented by vertex x and y
     template < class Element > inline void link(Element x, Element y)
     {
-        detail::link_sets(parent, rank, x, y, rep);
+        detail::link_sets(parent, rank, x, y);
     }
 
     // Union-Set - union the two sets containing vertex x and y
@@ -146,7 +146,7 @@ public:
     template < class Element > inline void link(Element x, Element y)
     {
         extend_sets(x, y);
-        detail::link_sets(&parent[0], &rank[0], get(id, x), get(id, y), rep);
+        detail::link_sets(&parent[0], &rank[0], get(id, x), get(id, y));
     }
     template < class Element > inline void union_set(Element x, Element y)
     {


### PR DESCRIPTION
The arguments are already required to be the representative of their class. If we do not know the representatives, we are supposed to call union_set instead, which first finds them.
Fix #327. In my application (very similar to minimum spanning tree), this saves about 5% of the total running time, which is small but not negligible. That was with full path compression, I think the gains are larger with path halving, where a second consecutive call is non-trivial.
In example/incremental_components.cpp, there is a DS with vertex type size_t, but link is called on plain int, which can cause some conversion warnings. After the patch, in debug mode, it may become a warning about comparing the 2 types. Depending on your compiler and options, it may thus give a new warning where there was none, but in my opinion that's independent from this PR.