### PR TITLE
Fix unused parameter/variable warnings

### DIFF
--- a/include/boost/graph/bron_kerbosch_all_cliques.hpp
+++ b/include/boost/graph/bron_kerbosch_all_cliques.hpp
@@ -104,7 +104,7 @@ struct max_clique_visitor
     max_clique_visitor(std::size_t& max) : maximum(max) {}
 
     template < typename Clique, typename Graph >
-    inline void clique(const Clique& p, const Graph& g)
+    inline void clique(const Clique& p, const Graph&)
     {
         BOOST_USING_STD_MAX();
         maximum = max BOOST_PREVENT_MACRO_SUBSTITUTION(maximum, p.size());
@@ -220,7 +220,7 @@ namespace detail
 
         // otherwise, iterate over candidates and and test
         // for maxmimal cliquiness.
-        typename Container::iterator i, j;
+        typename Container::iterator i;
         for (i = cands.begin(); i != cands.end();)
         {
             Vertex candidate = *i;


### PR DESCRIPTION
Fix the following warnings:

/data/mwrep/res/osp/Boost/23-0-0-4/include/boost/graph/bron_kerbosch_all_cliques.hpp:107:54: error: unused parameter 'g' [-Werror,-Wunused-parameter]
  107 |     inline void clique(const Clique& p, const Graph& g)

/data/mwrep/res/osp/Boost/23-0-0-4/include/boost/graph/bron_kerbosch_all_cliques.hpp:223:41: error: unused variable 'j' [-Werror,-Wunused-variable]
  223 |         typename Container::iterator i, j;