### PR TITLE
graph/labeled_graph: added remove_labeled_vertex

### DIFF
--- a/include/boost/graph/labeled_graph.hpp
+++ b/include/boost/graph/labeled_graph.hpp
@@ -260,6 +260,54 @@ namespace graph_detail
     }
     //@}
 
+    /** @name Remove Labeled Vertex */
+    //@{
+    // Tag dispatch on random access containers (i.e., vectors)
+    template <typename Container, typename Label, typename Graph>
+    void remove_labeled_vertex(Container& c, Graph& g, Label const& l,
+        random_access_container_tag)
+    {
+        if (l < c.size())
+        {
+            boost::remove_vertex(c[l], g);
+            c.erase(c.begin() + l);
+        }
+    }
+
+    // Tag dispatch on multi associative containers (i.e. multimaps).
+    template <typename Container, typename Label, typename Graph>
+    void remove_labeled_vertex(Container& c, Graph& g, Label const& l,
+        multiple_associative_container_tag)
+    {
+        typename Container::iterator c_it = c.find(l);
+        if (c_it != c.end())
+        {
+            boost::remove_vertex(c_it->second, g);
+            c.erase(c_it);
+        }
+    }
+
+    // Tag dispatch on unique associative containers (i.e. maps).
+    template <typename Container, typename Label, typename Graph>
+    void remove_labeled_vertex(Container& c, Graph& g, Label const& l,
+        unique_associative_container_tag)
+    {
+        typename Container::iterator c_it = c.find(l);
+        if (c_it != c.end())
+        {
+            boost::remove_vertex(c_it->second, g);
+            c.erase(c_it);
+        }
+    }
+
+    // Dispatcher
+    template <typename Container, typename Label, typename Graph>
+    void remove_labeled_vertex(Container& c, Graph& g, Label const& l)
+    {
+        remove_labeled_vertex(c, g, l, container_category(c));
+    }
+    //@}
+
 } // namespace detail
 
 struct labeled_graph_class_tag
@@ -451,7 +499,7 @@ public:
     /** Remove the vertex with the given label. */
     void remove_vertex(Label const& l)
     {
-        return boost::remove_vertex(vertex(l), _graph);
+        return graph_detail::remove_labeled_vertex(_map, _graph, l);
     }
 
     /** Return a descriptor for the given label. */

--- a/test/labeled_graph.cpp
+++ b/test/labeled_graph.cpp
@@ -24,12 +24,14 @@ using namespace boost;
 void test_norm();
 void test_temp();
 void test_bacon();
+void test_remove_labeled_vertex();
 
 int main()
 {
     test_norm();
     test_temp();
     test_bacon();
+    test_remove_labeled_vertex();
 }
 
 //////////////////////////////////////
@@ -146,4 +148,20 @@ void test_bacon()
         add_vertex(slater, g);
         add_edge_by_label(bacon, slater, murder, g);
     }
+}
+
+void test_remove_labeled_vertex()
+{
+    typedef labeled_graph< directed_graph<>, string > Graph;
+
+    Graph g;
+    g.add_vertex("foo");
+
+    auto v = g.vertex("foo");
+    BOOST_ASSERT(v != nullptr);
+
+    g.remove_vertex("foo");
+
+    auto v2 = g.vertex("foo");
+    BOOST_ASSERT(v2 == nullptr);
 }

--- a/test/labeled_graph.cpp
+++ b/test/labeled_graph.cpp
@@ -25,6 +25,7 @@ void test_norm();
 void test_temp();
 void test_bacon();
 void test_remove_labeled_vertex();
+void test_multiple_associative_container();
 
 int main()
 {
@@ -32,6 +33,7 @@ int main()
     test_temp();
     test_bacon();
     test_remove_labeled_vertex();
+    test_multiple_associative_container();
 }
 
 //////////////////////////////////////
@@ -164,4 +166,21 @@ void test_remove_labeled_vertex()
 
     auto v2 = g.vertex("foo");
     BOOST_ASSERT(v2 == nullptr);
+}
+
+void test_multiple_associative_container()
+{
+    typedef labeled_graph<adjacency_list<listS, multisetS, directedS>, string, multimapS> Graph;
+
+    Graph g;
+    g.add_vertex("test");
+    g.add_vertex("test");
+
+    BOOST_ASSERT(num_vertices(g) == 2);
+
+    g.remove_vertex("test");
+    BOOST_ASSERT(num_vertices(g) == 1);
+
+    g.remove_vertex("test");
+    BOOST_ASSERT(num_vertices(g) == 0);
 }


### PR DESCRIPTION
I took this patch from this ticket:
https://svn.boost.org/trac/boost/ticket/9493
which no longer exists.

But I believe the original ticket issue was identical to https://github.com/boostorg/graph/issues/167 which this patch fixes.