### PR TITLE
Fix missing namespace name

### DIFF
--- a/include/boost/graph/cycle_canceling.hpp
+++ b/include/boost/graph/cycle_canceling.hpp
@@ -172,7 +172,7 @@ namespace detail
 template < class Graph, class P, class T, class R >
 void cycle_canceling(Graph& g, const bgl_named_params< P, T, R >& params)
 {
-    cycle_canceling_dispatch1(g,
+    detail::cycle_canceling_dispatch1(g,
         choose_const_pmap(get_param(params, edge_weight), g, edge_weight),
         choose_const_pmap(get_param(params, edge_reverse), g, edge_reverse),
         choose_pmap(get_param(params, edge_residual_capacity), g,


### PR DESCRIPTION
For some reason when using `cycle_canceling` as part of a larger algorithm, Clang++19 reported that it could not find `cycle_canceling_dispatch1`. Compiling [the example](https://www.boost.org/doc/libs/1_86_0/libs/graph/example/cycle_canceling_example.cpp) with the same options did work. In any case I think the namespace name should be applied to the call.