### PR TITLE
Fix creation of nested subgraphs by vertex descriptors

### DIFF
--- a/include/boost/graph/subgraph.hpp
+++ b/include/boost/graph/subgraph.hpp
@@ -194,7 +194,7 @@ public:
         m_children.back()->m_parent = this;
         for (; first != last; ++first)
         {
-            add_vertex(*first, *m_children.back());
+            add_vertex(local_to_global(*first), *m_children.back());
         }
         return *m_children.back();
     }


### PR DESCRIPTION
When creating subgraphs on deeper levels of the subgraph tree, do not nterpret the vertex descriptors as global, but instead as vertex descriptors to the current graph.

Fix to https://github.com/boostorg/graph/issues/378