### PR TITLE
Remove link against boost regex library, as normally it is header only when using C++ >= 11.

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -16,7 +16,6 @@ lib boost_graph
     read_graphviz_new.cpp
     graphml.cpp
     :
-    <library>../../regex/build//boost_regex
     <link>shared:<define>BOOST_GRAPH_DYN_LINK=1
     # Without these flags, MSVC 7.1 and 8.0 crash
     # User reports that VC++ 8.0 does not fail anymore, so that is removed

--- a/doc/read_graphviz.html
+++ b/doc/read_graphviz.html
@@ -181,8 +181,8 @@ bool status = read_graphviz(gvgraph,graph,dp,&quot;node_id&quot;);
 <div class="section" id="building-the-graphviz-readers">
 <h1><a class="toc-backref" href="#id5">Building the GraphViz Readers</a></h1>
 <p>To use the GraphViz readers, you will need to build and link against
-the &quot;boost_graph&quot; and &quot;boost_regex&quot; libraries. These libraries can be built by following the
-<a class="reference external" href="../../../more/getting_started.html#Build_Install">Boost Jam Build Instructions</a> for the subdirectories <tt class="docutils literal"><span class="pre">libs/graph/build</span></tt> and <tt class="docutils literal"><span class="pre">libs/regex/build</span></tt>.</p>
+the &quot;boost_graph&quot; library. This library can be built by following the
+<a class="reference external" href="../../../more/getting_started.html#Build_Install">Boost Jam Build Instructions</a> for the subdirectory <tt class="docutils literal"><span class="pre">libs/graph/build</span></tt>.</p>
 </div>
 <div class="section" id="notes">
 <h1><a class="toc-backref" href="#id6">Notes</a></h1>

--- a/doc/read_graphviz.rst
+++ b/doc/read_graphviz.rst
@@ -182,8 +182,8 @@ GraphViz reader to populate an ``adjacency_list`` graph
 Building the GraphViz Readers
 -----------------------------
 To use the GraphViz readers, you will need to build and link against
-the "boost_graph" and "boost_regex" libraries. These libraries can be built by following the
-`Boost Jam Build Instructions`_ for the subdirectories ``libs/graph/build`` and ``libs/regex/build``.
+the "boost_graph" library. This library can be built by following the
+`Boost Jam Build Instructions`_ for the subdirectory ``libs/graph/build``.
 
 
 Notes

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -73,8 +73,7 @@ alias graph_test_regular :
     [ run graph.cpp : : : <define>TEST=9 : graph_9 ]
     [ compile graph_concepts.cpp ]
     [ run graphviz_test.cpp
-            ../build//boost_graph
-            ../../regex/build//boost_regex : --log_level=all ]
+            ../build//boost_graph : --log_level=all ]
     [ run metis_test.cpp : $(METIS_INPUT_FILE) ]
     [ run gursoy_atun_layout_test.cpp  : : : [ requires cxx11_noexcept cxx11_rvalue_references sfinae_expr cxx11_auto_declarations cxx11_lambdas cxx11_unified_initialization_syntax cxx11_hdr_tuple cxx11_hdr_initializer_list cxx11_hdr_chrono cxx11_thread_local cxx11_constexpr cxx11_nullptr cxx11_numeric_limits cxx11_decltype cxx11_hdr_array cxx11_hdr_atomic cxx11_hdr_type_traits cxx11_allocator cxx11_explicit_conversion_operators ] ]
     [ run layout_test.cpp : : : <test-info>always_show_run_output <toolset>intel:<debug-symbols>off [ requires cxx11_noexcept cxx11_rvalue_references sfinae_expr cxx11_auto_declarations cxx11_lambdas cxx11_unified_initialization_syntax cxx11_hdr_tuple cxx11_hdr_initializer_list cxx11_hdr_chrono cxx11_thread_local cxx11_constexpr cxx11_nullptr cxx11_numeric_limits cxx11_decltype cxx11_hdr_array cxx11_hdr_atomic cxx11_hdr_type_traits cxx11_allocator cxx11_explicit_conversion_operators ] ]
@@ -117,7 +116,7 @@ alias graph_test_regular :
     [ run weighted_matching_test.cpp ]
     [ run max_flow_test.cpp ]
     [ run boykov_kolmogorov_max_flow_test.cpp ]
-    [ run cycle_ratio_tests.cpp ../build//boost_graph ../../regex/build//boost_regex : $(CYCLE_RATIO_INPUT_FILE) ]
+    [ run cycle_ratio_tests.cpp ../build//boost_graph : $(CYCLE_RATIO_INPUT_FILE) ]
     [ run basic_planarity_test.cpp ]
     [ run make_connected_test.cpp ]
     [ run make_bicon_planar_test.cpp ]


### PR DESCRIPTION
It seems you recently dropped all support for gcc 4.x and C++ < 11 in general, so normally with the compilers you still support the Boost regex library shall be header only. Thus avoid linking against it explicitly.

I didn't test this locally, so let's wait the result of the CI.