### PR TITLE
Add a missing include to topology.hpp

### DIFF
--- a/include/boost/graph/topology.hpp
+++ b/include/boost/graph/topology.hpp
@@ -10,15 +10,16 @@
 #ifndef BOOST_GRAPH_TOPOLOGY_HPP
 #define BOOST_GRAPH_TOPOLOGY_HPP
 
-#include <boost/config/no_tr1/cmath.hpp>
-#include <cmath>
-#include <boost/random/uniform_01.hpp>
-#include <boost/random/linear_congruential.hpp>
-#include <boost/math/constants/constants.hpp> // For root_two
 #include <boost/algorithm/minmax.hpp>
 #include <boost/config.hpp> // For BOOST_STATIC_CONSTANT
+#include <boost/config/no_tr1/cmath.hpp>
+#include <boost/math/constants/constants.hpp> // For root_two
 #include <boost/math/special_functions/hypot.hpp>
+#include <boost/random/uniform_01.hpp>
+#include <boost/random/linear_congruential.hpp>
 #include <boost/shared_ptr.hpp>
+
+#include <cmath>
 
 // Classes and concepts to represent points in a space, with distance and move
 // operations (used for Gurson-Atun layout), plus other things like bounding

--- a/include/boost/graph/topology.hpp
+++ b/include/boost/graph/topology.hpp
@@ -18,6 +18,7 @@
 #include <boost/algorithm/minmax.hpp>
 #include <boost/config.hpp> // For BOOST_STATIC_CONSTANT
 #include <boost/math/special_functions/hypot.hpp>
+#include <boost/shared_ptr.hpp>
 
 // Classes and concepts to represent points in a space, with distance and move
 // operations (used for Gurson-Atun layout), plus other things like bounding


### PR DESCRIPTION
boost::shared_ptr is used in this file without the corresponding include, so currently this file does not compile on its own.