### PR TITLE
Ubuntu Bionic is deprecated and GitHub will no longer host CI workers running on it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,53 +56,6 @@ jobs:
       - name: Test
         run: ../../../b2 toolset=$TOOLSET cxxstd=03,11,14,17,2a
         working-directory: ../boost-root/libs/graph/test
-  ubuntu-bionic:
-    runs-on: ubuntu-18.04
-    strategy:
-      fail-fast: false
-      matrix:
-        compiler: [ g++-7, g++-8, clang++-7, clang++-8 ]
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: '0'
-      - uses: mstachniuk/ci-skip@v1
-        with:
-          commit-filter: '[skip ci];[ci skip];[CI SKIP];[SKIP CI];***CI SKIP***;***SKIP CI***;[windows];[Windows];[WINDOWS];[apple];[Apple];[APPLE]'
-          commit-filter-separator: ';'
-          fail-fast: true
-      - name: Set TOOLSET
-        run: echo ${{ matrix.compiler }} | awk '/^g/ { print "TOOLSET=gcc" } /^clang/ { print "TOOLSET=clang" }' >> $GITHUB_ENV
-      - name: Add repository
-        run: sudo apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
-      - name: Install packages
-        run: sudo apt install g++-7 g++-8 clang-7 clang-8
-      - name: Checkout main boost
-        run: git clone -b develop --depth 1 https://github.com/boostorg/boost.git ../boost-root
-      - name: Update tools/boostdep
-        run: git submodule update --init tools/boostdep
-        working-directory: ../boost-root
-      - name: Copy files
-        run: cp -r $GITHUB_WORKSPACE/* libs/graph
-        working-directory: ../boost-root
-      - name: Install deps
-        run: python tools/boostdep/depinst/depinst.py graph
-        working-directory: ../boost-root
-      - name: Bootstrap
-        run: ./bootstrap.sh
-        working-directory: ../boost-root
-      - name: Generate headers
-        run: ./b2 headers
-        working-directory: ../boost-root
-      - name: Generate user config
-        run: 'echo "using $TOOLSET : : ${{ matrix.compiler }} ;" > ~/user-config.jam'
-        working-directory: ../boost-root
-      - name: Config info install
-        run: ../../../b2 print_config_info toolset=$TOOLSET cxxstd=03,11,14,17
-        working-directory: ../boost-root/libs/config/test
-      - name: Test
-        run: ../../../b2 toolset=$TOOLSET cxxstd=03,11,14,17
-        working-directory: ../boost-root/libs/graph/test
   macos:
     runs-on: macos-latest
     strategy:

--- a/example/fr_layout.cpp
+++ b/example/fr_layout.cpp
@@ -16,7 +16,7 @@
 #include <map>
 #include <vector>
 #include <boost/random/linear_congruential.hpp>
-#include <boost/progress.hpp>
+#include <boost/timer/progress_display.hpp>
 #include <boost/shared_ptr.hpp>
 
 using namespace boost;
@@ -67,7 +67,7 @@ class progress_cooling : public linear_cooling< double >
 public:
     explicit progress_cooling(std::size_t iterations) : inherited(iterations)
     {
-        display.reset(new progress_display(iterations + 1, std::cerr));
+        display.reset(new boost::timer::progress_display(iterations + 1, std::cerr));
     }
 
     double operator()()
@@ -77,7 +77,7 @@ public:
     }
 
 private:
-    shared_ptr< boost::progress_display > display;
+    shared_ptr< boost::timer::progress_display > display;
 };
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
GitHub blog: https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/

Also fixes:
- Deprecation of boost/progress.hpp

Hopefully after this PR is merged the CI builds actually succeed for the develop branch. After that, new features can be implemented.