### PR TITLE
Add support for GraphViz cgraph library

### DIFF
--- a/example/cgraph-example.cpp
+++ b/example/cgraph-example.cpp
@@ -1,0 +1,221 @@
+/* C++ Standard Library */
+#include <iostream>
+
+/* Boost Graph Library */
+#include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/topological_sort.hpp>
+#include <boost/graph/graph/cgraph_graph.hpp>
+
+/* Graphviz */
+#include <graphviz/gvc.h>
+
+void example_a()
+{
+    GVC_t * gvc = ::gvContext();
+
+    Agraph_t * g = ::agopen("g", Agdirected, nullptr);
+    Agnode_t * n = ::agnode(g, "n", 1);
+    Agnode_t * m = ::agnode(g, "m", 1);
+    Agedge_t * e = ::agedge(g, n, m, nullptr, 1);
+    ::agsafeset(n, "color", "red", "");
+
+    ::gvLayout(gvc, g, "dot");
+    ::gvRender(gvc, g, "plain", stdout);
+
+    ::gvFreeLayout(gvc, g);
+    ::agclose(g);
+
+    ::gvFreeContext(gvc);
+}
+
+void example_b()
+{
+    // create a typedef for the Graph type
+    typedef boost::cgraph_graph_ptr Graph;
+    typedef boost::property_map<Graph, boost::graph_name_t>::type GraphNameMap;
+    typedef boost::property_map<Graph, boost::vertex_index_t>::type VertexIndexMap;
+    typedef boost::property_map<Graph, boost::vertex_name_t>::type VertexNameMap;
+    typedef boost::property_map<Graph, boost::edge_index_t>::type EdgeIndexMap;
+    typedef boost::property_map<Graph, boost::edge_name_t>::type EdgeNameMap;
+
+    BOOST_CONCEPT_ASSERT((boost::MultiPassInputIteratorConcept<Graph>));
+
+    /* graph concepts */
+    BOOST_CONCEPT_ASSERT((boost::GraphConcept<Graph>));
+    BOOST_CONCEPT_ASSERT((boost::IncidenceGraphConcept<Graph>));
+    BOOST_CONCEPT_ASSERT((boost::BidirectionalGraphConcept<Graph>));
+    BOOST_CONCEPT_ASSERT((boost::AdjacencyGraphConcept<Graph>));
+    BOOST_CONCEPT_ASSERT((boost::VertexListGraphConcept<Graph>));
+    BOOST_CONCEPT_ASSERT((boost::EdgeListGraphConcept<Graph>));
+    BOOST_CONCEPT_ASSERT((boost::VertexAndEdgeListGraphConcept<Graph>));
+    BOOST_CONCEPT_ASSERT((boost::EdgeMutableGraphConcept<Graph>));
+    BOOST_CONCEPT_ASSERT((boost::VertexMutableGraphConcept<Graph>));
+    BOOST_CONCEPT_ASSERT((boost::MutableGraphConcept<Graph>));
+//    BOOST_CONCEPT_ASSERT((boost::MutableIncidenceGraphConcept<Graph>));
+//    BOOST_CONCEPT_ASSERT((boost::MutableBidirectionalGraphConcept<Graph>));
+//    BOOST_CONCEPT_ASSERT((boost::MutableEdgeListGraphConcept<Graph>));
+    BOOST_CONCEPT_ASSERT((boost::VertexMutablePropertyGraphConcept<Graph>));
+    BOOST_CONCEPT_ASSERT((boost::EdgeMutablePropertyGraphConcept<Graph>));
+//    BOOST_CONCEPT_ASSERT((boost::AdjacencyMatrixConcept<Graph>));
+    BOOST_CONCEPT_ASSERT((boost::ReadablePropertyGraphConcept<Graph, boost::graph_traits<Graph>::edge_descriptor, boost::edge_index_t>));
+    BOOST_CONCEPT_ASSERT((boost::ReadablePropertyGraphConcept<Graph, boost::graph_traits<Graph>::vertex_descriptor, boost::vertex_index_t>));
+    BOOST_CONCEPT_ASSERT((boost::ReadablePropertyGraphConcept<Graph, Graph, boost::graph_name_t>));
+    BOOST_CONCEPT_ASSERT((boost::ReadablePropertyGraphConcept<Graph, boost::graph_traits<Graph>::edge_descriptor, boost::edge_name_t>));
+    BOOST_CONCEPT_ASSERT((boost::ReadablePropertyGraphConcept<Graph, boost::graph_traits<Graph>::vertex_descriptor, boost::vertex_name_t>));
+//    BOOST_CONCEPT_ASSERT((boost::PropertyGraphConcept<Graph>));
+//    BOOST_CONCEPT_ASSERT((boost::LvaluePropertyGraphConcept<Graph>));
+//    BOOST_CONCEPT_ASSERT((boost::VertexIndexGraphConcept<Graph>));
+//    BOOST_CONCEPT_ASSERT((boost::EdgeIndexGraphConcept<Graph>));
+
+    /* utility concepts */
+//    BOOST_CONCEPT_ASSERT((boost::ColorValueConcept<C>));
+//    BOOST_CONCEPT_ASSERT((boost::BasicMatrixConcept<M, I, V>));
+//    BOOST_CONCEPT_ASSERT((boost::NumericValueConcept<Numeric>));
+//    BOOST_CONCEPT_ASSERT((boost::DegreeMeasureConcept<Measure, Graph>));
+//    BOOST_CONCEPT_ASSERT((boost::DistanceMeasureConcept<Measure, Graph>));
+
+    /* iterator concepts */
+    BOOST_CONCEPT_ASSERT((boost::InputIteratorConcept<Graph>));
+//    BOOST_CONCEPT_ASSERT((boost::OutputIteratorConcept<Graph, ValueT));
+    BOOST_CONCEPT_ASSERT((boost::ForwardIteratorConcept<Graph>));
+    BOOST_CONCEPT_ASSERT((boost::Mutable_ForwardIteratorConcept<Graph>));
+    BOOST_CONCEPT_ASSERT((boost::BidirectionalIteratorConcept<Graph>));
+    BOOST_CONCEPT_ASSERT((boost::Mutable_BidirectionalIteratorConcept<Graph>));
+    BOOST_CONCEPT_ASSERT((boost::RandomAccessIteratorConcept<Graph>));
+    BOOST_CONCEPT_ASSERT((boost::Mutable_RandomAccessIteratorConcept<Graph>));
+
+    /* property map concepts */
+    BOOST_CONCEPT_ASSERT((boost::ReadablePropertyMapConcept<boost::cgraph_graph_id_map, boost::graph_traits<Graph>::edge_descriptor>));
+    BOOST_CONCEPT_ASSERT((boost::ReadablePropertyMapConcept<boost::cgraph_graph_id_map, boost::graph_traits<Graph>::vertex_descriptor>));
+    BOOST_CONCEPT_ASSERT((boost::ReadablePropertyMapConcept<boost::cgraph_graph_name_map, Graph>));
+    BOOST_CONCEPT_ASSERT((boost::ReadablePropertyMapConcept<boost::cgraph_graph_name_map, boost::graph_traits<Graph>::edge_descriptor>));
+    BOOST_CONCEPT_ASSERT((boost::ReadablePropertyMapConcept<boost::cgraph_graph_name_map, boost::graph_traits<Graph>::vertex_descriptor>));
+//    BOOST_CONCEPT_ASSERT((boost::WritablePropertyMapConcept<boost::cgraph_graph_id_map, void *>));
+//    BOOST_CONCEPT_ASSERT((boost::ReadWritePropertyMapConcept<boost::cgraph_graph_id_map, void *>));
+//    BOOST_CONCEPT_ASSERT((boost::LvaluePropertyMapConcept<boost::cgraph_graph_id_map, void *>));
+//    BOOST_CONCEPT_ASSERT((boost::Mutable_LvaluePropertyMapConcept<boost::cgraph_graph_id_map, void *>));
+
+    GVC_t * gvc = ::gvContext();
+
+    // declare a graph object
+    Graph g = ::agopen("g", Agdirected, nullptr);
+
+    // add nodes
+    boost::graph_traits<Graph>::vertex_descriptor A = boost::add_vertex("A", g);
+    boost::graph_traits<Graph>::vertex_descriptor B = boost::add_vertex("B", g);
+    boost::graph_traits<Graph>::vertex_descriptor C = boost::add_vertex("C", g);
+    boost::graph_traits<Graph>::vertex_descriptor D = boost::add_vertex("D", g);
+    boost::graph_traits<Graph>::vertex_descriptor E = boost::add_vertex("E", g);
+
+    // add edges
+    std::pair<boost::graph_traits<Graph>::edge_descriptor, bool> AB = boost::add_edge(A, B, "AB", g);
+    std::pair<boost::graph_traits<Graph>::edge_descriptor, bool> AD = boost::add_edge(A, D, "AD", g);
+    std::pair<boost::graph_traits<Graph>::edge_descriptor, bool> CA = boost::add_edge(C, A, "CA", g);
+    std::pair<boost::graph_traits<Graph>::edge_descriptor, bool> DC = boost::add_edge(D, C, "DC", g);
+    std::pair<boost::graph_traits<Graph>::edge_descriptor, bool> CE = boost::add_edge(C, E, "CE", g);
+    std::pair<boost::graph_traits<Graph>::edge_descriptor, bool> BD = boost::add_edge(B, D, "BD", g);
+    std::pair<boost::graph_traits<Graph>::edge_descriptor, bool> DE = boost::add_edge(D, E, "DE", g);
+
+    std::cout << "vertices(g) = ";
+    typedef boost::graph_traits<Graph>::vertex_iterator vertex_iter;
+    VertexIndexMap vertexIndex = get(boost::vertex_index, g);
+    VertexNameMap vertexName = get(boost::vertex_name, g);
+    std::pair<vertex_iter, vertex_iter> vp;
+    for (vp = vertices(g); vp.first != vp.second; ++vp.first) {
+        const boost::graph_traits<Graph>::vertex_descriptor v = *vp.first;
+        std::cout << vertexIndex[v];
+        if(vertexName[v]) {
+            std::cout << ':' << vertexName[v];
+        }
+        std::cout << " ";
+    }
+    std::cout << std::endl;
+
+    std::cout << "edges(g) = ";
+    boost::graph_traits<Graph>::edge_iterator ei, ei_end;
+    EdgeIndexMap edgeIndex = get(boost::edge_index, g);
+    EdgeNameMap edgeName = get(boost::edge_name, g);
+    for (boost::tie(ei, ei_end) = boost::edges(g); ei != ei_end; ++ei) {
+        boost::graph_traits<Graph>::vertex_descriptor src = source(*ei, g);
+        boost::graph_traits<Graph>::vertex_descriptor trg = target(*ei, g);
+        std::cout << "(";
+        std::cout << edgeIndex[*ei];
+        if(edgeName[*ei]) {
+            std::cout << ':' << edgeName[*ei];
+        }
+        std::cout << ") ";
+    }
+    std::cout << std::endl;
+
+    std::cout << "out-edges of A: ";
+    boost::graph_traits<Graph>::out_edge_iterator out_i, out_end;
+    for (boost::tie(out_i, out_end) = out_edges(A, g); out_i != out_end; ++out_i) {
+        boost::graph_traits<Graph>::vertex_descriptor src = source(*out_i, g);
+        boost::graph_traits<Graph>::vertex_descriptor targ = target(*out_i, g);
+        std::cout << "(";
+        std::cout << edgeIndex[*out_i];
+        if(edgeName[*out_i]) {
+            std::cout << ':' << edgeName[*out_i];
+        }
+        std::cout << ") ";
+    }
+    std::cout << std::endl;
+
+    std::cout << "in-edges of A: ";
+    boost::graph_traits<Graph>::in_edge_iterator in_i, in_end;
+    for (boost::tie(in_i, in_end) = in_edges(A, g); in_i != in_end; ++in_i) {
+        boost::graph_traits<Graph>::vertex_descriptor src = source(*in_i, g);
+        boost::graph_traits<Graph>::vertex_descriptor targ = target(*in_i, g);
+        std::cout << "(";
+        std::cout << edgeIndex[*in_i];
+        if(edgeName[*in_i]) {
+            std::cout << ':' << edgeName[*in_i];
+        }
+        std::cout << ") ";
+    }
+    std::cout << std::endl;
+
+    std::cout << "adjacent vertices of C: ";
+    boost::graph_traits<Graph>::adjacency_iterator ai, ai_end;
+    for (boost::tie(ai, ai_end) = adjacent_vertices(C, g); ai != ai_end; ++ai) {
+        std::cout << "(";
+        std::cout << edgeIndex[*ai];
+        if(edgeName[*ai]) {
+            std::cout << ':' << edgeName[*ai];
+        }
+        std::cout << ") ";
+    }
+    std::cout << std::endl;
+
+    // @todo the following terminates with
+    // terminate called after throwing an instance of 'boost::wrapexcept<boost::not_a_dag>'
+    //     what():  The graph must be a DAG.
+    typedef boost::graph_traits<Graph>::vertex_descriptor Vertex;
+    typedef std::list<Vertex> container;
+    std::list<Vertex> c;
+    std::map<Vertex, boost::default_color_type> vertex_colors;
+    boost::topological_sort(g, std::back_inserter(c), boost::color_map(boost::make_assoc_property_map(vertex_colors)));
+    std::cout << "A topological ordering: ";
+    for (container::reverse_iterator ii = c.rbegin(); ii != c.rend(); ++ii) {
+        std::cout << vertexIndex[*ii];
+        if(vertexName[*ii]) {
+            std::cout << ':' << vertexName[*ii];
+        }
+    }
+    std::cout << std::endl;
+
+    ::gvLayout(gvc, g, "dot");
+    ::gvRender(gvc, g, "plain", stdout);
+
+    ::gvFreeLayout(gvc, g);
+    ::agclose(g);
+
+    ::gvFreeContext(gvc);
+}
+
+int main(int argc, char *argv[])
+{
+    example_b();
+
+    return EXIT_SUCCESS;
+}

--- a/include/boost/graph/cgraph_graph.hpp
+++ b/include/boost/graph/cgraph_graph.hpp
@@ -1,0 +1,758 @@
+/*
+ * Copyright (C) 2023 Tobias Lorenz
+ *
+ * Author: tobias.lorenz@gmx.net
+ *
+ * Distributed under the Boost Software License, Version 1.0. (See
+ * accompanying file LICENSE_1_0.txt or copy at
+ * http://www.boost.org/LICENSE_1_0.txt)
+ */
+
+#ifndef BOOST_GRAPH_CGRAPH_GRAPH_HPP
+#define BOOST_GRAPH_CGRAPH_GRAPH_HPP
+
+/* C++ Standard Library */
+#include <cassert>
+
+/* Boost Graph Library */
+#include <boost/graph/graph_traits.hpp>
+#include <boost/graph/properties.hpp>
+
+/* Graphviz */
+#include <graphviz/cgraph.h>
+
+namespace boost {
+
+// @todo subgraphs are not handled yet
+
+typedef ::Agraph_t * cgraph_graph_ptr;
+
+#define cgraph_type Agdirected
+//#define cgraph_type Agstrictdirected
+//#define cgraph_type Agundirected
+//#define cgraph_type Agstrictundirected
+
+template <>
+struct graph_traits<cgraph_graph_ptr>
+{
+    /* Graph */
+
+    typedef ::Agnode_t * vertex_descriptor;
+    typedef ::Agedge_t * edge_descriptor;
+
+// @todo How can this runtime setting be handled in the template?
+#if cgraph_type == Agdirected
+    // Agdirected (digraph)
+    typedef bidirectional_tag directed_category;
+    typedef allow_parallel_edge_tag edge_parallel_category;
+#elif cgraph_type == Agstrictdirected
+    // Agstrictdirected (strict digraph)
+    typedef bidirectional_tag directed_category;
+    typedef disallow_parallel_edge_tag edge_parallel_category;
+#elif cgraph_type == Agundirected
+    // Agundirected (graph)
+    typedef undirected_tag directed_category;
+    typedef allow_parallel_edge_tag edge_parallel_category;
+#elif cgraph_type == Agstrictundirected
+    // Agstrictundirected (strict graph)
+    typedef undirected_tag directed_category;
+    typedef disallow_parallel_edge_tag edge_parallel_category;
+#endif
+    struct traversal_category:
+        //public virtual incidence_graph_tag, // included in bidirectional_graph_tag
+        public virtual adjacency_graph_tag,
+        public virtual bidirectional_graph_tag,
+        public virtual vertex_list_graph_tag,
+        public virtual edge_list_graph_tag
+        //public virtual adjacency_matrix_tag, => edge(u, v, g)
+    {
+    };
+
+    static constexpr vertex_descriptor null_vertex()
+    {
+        return nullptr;
+    }
+
+    /* IncidenceGraph */
+
+    class out_edge_iterator:
+        public iterator_facade<out_edge_iterator, edge_descriptor, forward_traversal_tag, edge_descriptor>
+    {
+    public:
+        explicit out_edge_iterator(edge_descriptor edge = nullptr, cgraph_graph_ptr graph = nullptr):
+            edge(edge),
+            graph(graph)
+        {
+        }
+
+    private:
+        reference dereference() const
+        {
+            return edge;
+        }
+
+        bool equal(const out_edge_iterator & j) const
+        {
+            return edge == j.edge;
+        }
+
+        void increment()
+        {
+            assert(graph);
+            assert(edge);
+            edge = ::agnxtout(graph, edge);
+        }
+
+        edge_descriptor edge{nullptr};
+        cgraph_graph_ptr graph{nullptr};
+
+        friend class iterator_core_access;
+    };
+
+    typedef int degree_size_type;
+
+    /* BidirectionalGraph */
+
+    class in_edge_iterator:
+        public iterator_facade<in_edge_iterator, edge_descriptor, forward_traversal_tag, edge_descriptor>
+    {
+    public:
+        explicit in_edge_iterator(edge_descriptor edge = nullptr, cgraph_graph_ptr graph = nullptr):
+            edge(edge),
+            graph(graph)
+        {
+        }
+
+    private:
+        reference dereference() const
+        {
+            return edge;
+        }
+
+        bool equal(const in_edge_iterator & j) const
+        {
+            return edge == j.edge;
+        }
+
+        void increment()
+        {
+            assert(graph);
+            assert(edge);
+            edge = ::agnxtin(graph, edge);
+        }
+
+        edge_descriptor edge{nullptr};
+        cgraph_graph_ptr graph{nullptr};
+
+        friend class iterator_core_access;
+    };
+
+    /* AdjacencyGraph */
+
+    class adjacency_iterator:
+        public iterator_facade<adjacency_iterator, vertex_descriptor, forward_traversal_tag, vertex_descriptor>
+    {
+    public:
+        explicit adjacency_iterator(vertex_descriptor node = nullptr, edge_descriptor edge = nullptr, cgraph_graph_ptr graph = nullptr):
+            node(node),
+            edge(edge),
+            graph(graph)
+        {
+        }
+
+    private:
+        reference dereference() const
+        {
+            assert(edge);
+            return aghead(edge);
+        }
+
+        bool equal(const adjacency_iterator & j) const
+        {
+            return (node == j.node) && (edge == j.edge);
+        }
+
+        void increment()
+        {
+            assert(graph);
+            if (::agisdirected(graph)) {
+                assert(edge);
+                edge = ::agnxtout(graph, edge);
+            }
+            if (::agisundirected(graph)) {
+                assert(edge);
+                assert(node);
+                edge = ::agnxtedge(graph, edge, node);
+            }
+        }
+
+        vertex_descriptor node{nullptr};
+        edge_descriptor edge{nullptr};
+        cgraph_graph_ptr graph{nullptr};
+
+        friend class iterator_core_access;
+    };
+
+    /* VertexListGraph */
+
+    class vertex_iterator:
+        public iterator_facade<vertex_iterator, vertex_descriptor, bidirectional_traversal_tag, vertex_descriptor>
+    {
+    public:
+        explicit vertex_iterator(vertex_descriptor node = nullptr, cgraph_graph_ptr graph = nullptr):
+            node(node),
+            graph(graph)
+        {
+        }
+
+    private:
+        reference dereference() const
+        {
+            return node;
+        }
+
+        bool equal(const vertex_iterator & j) const
+        {
+            return node == j.node;
+        }
+
+        void increment()
+        {
+            assert(graph);
+            assert(node);
+            node = ::agnxtnode(graph, node);
+        }
+
+        void decrement()
+        {
+            assert(graph);
+            assert(node);
+            node = ::agprvnode(graph, node);
+        }
+
+//        void advance(difference_type n)
+//        {
+//            while (n > 0) {
+//                increment();
+//                n--;
+//            }
+//            while (n < 0) {
+//                decrement();
+//                n++;
+//            }
+//        }
+
+//        difference_type distance_to(const vertex_iterator & j) const
+//        {
+//            difference_type n = 0;
+//            vertex_descriptor jnode = j.node;
+//            while(node != jnode) {
+//                jnode = ::agnxtnode(graph, jnode);
+//                n++;
+//            }
+//            return n;
+//        }
+
+        vertex_descriptor node{nullptr};
+        cgraph_graph_ptr graph{nullptr};
+
+        friend class iterator_core_access;
+    };
+
+    typedef int vertices_size_type;
+
+    /* EdgeListGraph */
+
+    class edge_iterator:
+        public iterator_facade<edge_iterator, edge_descriptor, forward_traversal_tag, edge_descriptor>
+    {
+    public:
+        explicit edge_iterator(vertex_descriptor node = nullptr, edge_descriptor edge = nullptr, const cgraph_graph_ptr graph = nullptr):
+            node(node),
+            edge(edge),
+            graph(graph)
+        {
+        }
+
+    private:
+        const edge_descriptor & dereference() const
+        {
+            return edge;
+        }
+
+        bool equal(const edge_iterator & j) const
+        {
+            return edge == j.edge;
+        }
+
+        void increment()
+        {
+            assert(graph);
+            if (::agisdirected(graph)) {
+                assert(edge);
+                edge = ::agnxtout(graph, edge);
+                if (!edge) {
+                    node = ::agnxtnode(graph, node);
+                    if (node) {
+                        edge = ::agfstout(graph, node);
+                    }
+                }
+            }
+            if (::agisundirected(graph)) {
+                assert(edge);
+                assert(node);
+                edge = ::agnxtedge(graph, edge, node);
+                if (!edge) {
+                    node = ::agnxtnode(graph, node);
+                    if (node) {
+                        edge = ::agfstedge(graph, node);
+                    }
+                }
+            }
+        }
+
+        vertex_descriptor node{nullptr};
+        edge_descriptor edge{nullptr};
+        cgraph_graph_ptr graph{nullptr};
+
+        friend class iterator_core_access;
+    };
+
+    typedef int edges_size_type;
+
+    /* MutablePropertyGraph */
+
+    // @todo the following typedefs are suffient to set the name, however std::map would allow all attributes to be set.
+    typedef char * edge_property_type;
+    typedef char * vertex_property_type;
+};
+
+/* IncidenceGraph */
+
+graph_traits<cgraph_graph_ptr>::vertex_descriptor source(graph_traits<cgraph_graph_ptr>::edge_descriptor e, const cgraph_graph_ptr & g)
+{
+    assert(e);
+    assert(g);
+    return agtail(e);
+}
+
+graph_traits<cgraph_graph_ptr>::vertex_descriptor target(graph_traits<cgraph_graph_ptr>::edge_descriptor e, const cgraph_graph_ptr & g)
+{
+    assert(e);
+    assert(g);
+    return aghead(e);
+}
+
+inline std::pair<graph_traits<cgraph_graph_ptr>::out_edge_iterator, graph_traits<cgraph_graph_ptr>::out_edge_iterator> out_edges(graph_traits<cgraph_graph_ptr>::vertex_descriptor v, const cgraph_graph_ptr & g)
+{
+    assert(v);
+    assert(g);
+    typedef graph_traits<cgraph_graph_ptr>::out_edge_iterator Iter;
+    return std::make_pair(Iter(::agfstout(g, v), g), Iter(nullptr, g));
+}
+
+graph_traits<cgraph_graph_ptr>::degree_size_type out_degree(graph_traits<cgraph_graph_ptr>::vertex_descriptor v, const cgraph_graph_ptr & g)
+{
+    assert(v);
+    assert(g);
+    // @todo agdegree or agcountuniqedges ?
+    return ::agdegree(g, v, 0, 1);
+}
+
+/* BidirectionalGraph */
+
+inline std::pair<graph_traits<cgraph_graph_ptr>::in_edge_iterator, graph_traits<cgraph_graph_ptr>::in_edge_iterator> in_edges(graph_traits<cgraph_graph_ptr>::vertex_descriptor v, const cgraph_graph_ptr & g)
+{
+    assert(v);
+    assert(g);
+    typedef graph_traits<cgraph_graph_ptr>::in_edge_iterator Iter;
+    return std::make_pair(Iter(::agfstin(g, v), g), Iter(nullptr, g));
+}
+
+graph_traits<cgraph_graph_ptr>::degree_size_type in_degree(graph_traits<cgraph_graph_ptr>::vertex_descriptor v, const cgraph_graph_ptr & g)
+{
+    assert(v);
+    assert(g);
+    return ::agdegree(g, v, 1, 0);
+}
+
+graph_traits<cgraph_graph_ptr>::degree_size_type degree(graph_traits<cgraph_graph_ptr>::vertex_descriptor u, const cgraph_graph_ptr & g)
+{
+    assert(u);
+    assert(g);
+    return ::agdegree(g, u, 1, 1);
+}
+
+/* AdjacencyGraph */
+
+inline std::pair<graph_traits<cgraph_graph_ptr>::adjacency_iterator, graph_traits<cgraph_graph_ptr>::adjacency_iterator> adjacent_vertices(graph_traits<cgraph_graph_ptr>::vertex_descriptor v, const cgraph_graph_ptr & g)
+{
+    assert(v);
+    assert(g);
+    typedef graph_traits<cgraph_graph_ptr>::adjacency_iterator Iter;
+    if (::agisdirected(g)) {
+        return std::make_pair(Iter(v, ::agfstout(g, v), g), Iter(v, nullptr, g));
+    }
+    if (::agisundirected(g)) {
+        return std::make_pair(Iter(v, ::agfstedge(g, v), g), Iter(v, nullptr, g));
+    }
+    return std::make_pair(Iter(v, nullptr, g), Iter(v, nullptr, g));
+}
+
+/* VertexListGraph */
+
+inline std::pair<graph_traits<cgraph_graph_ptr>::vertex_iterator, graph_traits<cgraph_graph_ptr>::vertex_iterator> vertices(const cgraph_graph_ptr & g)
+{
+    assert(g);
+    typedef graph_traits<cgraph_graph_ptr>::vertex_iterator Iter;
+    return std::make_pair(Iter(::agfstnode(g), g), Iter(nullptr, g));
+}
+
+graph_traits<cgraph_graph_ptr>::vertices_size_type num_vertices(const cgraph_graph_ptr & g)
+{
+    assert(g);
+    return ::agnnodes(g);
+}
+
+/* EdgeListGraph */
+
+inline std::pair<graph_traits<cgraph_graph_ptr>::edge_iterator, graph_traits<cgraph_graph_ptr>::edge_iterator> edges(const cgraph_graph_ptr & g)
+{
+    assert(g);
+    typedef graph_traits<cgraph_graph_ptr>::edge_iterator Iter;
+    graph_traits<cgraph_graph_ptr>::vertex_descriptor n = ::agfstnode(g);
+    assert(n);
+    if (::agisdirected(g)) {
+        graph_traits<cgraph_graph_ptr>::edge_descriptor e = ::agfstedge(g, n);
+        return std::make_pair(Iter(n, e, g), Iter(nullptr, nullptr, g));
+    }
+    if (::agisundirected(g)) {
+        graph_traits<cgraph_graph_ptr>::edge_descriptor e = ::agfstedge(g, n);
+        return std::make_pair(Iter(n, e, g), Iter(nullptr, nullptr, g));
+    }
+    return std::make_pair(Iter(nullptr, nullptr, g), Iter(nullptr, nullptr, g));
+}
+
+graph_traits<cgraph_graph_ptr>::edges_size_type num_edges(const cgraph_graph_ptr & g)
+{
+    assert(g);
+    return ::agnedges(g);
+}
+
+// source(e, g) defines in IncidenceGraph
+// target(e, g) defined in IncidenceGraph
+
+/* AdjancencyMatrix */
+
+// edge(u, v, g)
+
+/* MutableGraph */
+
+std::pair<graph_traits<cgraph_graph_ptr>::edge_descriptor, bool> add_edge(graph_traits<cgraph_graph_ptr>::vertex_descriptor u, graph_traits<cgraph_graph_ptr>::vertex_descriptor v, cgraph_graph_ptr g)
+{
+    assert(u);
+    assert(v);
+    assert(g);
+    graph_traits<cgraph_graph_ptr>::edge_descriptor edge = ::agedge(g, u, v, nullptr, 1);
+    return std::make_pair(edge, true); // @todo false if strict and edge exists already
+}
+
+void remove_edge(graph_traits<cgraph_graph_ptr>::vertex_descriptor u, graph_traits<cgraph_graph_ptr>::vertex_descriptor v, cgraph_graph_ptr g)
+{
+    assert(u);
+    assert(v);
+    assert(g);
+    graph_traits<cgraph_graph_ptr>::edge_descriptor edge = ::agedge(g, u, v, nullptr, 0);
+    if (edge) {
+        ::agdeledge(g, edge);
+    }
+}
+
+void remove_edge(graph_traits<cgraph_graph_ptr>::edge_descriptor e, cgraph_graph_ptr g)
+{
+    assert(e);
+    assert(g);
+    ::agdeledge(g, e);
+}
+
+void remove_edge(graph_traits<cgraph_graph_ptr>::out_edge_iterator iter, cgraph_graph_ptr g)
+{
+    assert(*iter);
+    assert(g);
+    ::agdeledge(g, *iter);
+}
+
+template<typename Predicate>
+void remove_edge_if(Predicate p, cgraph_graph_ptr g)
+{
+    // assert(p);
+    assert(g);
+    for (graph_traits<cgraph_graph_ptr>::vertex_descriptor v = ::agfstnode(g); v; v = ::agnxtnode(g, v)) {
+        for (graph_traits<cgraph_graph_ptr>::edge_descriptor e = ::agfstout(g, v); e; e = ::agnxtout(g, e)) {
+            if (p(e)) {
+                ::agdeledge(g, e);
+            }
+        }
+    }
+}
+
+template<typename Predicate>
+void remove_out_edge_if(graph_traits<cgraph_graph_ptr>::vertex_descriptor u, Predicate p, cgraph_graph_ptr g)
+{
+    assert(u);
+    // assert(p);
+    assert(g);
+    for (graph_traits<cgraph_graph_ptr>::edge_descriptor e = ::agfstout(g, u); e; e = ::agnxtout(g, e)) {
+        if (p(e)) {
+            ::agdeledge(g, e);
+        }
+    }
+}
+
+template<typename Predicate>
+void remove_in_edge_if(graph_traits<cgraph_graph_ptr>::vertex_descriptor u, Predicate p, cgraph_graph_ptr g)
+{
+    assert(u);
+    // assert(p);
+    assert(g);
+    for (graph_traits<cgraph_graph_ptr>::edge_descriptor e = ::agfstin(g, u); e; e = ::agnxtin(g, e)) {
+        if (p(e)) {
+            ::agdeledge(g, e);
+        }
+    }
+}
+
+graph_traits<cgraph_graph_ptr>::vertex_descriptor add_vertex(cgraph_graph_ptr g)
+{
+    assert(g);
+    return ::agnode(g, nullptr, 1);
+}
+
+void clear_vertex(graph_traits<cgraph_graph_ptr>::vertex_descriptor v, cgraph_graph_ptr g)
+{
+    assert(v);
+    assert(g);
+    for (graph_traits<cgraph_graph_ptr>::edge_descriptor e = ::agfstout(g, v); e; e = ::agnxtout(g, e)) {
+        ::agdeledge(g, e);
+    }
+    for (graph_traits<cgraph_graph_ptr>::edge_descriptor e = ::agfstin(g, v); e; e = ::agnxtin(g, e)) {
+        ::agdeledge(g, e);
+    }
+}
+
+void remove_vertex(graph_traits<cgraph_graph_ptr>::vertex_descriptor v, cgraph_graph_ptr g)
+{
+    assert(v);
+    assert(g);
+    ::agdelnode(g, v);
+}
+
+/* PropertyGraph */
+
+class cgraph_graph_id_map :
+    public put_get_helper<::IDTYPE, cgraph_graph_id_map>
+{
+public:
+    typedef readable_property_map_tag category;
+    typedef ::IDTYPE value_type;
+    typedef ::IDTYPE reference;
+    typedef void * key_type;
+
+    cgraph_graph_id_map()
+    {
+    }
+
+    ::IDTYPE operator[](void * x) const
+    {
+        assert(x);
+        return AGID(x);
+    }
+};
+
+inline cgraph_graph_id_map get(edge_index_t /*p*/, const cgraph_graph_ptr & g)
+{
+    // assert(p);
+    assert(g);
+    return cgraph_graph_id_map();
+}
+
+inline ::IDTYPE get(edge_index_t p, const cgraph_graph_ptr & g, const graph_traits<cgraph_graph_ptr>::edge_descriptor & x)
+{
+    // assert(p);
+    assert(g);
+    assert(x);
+    return get(get(p, g), x);
+}
+
+inline cgraph_graph_id_map get(vertex_index_t /*p*/, const cgraph_graph_ptr & g)
+{
+    // assert(p);
+    assert(g);
+    return cgraph_graph_id_map();
+}
+
+inline ::IDTYPE get(vertex_index_t p, const cgraph_graph_ptr & g, const graph_traits<cgraph_graph_ptr>::vertex_descriptor & x)
+{
+    // assert(p);
+    assert(g);
+    assert(x);
+    return get(get(p, g), x);
+}
+
+template<>
+struct property_map<cgraph_graph_ptr, edge_index_t>
+{
+    typedef cgraph_graph_id_map type;
+    typedef cgraph_graph_id_map const_type;
+};
+
+template<>
+struct property_map<cgraph_graph_ptr, vertex_index_t>
+{
+    typedef cgraph_graph_id_map type;
+    typedef cgraph_graph_id_map const_type;
+};
+
+class cgraph_graph_name_map :
+    public put_get_helper<char *, cgraph_graph_name_map>
+{
+public:
+    typedef readable_property_map_tag category;
+    typedef char * value_type;
+    typedef char * reference;
+    typedef void * key_type;
+
+    cgraph_graph_name_map()
+    {
+    }
+
+    char * operator[](void * x) const
+    {
+        assert(x);
+        return ::agnameof(x);
+    }
+};
+
+inline cgraph_graph_name_map get(graph_name_t /*p*/, const cgraph_graph_ptr & g)
+{
+    // assert(p);
+    assert(g);
+    return cgraph_graph_name_map();
+}
+
+inline char * get(graph_name_t p, const cgraph_graph_ptr & g, const cgraph_graph_ptr & x)
+{
+    // assert(p);
+    assert(g);
+    assert(x);
+    return get(get(p, g), x);
+}
+
+inline cgraph_graph_name_map get(edge_name_t /*p*/, const cgraph_graph_ptr & g)
+{
+    // assert(p);
+    assert(g);
+    return cgraph_graph_name_map();
+}
+
+inline char * get(edge_name_t p, const cgraph_graph_ptr & g, const graph_traits<cgraph_graph_ptr>::edge_descriptor & x)
+{
+    // assert(p);
+    assert(g);
+    assert(x);
+    return get(get(p, g), x);
+}
+
+inline cgraph_graph_name_map get(vertex_name_t /*p*/, const cgraph_graph_ptr & g)
+{
+    // assert(p);
+    assert(g);
+    return cgraph_graph_name_map();
+}
+
+inline char * get(vertex_name_t p, const cgraph_graph_ptr & g, const graph_traits<cgraph_graph_ptr>::vertex_descriptor & x)
+{
+    // assert(p);
+    assert(g);
+    assert(x);
+    return get(get(p, g), x);
+}
+
+template<>
+struct property_map<cgraph_graph_ptr, graph_name_t>
+{
+    typedef cgraph_graph_name_map type;
+    typedef cgraph_graph_name_map const_type;
+};
+
+template<>
+struct property_map<cgraph_graph_ptr, edge_name_t>
+{
+    typedef cgraph_graph_name_map type;
+    typedef cgraph_graph_name_map const_type;
+};
+
+template<>
+struct property_map<cgraph_graph_ptr, vertex_name_t>
+{
+    typedef cgraph_graph_name_map type;
+    typedef cgraph_graph_name_map const_type;
+};
+
+// @todo how are all the other graphviz properties be handled?
+
+/* MutablePropertyGraph */
+
+template<>
+struct edge_property_type<cgraph_graph_ptr>
+{
+    typedef graph_traits<cgraph_graph_ptr>::edge_property_type type;
+};
+
+std::pair<graph_traits<cgraph_graph_ptr>::edge_descriptor, bool> add_edge(graph_traits<cgraph_graph_ptr>::vertex_descriptor u, graph_traits<cgraph_graph_ptr>::vertex_descriptor v, graph_traits<cgraph_graph_ptr>::edge_property_type ep, cgraph_graph_ptr g)
+{
+    assert(u);
+    assert(v);
+    assert(ep);
+    assert(g);
+    graph_traits<cgraph_graph_ptr>::edge_descriptor edge = ::agedge(g, u, v, ep, 1);
+    return std::make_pair(edge, true); // @todo false if strict and edge exists already
+}
+
+template<>
+struct vertex_property_type<cgraph_graph_ptr>
+{
+    typedef graph_traits<cgraph_graph_ptr>::vertex_property_type type;
+};
+
+graph_traits<cgraph_graph_ptr>::vertex_descriptor add_vertex(graph_traits<cgraph_graph_ptr>::vertex_property_type vp, cgraph_graph_ptr g)
+{
+    assert(vp);
+    assert(g);
+    return ::agnode(g, vp, 1);
+}
+
+} // namespace boost
+
+/* @todo got concept check failures (fpermissive) without this... */
+using boost::out_edges;
+using boost::source;
+using boost::target;
+using boost::out_degree;
+using boost::in_edges;
+using boost::in_degree;
+using boost::degree;
+using boost::adjacent_vertices;
+using boost::vertices;
+using boost::num_vertices;
+using boost::edges;
+using boost::num_edges;
+using boost::add_vertex;
+using boost::clear_vertex;
+using boost::remove_vertex;
+using boost::add_edge;
+using boost::remove_edge;
+using boost::get;
+using boost::put;
+
+#endif // BOOST_GRAPH_CGRAPH_GRAPH_HPP


### PR DESCRIPTION
Hi,

GraphViz provides a native C API, called cgraph.
This adds supports for cgraph in a similar way to existing leda_graph.hpp and stanford_graph.hpp implementations.

The implementation already works well and fulfills all static `BOOST_CONCEPT_ASSERT` tests. However there are some issues remaining though. I tagged all issues in the source code with `@todo`.

1. The cgraph (`Agraph_t`) can be made directed or undirected, and also strict (=disallow parallel edges) or not. This is a runtime setting, set during instantiation or determined when loading graphviz files. I found now suitable way to handle this runtime setting already in the template in order to define the typedefs for bidirectional_tag and allow_parallel_edge_tag. How can this be handled?
2. cgraph has a longer list of properties on all levels, which I don't want to define all as property_tags. Is there a way to dynamically handle this and prevent `BOOST_DEF_PROPERTY`, property_map<...>, get, ... implementations for each of them?
3. The add_edge(u, v, ep, g) and add_vertex(vp, g) functions are currently configured to transport the edge's name in ep resp. the vertex's name in vp. But I could also feed in a std::map, so that `add_vertex("V", g)` becomes `add_vertex{{"name", "V"}, g)`. Would that make sense?
4. The boost concept checks fail, unless I pull all functions into global namespace by `using boost::out_edges;`, .... Any idea why this happens?
5. subgraphs are currently not implemented.

Bye
Tobias