### PR TITLE
Update Boost.Filesystem usage

### DIFF
--- a/test/all_planar_input_files_test.cpp
+++ b/test/all_planar_input_files_test.cpp
@@ -233,7 +233,7 @@ int main(int argc, char* argv[])
         if (dir_itr->path().extension() != dimacs_extension)
             continue;
 
-        std::cout << "Testing " << dir_itr->path().leaf() << "... ";
+        std::cout << "Testing " << dir_itr->path().filename() << "... ";
         BOOST_TEST(test_graph(dir_itr->path().string()) == 0);
 
         std::cout << std::endl;

--- a/test/parallel_edges_loops_test.cpp
+++ b/test/parallel_edges_loops_test.cpp
@@ -302,7 +302,7 @@ int main(int argc, char* argv[])
         if (dir_itr->path().extension() != dimacs_extension)
             continue;
 
-        std::cerr << "Testing " << dir_itr->path().leaf() << "... ";
+        std::cerr << "Testing " << dir_itr->path().filename() << "... ";
         BOOST_TEST(test_graph(dir_itr->path().string()) == 0);
 
         std::cerr << std::endl;


### PR DESCRIPTION
This commit updates tests to avoid using Boost.Filesystem APIs that were deprecated and then removed.