### PR TITLE
Add missing break to switch

### DIFF
--- a/src/read_graphviz_new.cpp
+++ b/src/read_graphviz_new.cpp
@@ -882,6 +882,7 @@ namespace read_graphviz_detail
                           "port location");
                 }
             }
+            break;
             default:
                 break;
             }


### PR DESCRIPTION
Clang warns about this with `-Wimplicit-fallthrough`.