### PR TITLE
Fix the O(n^3) performance issue in `is_connected` utility function

### DIFF
--- a/include/boost/graph/graph_utility.hpp
+++ b/include/boost/graph/graph_utility.hpp
@@ -342,7 +342,8 @@ inline bool is_reachable(
 }
 
 template < typename Graph, typename VertexColorMap >
-inline bool is_connected_dispatch(const Graph& g, VertexColorMap color, undirected_tag)
+inline bool is_connected_dispatch(const Graph& g, VertexColorMap color,
+    undirected_tag)
 {
     typedef typename property_traits< VertexColorMap >::value_type ColorValue;
     typedef color_traits< ColorValue > Color;
@@ -369,8 +370,8 @@ inline bool is_connected_dispatch(const Graph& g, VertexColorMap, directed_tag)
 {
     // Run the Tarjan SCC algorithm
     std::vector< size_t > comp_map(num_vertices(g));
-    strong_components(g,
-        make_iterator_property_map(comp_map.begin(), get(vertex_index, g)));
+    strong_components(
+        g, make_iterator_property_map(comp_map.begin(), get(vertex_index, g)));
 
     // If the directed graph is strongly connected, all vertices are in
     // the same component 0
@@ -380,7 +381,6 @@ inline bool is_connected_dispatch(const Graph& g, VertexColorMap, directed_tag)
             return false;
     return true;
 }
-
 
 // Is the undirected graph connected?
 // Is the directed graph strongly connected?

--- a/include/boost/graph/graph_utility.hpp
+++ b/include/boost/graph/graph_utility.hpp
@@ -344,9 +344,13 @@ inline bool is_reachable(
 template < typename Graph, typename VertexColorMap >
 inline bool is_connected_dispatch(const Graph& g, VertexColorMap color, undirected_tag)
 {
-    // color map should start out white for each vertex
     typedef typename property_traits< VertexColorMap >::value_type ColorValue;
     typedef color_traits< ColorValue > Color;
+    typename graph_traits< Graph >::vertex_iterator ui, ui_end, ci, ci_end;
+
+    // clear the colormap to preserve backward compatibility
+    for (boost::tie(ci, ci_end) = vertices(g); ci != ci_end; ++ci)
+        put(color, *ci, Color::white());
 
     default_dfs_visitor vis;
     detail::depth_first_visit_impl(g, detail::get_default_starting_vertex(g),
@@ -354,7 +358,6 @@ inline bool is_connected_dispatch(const Graph& g, VertexColorMap color, undirect
 
     // If an undirected graph is connected, then each vertex is reachable in a
     // single DFS visit. If any vertex was unreachable, grpah is not connected.
-    typename graph_traits< Graph >::vertex_iterator ui, ui_end;
     for (boost::tie(ui, ui_end) = vertices(g); ui != ui_end; ++ui)
         if (get(color, *ui) == Color::white())
             return false;

--- a/include/boost/graph/graph_utility.hpp
+++ b/include/boost/graph/graph_utility.hpp
@@ -359,7 +359,6 @@ inline bool is_connected_dispatch(const Graph& g, VertexColorMap color, undirect
         if (get(color, *ui) == Color::white())
             return false;
     return true;
-
 }
 
 template < typename Graph, typename VertexColorMap >

--- a/include/boost/graph/is_connected.hpp
+++ b/include/boost/graph/is_connected.hpp
@@ -1,0 +1,242 @@
+#ifndef BOOST_GRAPH_IS_CONNECTED_HPP
+#define BOOST_GRAPH_IS_CONNECTED_HPP
+
+#include <boost/graph/graph_traits.hpp>
+#include <boost/graph/strong_components.hpp>
+#include <boost/graph/depth_first_search.hpp>
+#include <boost/graph/neighbor_bfs.hpp>
+#include <boost/graph/create_condensation_graph.hpp>
+#include <boost/graph/adjacency_list.hpp>
+
+namespace boost
+{
+
+struct is_connected_kind {
+    enum weak_t { weak };
+    enum unilateral_t { unilateral };
+    enum strong_t { strong };
+};
+
+// used for static assert below
+BOOST_MPL_HAS_XXX_TRAIT_NAMED_DEF(has_value_type_ic, value_type, false)
+
+template < typename Graph, typename ConnectedKind = is_connected_kind::strong_t >
+inline bool is_connected(const Graph& g, ConnectedKind kind = is_connected_kind::strong)
+{
+    // Issue error message if these functions are called with a ColorMap.
+    // This is to gracefully handle possible old usages of is_connected.
+    // todo: consider checking for ColorValueConcept as well
+    BOOST_STATIC_ASSERT_MSG(
+        (mpl::not_< has_value_type_ic< ConnectedKind > >::value),
+        "ColorMap argument to is_connected is deprecated. Omit the second "
+        "argument to preserve the old behavior or use it to specify the "
+        "connection kind (for directed graph).");
+
+    typedef typename graph_traits< Graph >::directed_category Cat;
+    return is_connected_dispatch(g, Cat(), kind);
+}
+
+// Undirected graph
+template < typename IncidenceGraph, typename ConnectedKind >
+inline bool is_connected_dispatch(const IncidenceGraph& g, undirected_tag,
+                                  ConnectedKind)
+{
+    // ignore the connection kind for undirected graph
+    BOOST_CONCEPT_ASSERT((IncidenceGraphConcept< IncidenceGraph >));
+    return is_connected_undirected(g);
+}
+
+template < typename IncidenceGraph >
+inline bool is_connected_undirected(const IncidenceGraph& g)
+{
+    return is_connected_undirected(g,
+        make_two_bit_color_map(num_vertices(g), get(boost::vertex_index, g)));
+}
+
+// color should start out white for every vertex
+template < typename IncidenceGraph, typename VertexColorMap >
+inline bool is_connected_undirected(const IncidenceGraph& g,
+    VertexColorMap colormap)
+{
+    typedef typename property_traits< VertexColorMap >::value_type ColorValue;
+    typedef color_traits< ColorValue > Color;
+
+    default_dfs_visitor vis;
+    depth_first_visit(g, detail::get_default_starting_vertex(g), vis, colormap);
+
+    // If an undirected graph is connected, then each vertex is reachable in a
+    // single DFS visit. If any vertex was unreachable, grpah is not connected.
+    typename graph_traits< IncidenceGraph >::vertex_iterator ui, ui_end;
+    for (boost::tie(ui, ui_end) = vertices(g); ui != ui_end; ++ui)
+        if (get(colormap, *ui) == Color::white())
+            return false;
+    return true;
+}
+
+// Directed graph, strongly connected
+template < typename IncidenceGraph >
+inline bool is_connected_dispatch(const IncidenceGraph& g, directed_tag,
+                                  is_connected_kind::strong_t)
+{
+    return is_strongly_connected(g);
+}
+
+template < typename Graph >
+inline bool is_strongly_connected(const Graph& g)
+{
+    // A directed graph is stronly connected if and only if all its vertices
+    // are in a sinlge stronly connected component
+
+    BOOST_CONCEPT_ASSERT((IncidenceGraphConcept< Graph >));
+    // adj_list is not VertexIndexGraph due to missing renumber_vertex_indices
+    // This requirement should probably be dropped from the concept
+    // BOOST_CONCEPT_ASSERT((VertexIndexGraphConcept< Graph >));
+    BOOST_CONCEPT_ASSERT((boost::Convertible<
+        typename boost::graph_traits< Graph >::directed_category,
+        boost::directed_tag >));
+
+    // Run the Tarjan's SCC algorithm
+    std::vector< size_t > comp_map(num_vertices(g));
+    size_t num_scc = strong_components(
+        g, make_iterator_property_map(comp_map.begin(), get(vertex_index, g)));
+
+    return num_scc == 1;
+}
+
+// Directed graph, weakly connected
+template < typename IncidenceGraph >
+inline bool is_connected_dispatch(const IncidenceGraph& g, directed_tag,
+                                  is_connected_kind::weak_t)
+{
+    return is_weakly_connected(g);
+}
+
+template < typename BidirectionalGraph >
+inline bool is_weakly_connected(const BidirectionalGraph & g)
+{
+    BOOST_CONCEPT_ASSERT((boost::Convertible<
+        typename graph_traits< BidirectionalGraph >::directed_category,
+        bidirectional_tag >));
+    BOOST_CONCEPT_ASSERT(
+            (Convertible<
+                typename graph_traits< BidirectionalGraph >::traversal_category,
+                bidirectional_graph_tag >));
+
+    // For now do an undirected BFS walk
+    return is_weakly_connected(g,
+        make_two_bit_color_map(num_vertices(g), get(boost::vertex_index, g)));
+}
+
+template < typename BidirectionalGraph , typename VertexColorMap >
+inline bool is_weakly_connected(const BidirectionalGraph& g, VertexColorMap colormap)
+{
+    // A directed graph is weakly connected if and only if all its vertices
+    // can be reached in a single undirected BFS (or DFS) visit.
+    typedef typename property_traits< VertexColorMap >::value_type ColorValue;
+    typedef color_traits< ColorValue > Color;
+
+    // todo: consider reimplementing this as DFS (is_connected above) over an
+    // as_undirected adaptor.
+
+    neighbor_breadth_first_visit(
+        g,
+        detail::get_default_starting_vertex(g),
+        color_map(colormap)
+    );
+
+    typename graph_traits< BidirectionalGraph >::vertex_iterator ui, ui_end;
+    for (boost::tie(ui, ui_end) = vertices(g); ui != ui_end; ++ui)
+        if (get(colormap, *ui) == Color::white())
+            return false;
+    return true;
+}
+
+// Directed graph, unilaterally connected
+template < typename IncidenceGraph >
+inline bool is_connected_dispatch(const IncidenceGraph& g, directed_tag,
+                                  is_connected_kind::unilateral_t)
+{
+    return is_unilaterally_connected(g);
+}
+
+namespace detail {
+
+    template < typename Graph >
+    struct unique_topological_order_visitor : public default_dfs_visitor
+    {
+        typedef typename graph_traits< Graph >::vertex_descriptor vertex_t;
+        vertex_t last_vertex;
+        bool& result;
+
+        unique_topological_order_visitor(bool& result)
+            : last_vertex(graph_traits< Graph >::null_vertex()), result(result)
+        {
+            result = true;
+        }
+
+        template < typename Vertex, typename G >
+        void finish_vertex(const Vertex& u, const G& g)
+        {
+            // todo: consider using TerminatorFunc or an exception to exit
+            // the DFS early (performance optimization)
+            if (result == false)
+                return;
+
+            if (last_vertex != graph_traits< Graph >::null_vertex())
+            {
+                if (!edge(u, last_vertex, g).second)
+                {
+                    result = false;
+                }
+            }
+            last_vertex = u;
+        }
+
+    };
+
+}
+
+// Checks if the graph is in unique topological order, i.e. linear
+template < typename Graph >
+bool has_unique_topological_order(const Graph& g)
+{
+    bool result;
+    detail::unique_topological_order_visitor<Graph> vis(result);
+    depth_first_search(g, visitor(vis));
+    return result;
+}
+
+
+template < typename Graph >
+inline bool is_unilaterally_connected(const Graph& g)
+{
+    // A directed graph is unilaterally connected if and only if its
+    // condensation graph is in unique topological order.
+
+    BOOST_CONCEPT_ASSERT((IncidenceGraphConcept< Graph >));
+    // See comment about renumber_vertex_indices above
+    // BOOST_CONCEPT_ASSERT((VertexIndexGraphConcept< Graph >));
+    BOOST_CONCEPT_ASSERT((boost::Convertible<
+        typename boost::graph_traits< Graph >::directed_category,
+        boost::directed_tag >));
+
+    typedef typename graph_traits< Graph >::vertices_size_type vertex_index_t;
+    // Run the Tarjan's SCC algorithm
+    std::vector< vertex_index_t > comp_number(num_vertices(g));
+    vertex_index_t num_scc = strong_components(
+        g, make_iterator_property_map(comp_number.begin(), get(vertex_index, g)));
+    // Build the condensation graph
+    adjacency_list<> c;
+    std::vector< std::vector< typename graph_traits< Graph >::vertices_size_type > > components;
+    build_component_lists(g, num_scc, comp_number, components);
+    create_condensation_graph(g, components, comp_number, c);
+    // Check if the condensation is linear
+    return has_unique_topological_order(c);
+}
+
+
+} // namespace boost
+
+#endif /* BOOST_GRAPH_IS_CONNECTED_HPP */
+
+

--- a/include/boost/graph/is_connected.hpp
+++ b/include/boost/graph/is_connected.hpp
@@ -37,7 +37,7 @@ inline bool is_connected(const Graph& g, ConnectedKind kind = connected_kind::un
     BOOST_STATIC_ASSERT_MSG(
         (mpl::not_< mpl::and_ <
                 is_same < ConnectedKind, connected_kind::unspecified_t >,
-                is_convertible<Cat, directed_tag > > >::value),
+                is_directed_graph< Graph > > >::value),
         "connected_kind must be specified for directed graphs");
 
     return is_connected_dispatch(g, Cat(), kind);
@@ -49,13 +49,14 @@ inline bool is_connected_dispatch(const IncidenceGraph& g, undirected_tag,
                                   ConnectedKind)
 {
     // ignore the connection kind for undirected graph
-    BOOST_CONCEPT_ASSERT((IncidenceGraphConcept< IncidenceGraph >));
     return is_connected_undirected(g);
 }
 
 template < typename IncidenceGraph >
 inline bool is_connected_undirected(const IncidenceGraph& g)
 {
+    BOOST_CONCEPT_ASSERT((IncidenceGraphConcept< IncidenceGraph >));
+
     return is_connected_undirected(g,
         make_two_bit_color_map(num_vertices(g), get(boost::vertex_index, g)));
 }
@@ -95,9 +96,7 @@ inline bool is_strongly_connected(const Graph& g)
     // are in a sinlge stronly connected component
 
     BOOST_CONCEPT_ASSERT((IncidenceGraphConcept< Graph >));
-    BOOST_CONCEPT_ASSERT((boost::Convertible<
-        typename boost::graph_traits< Graph >::directed_category,
-        boost::directed_tag >));
+    BOOST_STATIC_ASSERT((is_directed_graph< Graph >::value));
 
     // Run the Tarjan's SCC algorithm
     std::vector< size_t > comp_map(num_vertices(g));
@@ -116,15 +115,9 @@ inline bool is_connected_dispatch(const IncidenceGraph& g, directed_tag,
 }
 
 template < typename BidirectionalGraph >
-inline bool is_weakly_connected(const BidirectionalGraph & g)
+inline bool is_weakly_connected(const BidirectionalGraph& g)
 {
-    BOOST_CONCEPT_ASSERT((boost::Convertible<
-        typename graph_traits< BidirectionalGraph >::directed_category,
-        bidirectional_tag >));
-    BOOST_CONCEPT_ASSERT(
-            (Convertible<
-                typename graph_traits< BidirectionalGraph >::traversal_category,
-                bidirectional_graph_tag >));
+    BOOST_CONCEPT_ASSERT((BidirectionalGraphConcept< BidirectionalGraph >));
 
     // For now do an undirected BFS walk
     return is_weakly_connected(g,
@@ -222,9 +215,7 @@ inline bool is_unilaterally_connected(const Graph& g)
     BOOST_CONCEPT_ASSERT((IncidenceGraphConcept< Graph >));
     // See comment about renumber_vertex_indices above
     // BOOST_CONCEPT_ASSERT((VertexIndexGraphConcept< Graph >));
-    BOOST_CONCEPT_ASSERT((boost::Convertible<
-        typename boost::graph_traits< Graph >::directed_category,
-        boost::directed_tag >));
+    BOOST_STATIC_ASSERT((is_directed_graph< Graph >::value));
 
     // Run the Tarjan's SCC algorithm
     std::vector< size_t > comp_number(num_vertices(g));

--- a/include/boost/graph/is_connected.hpp
+++ b/include/boost/graph/is_connected.hpp
@@ -33,23 +33,54 @@ inline bool is_connected(const Graph& g, ConnectedKind kind = connected_kind::un
         "argument for undirected graphs or specify connected_kind::strong "
         "to preserve the old behavior.");
 
-    typedef typename graph_traits< Graph >::directed_category Cat;
     BOOST_STATIC_ASSERT_MSG(
         (mpl::not_< mpl::and_ <
                 is_same < ConnectedKind, connected_kind::unspecified_t >,
                 is_directed_graph< Graph > > >::value),
         "connected_kind must be specified for directed graphs");
 
-    return is_connected_dispatch(g, Cat(), kind);
+/*
+// all wrong
+    // BOOST_CONCEPT_ASSERT((VertexIndexGraphConcept< Graph >));
+    BOOST_STATIC_ASSERT_MSG(
+        (mpl::not_< is_same<
+//            typename property_map< Graph, vertex_index_t >::const_type,
+//             typename property_value< Graph, vertex_index_t >::type,
+            typename property_value< vertex_property_type< Graph >, vertex_index_t >::type,
+            void > >::value),
+        "graph has no vertex_index map");
+*/
+
+    // typedef typename graph_traits< Graph >::directed_category Cat;
+    return is_connected(g, get(boost::vertex_index, g), kind);
 }
 
-// Undirected graph
-template < typename IncidenceGraph, typename ConnectedKind >
-inline bool is_connected_dispatch(const IncidenceGraph& g, undirected_tag,
-                                  ConnectedKind)
+
+template < typename Graph, typename VertexIndex, typename ConnectedKind >
+inline bool is_connected(const Graph& g, VertexIndex vertex_index, ConnectedKind kind)
 {
-    // ignore the connection kind for undirected graph
-    return is_connected_undirected(g);
+    BOOST_STATIC_ASSERT_MSG(
+        (mpl::not_< mpl::and_ <
+                is_same < ConnectedKind, connected_kind::unspecified_t >,
+                is_directed_graph< Graph > > >::value),
+        "connected_kind must be specified for directed graphs");
+
+    typedef typename graph_traits< Graph >::directed_category Cat;
+    return is_connected_dispatch(g, Cat(), kind, vertex_index);
+}
+
+
+
+
+
+
+// Undirected graph
+template < typename IncidenceGraph, typename ConnectedKind, typename VertexIndexMap >
+inline bool is_connected_dispatch(const IncidenceGraph& g, undirected_tag,
+                                  ConnectedKind, VertexIndexMap vertex_index)
+{
+    // ignore the connection kind and vertex_index for undirected graph
+    return is_connected_undirected(g, vertex_index);
 }
 
 template < typename IncidenceGraph >
@@ -57,14 +88,23 @@ inline bool is_connected_undirected(const IncidenceGraph& g)
 {
     BOOST_CONCEPT_ASSERT((IncidenceGraphConcept< IncidenceGraph >));
 
-    return is_connected_undirected(g,
-        make_two_bit_color_map(num_vertices(g), get(boost::vertex_index, g)));
+    return is_connected_undirected(g, get(vertex_index, g));
 }
 
+template < typename IncidenceGraph, typename VertexIndexMap >
+inline bool is_connected_undirected(const IncidenceGraph& g, VertexIndexMap vertex_index)
+{
+    BOOST_CONCEPT_ASSERT((IncidenceGraphConcept< IncidenceGraph >));
+
+    return is_connected_undirected(g,
+        make_two_bit_color_map(num_vertices(g), vertex_index), vertex_index);
+}
+
+
 // color should start out white for every vertex
-template < typename IncidenceGraph, typename VertexColorMap >
+template < typename IncidenceGraph, typename VertexColorMap, typename VertexIndexMap >
 inline bool is_connected_undirected(const IncidenceGraph& g,
-    VertexColorMap colormap)
+    VertexColorMap colormap, VertexIndexMap)
 {
     typedef typename property_traits< VertexColorMap >::value_type ColorValue;
     typedef color_traits< ColorValue > Color;
@@ -82,15 +122,21 @@ inline bool is_connected_undirected(const IncidenceGraph& g,
 }
 
 // Directed graph, strongly connected
-template < typename IncidenceGraph >
+template < typename IncidenceGraph, typename VertexIndexMap >
 inline bool is_connected_dispatch(const IncidenceGraph& g, directed_tag,
-                                  connected_kind::strong_t)
+                                  connected_kind::strong_t, VertexIndexMap vertex_index)
 {
-    return is_strongly_connected(g);
+    return is_strongly_connected(g, vertex_index);
 }
 
 template < typename Graph >
 inline bool is_strongly_connected(const Graph& g)
+{
+    return is_strongly_connected(g, get(vertex_index, g));
+}
+
+template < typename Graph, typename VertexIndexMap >
+inline bool is_strongly_connected(const Graph& g, VertexIndexMap vertex_index)
 {
     // A directed graph is stronly connected if and only if all its vertices
     // are in a sinlge stronly connected component
@@ -101,31 +147,40 @@ inline bool is_strongly_connected(const Graph& g)
     // Run the Tarjan's SCC algorithm
     std::vector< size_t > comp_map(num_vertices(g));
     size_t num_scc = strong_components(
-        g, make_iterator_property_map(comp_map.begin(), get(vertex_index, g)));
+        g, make_iterator_property_map(comp_map.begin(), vertex_index), 
+//        g, make_safe_iterator_property_map(comp_map.begin(), vertex_index), 
+        vertex_index_map(vertex_index));
 
     return num_scc == 1;
 }
 
+
 // Directed graph, weakly connected
-template < typename IncidenceGraph >
+template < typename IncidenceGraph, typename VertexIndexMap >
 inline bool is_connected_dispatch(const IncidenceGraph& g, directed_tag,
-                                  connected_kind::weak_t)
+                                  connected_kind::weak_t, VertexIndexMap vertex_index)
 {
-    return is_weakly_connected(g);
+    return is_weakly_connected(g, vertex_index);
 }
 
 template < typename BidirectionalGraph >
 inline bool is_weakly_connected(const BidirectionalGraph& g)
 {
+    return is_weakly_connected(g, get(boost::vertex_index, g));
+}
+
+template < typename BidirectionalGraph, typename VertexIndexMap >
+inline bool is_weakly_connected(const BidirectionalGraph& g, VertexIndexMap vertex_index)
+{
     BOOST_CONCEPT_ASSERT((BidirectionalGraphConcept< BidirectionalGraph >));
 
     // For now do an undirected BFS walk
     return is_weakly_connected(g,
-        make_two_bit_color_map(num_vertices(g), get(boost::vertex_index, g)));
+        make_two_bit_color_map(num_vertices(g), vertex_index), vertex_index);
 }
 
-template < typename BidirectionalGraph , typename VertexColorMap >
-inline bool is_weakly_connected(const BidirectionalGraph& g, VertexColorMap colormap)
+template < typename BidirectionalGraph , typename VertexColorMap, typename VertexIndexMap >
+inline bool is_weakly_connected(const BidirectionalGraph& g, VertexColorMap colormap, VertexIndexMap vertex_index)
 {
     // A directed graph is weakly connected if and only if all its vertices
     // can be reached in a single undirected BFS (or DFS) visit.
@@ -149,11 +204,12 @@ inline bool is_weakly_connected(const BidirectionalGraph& g, VertexColorMap colo
 }
 
 // Directed graph, unilaterally connected
-template < typename IncidenceGraph >
+template < typename IncidenceGraph, typename VertexIndexMap>
 inline bool is_connected_dispatch(const IncidenceGraph& g, directed_tag,
-                                  connected_kind::unilateral_t)
+                                  connected_kind::unilateral_t,
+                                  VertexIndexMap vertex_index_map)
 {
-    return is_unilaterally_connected(g);
+    return is_unilaterally_connected(g, vertex_index_map);
 }
 
 namespace detail {
@@ -208,27 +264,34 @@ bool has_unique_topological_order(const Graph& g)
 template < typename Graph >
 inline bool is_unilaterally_connected(const Graph& g)
 {
+    return is_unilaterally_connected(g, get(vertex_index, g));
+}
+
+
+template < typename Graph, typename VertexIndexMap >
+inline bool is_unilaterally_connected(const Graph& g, VertexIndexMap vertex_index)
+{
     // A directed graph is unilaterally connected if and only if its
     // condensation graph is in unique topological order.
     // Warning: condensation might be slow and consume 2x memory for the graph.
 
     BOOST_CONCEPT_ASSERT((IncidenceGraphConcept< Graph >));
-    // See comment about renumber_vertex_indices above
-    // BOOST_CONCEPT_ASSERT((VertexIndexGraphConcept< Graph >));
     BOOST_STATIC_ASSERT((is_directed_graph< Graph >::value));
 
     // Run the Tarjan's SCC algorithm
-    std::vector< size_t > comp_number(num_vertices(g));
-    size_t num_scc = strong_components(
-        g, make_iterator_property_map(comp_number.begin(), get(vertex_index, g)));
+    std::vector< size_t > comp_number_store(num_vertices(g));
+    auto comp_number = make_iterator_property_map(comp_number_store.begin(), vertex_index);
+
+    size_t num_scc = strong_components(g, comp_number, vertex_index_map(vertex_index));
     if (num_scc == 1) // strongly connected case
         return true;
 
     // Build the condensation graph
     adjacency_list<> c;
-    std::vector< std::vector< typename graph_traits< Graph >::vertices_size_type > > components;
+    std::vector< std::vector< typename graph_traits< Graph >::vertex_descriptor > > components;
     build_component_lists(g, num_scc, comp_number, components);
     create_condensation_graph(g, components, comp_number, c);
+
     // Check if the condensation is linear
     return has_unique_topological_order(c);
 }

--- a/include/boost/graph/strong_components.hpp
+++ b/include/boost/graph/strong_components.hpp
@@ -260,6 +260,17 @@ void build_component_lists(const Graph& g,
         components[component_number[*vi]].push_back(*vi);
 }
 
+template < typename Graph, typename ComponentMap, typename ComponentLists, typename VertexIndexMap >
+void build_component_lists(const Graph& g,
+    typename graph_traits< Graph >::vertices_size_type num_scc,
+    ComponentMap component_number, ComponentLists& components, VertexIndexMap vertex_index)
+{
+    components.resize(num_scc);
+    typename graph_traits< Graph >::vertex_iterator vi, vi_end;
+    for (boost::tie(vi, vi_end) = vertices(g); vi != vi_end; ++vi)
+        components[component_number[get(vertex_index, *vi)]].push_back(*vi);
+}
+
 } // namespace boost
 
 #include <queue>

--- a/include/boost/pending/detail/disjoint_sets.hpp
+++ b/include/boost/pending/detail/disjoint_sets.hpp
@@ -7,12 +7,14 @@
 #define BOOST_DETAIL_DISJOINT_SETS_HPP
 
 #include <cassert>
+#include <boost/property_map/property_map.hpp>
 
 namespace boost
 {
 
 namespace detail
 {
+    using boost::get;
 
     template < class ParentPA, class Vertex >
     Vertex find_representative_with_path_halving(ParentPA p, Vertex v)

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -159,6 +159,7 @@ alias graph_test_regular :
     [ run delete_edge.cpp ]
     [ run johnson-test.cpp ]
     [ run lvalue_pmap.cpp ]
+    [ run is_connected.cpp ]
     ;
 
 alias graph_test_with_filesystem : :

--- a/test/is_connected.cpp
+++ b/test/is_connected.cpp
@@ -96,7 +96,6 @@ int main(int argc, char* argv[])
         undir_graph_t g(size * size);
         // the undirected graph is already strongly connected
         fill_square_graph(g, size);
-        run_test(g, true);
 
         BOOST_TEST(is_connected(g) == true);
         BOOST_TEST(is_connected_undirected(g) == true);

--- a/test/is_connected.cpp
+++ b/test/is_connected.cpp
@@ -33,6 +33,25 @@ void run_test(const Graph& g, bool exp_result) {
     BOOST_TEST(exp_result == result);
 }
 
+template <typename Graph, typename ColorMap>
+void test_colormap_reuse_disp(Graph& g, ColorMap color, size_t size) {
+    fill_square_graph(g, size);
+    bool result = is_connected(g, color);
+    BOOST_TEST(result == true);
+
+    Graph g2(num_vertices(g));
+    bool result2 = is_connected(g2, color);
+    BOOST_TEST(result2 == false);
+}
+
+// test that the colormap is cleared (preserve backward compatibility)
+void test_colormap_reuse(size_t size)
+{
+    typedef adjacency_list<vecS, vecS, undirectedS> undir_graph_t;
+    undir_graph_t g(size * size);
+    test_colormap_reuse_disp(g, boost::make_two_bit_color_map(num_vertices(g), get(boost::vertex_index, g)), size);
+}
+
 int main(int argc, char* argv[])
 {
     // the side length of the square graph
@@ -62,6 +81,8 @@ int main(int argc, char* argv[])
     undir_graph_t ug2(size * (size + 1));
     fill_square_graph(ug2, size);
     run_test(ug2, false);
+
+    test_colormap_reuse(size);
 
     return boost::report_errors();
 }

--- a/test/is_connected.cpp
+++ b/test/is_connected.cpp
@@ -8,16 +8,20 @@ using namespace std;
 using namespace boost;
 
 // todo: consider mdspan when it's widely implemented
-inline size_t coord_to_idx(size_t height, size_t x, size_t y) {
+inline size_t coord_to_idx(size_t height, size_t x, size_t y)
+{
     return y * height + x;
 }
 
-template <class Graph>
-void fill_square_graph(Graph& graph, size_t size) {
+template < class Graph >
+void fill_square_graph(Graph& graph, size_t size)
+{
     const size_t W = size, H = size;
 
-    for (size_t i = 0; i < W; ++i) {
-        for (size_t j = 0; j < H; ++j) {
+    for (size_t i = 0; i < W; ++i)
+    {
+        for (size_t j = 0; j < H; ++j)
+        {
             size_t idx = coord_to_idx(H, i, j);
             if (i > 0)
                 add_edge(coord_to_idx(H, i - 1, j), idx, graph);
@@ -27,14 +31,18 @@ void fill_square_graph(Graph& graph, size_t size) {
     }
 }
 
-template <typename Graph>
-void run_test(const Graph& g, bool exp_result) {
-    bool result = is_connected(g, boost::make_two_bit_color_map(num_vertices(g), get(boost::vertex_index, g)));
+template < typename Graph >
+void run_test(const Graph& g, bool exp_result)
+{
+    bool result = is_connected(g,
+        boost::make_two_bit_color_map(
+            num_vertices(g), get(boost::vertex_index, g)));
     BOOST_TEST(exp_result == result);
 }
 
-template <typename Graph, typename ColorMap>
-void test_colormap_reuse_disp(Graph& g, ColorMap color, size_t size) {
+template < typename Graph, typename ColorMap >
+void test_colormap_reuse_disp(Graph& g, ColorMap color, size_t size)
+{
     fill_square_graph(g, size);
     bool result = is_connected(g, color);
     BOOST_TEST(result == true);
@@ -47,9 +55,12 @@ void test_colormap_reuse_disp(Graph& g, ColorMap color, size_t size) {
 // test that the colormap is cleared (preserve backward compatibility)
 void test_colormap_reuse(size_t size)
 {
-    typedef adjacency_list<vecS, vecS, undirectedS> undir_graph_t;
+    typedef adjacency_list< vecS, vecS, undirectedS > undir_graph_t;
     undir_graph_t g(size * size);
-    test_colormap_reuse_disp(g, boost::make_two_bit_color_map(num_vertices(g), get(boost::vertex_index, g)), size);
+    test_colormap_reuse_disp(g,
+        boost::make_two_bit_color_map(
+            num_vertices(g), get(boost::vertex_index, g)),
+        size);
 }
 
 int main(int argc, char* argv[])
@@ -67,11 +78,12 @@ int main(int argc, char* argv[])
     fill_square_graph(g, size);
     run_test(g, false);
 
-    // now make it connected with one more edge from the last vertex to the first
+    // now make it connected with one more edge from the last vertex to the
+    // first
     add_edge(coord_to_idx(size, size - 1, size - 1), 0, g);
     run_test(g, true);
 
-    typedef adjacency_list<vecS, vecS, undirectedS> undir_graph_t;
+    typedef adjacency_list< vecS, vecS, undirectedS > undir_graph_t;
     undir_graph_t ug(size * size);
     // the undirected graph is already strongly connected
     fill_square_graph(g, size);
@@ -86,4 +98,3 @@ int main(int argc, char* argv[])
 
     return boost::report_errors();
 }
-

--- a/test/is_connected.cpp
+++ b/test/is_connected.cpp
@@ -1,7 +1,13 @@
 #include <boost/core/lightweight_test.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/adjacency_matrix.hpp>
 #include <boost/graph/graph_utility.hpp>
+/*
+#include <boost/graph/two_bit_color_map.hpp>
+*/
+#include <boost/graph/is_connected.hpp>
+
 #include <boost/graph/two_bit_color_map.hpp>
 
 using namespace std;
@@ -31,38 +37,6 @@ void fill_square_graph(Graph& graph, size_t size)
     }
 }
 
-template < typename Graph >
-void run_test(const Graph& g, bool exp_result)
-{
-    bool result = is_connected(g,
-        boost::make_two_bit_color_map(
-            num_vertices(g), get(boost::vertex_index, g)));
-    BOOST_TEST(exp_result == result);
-}
-
-template < typename Graph, typename ColorMap >
-void test_colormap_reuse_disp(Graph& g, ColorMap color, size_t size)
-{
-    fill_square_graph(g, size);
-    bool result = is_connected(g, color);
-    BOOST_TEST(result == true);
-
-    Graph g2(num_vertices(g));
-    bool result2 = is_connected(g2, color);
-    BOOST_TEST(result2 == false);
-}
-
-// test that the colormap is cleared (preserve backward compatibility)
-void test_colormap_reuse(size_t size)
-{
-    typedef adjacency_list< vecS, vecS, undirectedS > undir_graph_t;
-    undir_graph_t g(size * size);
-    test_colormap_reuse_disp(g,
-        boost::make_two_bit_color_map(
-            num_vertices(g), get(boost::vertex_index, g)),
-        size);
-}
-
 int main(int argc, char* argv[])
 {
     // the side length of the square graph
@@ -72,29 +46,170 @@ int main(int argc, char* argv[])
         size = lexical_cast< int >(argv[1]);
     }
 
-    typedef adjacency_list<> dir_graph_t;
-    dir_graph_t g(size * size);
-    // the directed graph is not strongly connected
-    fill_square_graph(g, size);
-    run_test(g, false);
+    {
+        // test is_strongly_connected
+        typedef adjacency_list<> dir_graph_t;
+        dir_graph_t g(size * size);
+        // the directed graph is not strongly connected
+        fill_square_graph(g, size);
 
-    // now make it connected with one more edge from the last vertex to the
-    // first
-    add_edge(coord_to_idx(size, size - 1, size - 1), 0, g);
-    run_test(g, true);
+        BOOST_TEST(is_connected(g) == false);
+        BOOST_TEST(is_connected(g, is_connected_kind::strong) == false);
+        BOOST_TEST(is_strongly_connected(g) == false);
+        BOOST_TEST(is_connected(g, is_connected_kind::unilateral) == false);
 
-    typedef adjacency_list< vecS, vecS, undirectedS > undir_graph_t;
-    undir_graph_t ug(size * size);
-    // the undirected graph is already strongly connected
-    fill_square_graph(g, size);
-    run_test(g, true);
+        // now make it strongly connected with one more edge from the last vertex
+        // to the first
+        add_edge(coord_to_idx(size, size - 1, size - 1), 0, g);
 
-    // now fill fewer edges, so one row is disconnected
-    undir_graph_t ug2(size * (size + 1));
-    fill_square_graph(ug2, size);
-    run_test(ug2, false);
+        BOOST_TEST(is_connected(g) == true);
+        BOOST_TEST(is_connected(g, is_connected_kind::strong) == true);
+        BOOST_TEST(is_strongly_connected(g) == true);
+        BOOST_TEST(is_connected(g, is_connected_kind::unilateral) == true);
+    }
 
-    test_colormap_reuse(size);
+    {
+        // test is_weakly_connected -- it requires bidirectional graph
+        typedef adjacency_list< vecS, vecS, bidirectionalS > bidir_graph_t;
+        bidir_graph_t g(size * size);
+        fill_square_graph(g, size);
+        // the directed graph is not strongly connected
+        BOOST_TEST(is_connected(g, is_connected_kind::strong) == false);
+        BOOST_TEST(is_strongly_connected(g) == false);
+        // but it is weakly connected
+        BOOST_TEST(is_connected(g, is_connected_kind::weak) == true);
+        BOOST_TEST(is_weakly_connected(g) == true);
+
+        // another graph, 2 disconnected vertices
+        bidir_graph_t g2(2);
+        BOOST_TEST(is_connected(g2, is_connected_kind::weak) == false);
+
+        // make it weakly connected
+        add_edge(0, 1, g2);
+        BOOST_TEST(is_connected(g2, is_connected_kind::weak) == true);
+        BOOST_TEST(is_connected(g2, is_connected_kind::strong) == false);
+    }
+
+    {
+        // test undirected is_connected, it is the same for all connection kinds
+        typedef adjacency_list< vecS, vecS, undirectedS > undir_graph_t;
+        undir_graph_t g(size * size);
+        // the undirected graph is already strongly connected
+        fill_square_graph(g, size);
+        run_test(g, true);
+
+        BOOST_TEST(is_connected(g) == true);
+        BOOST_TEST(is_connected_undirected(g) == true);
+        BOOST_TEST(is_connected(g, is_connected_kind::strong) == true);
+        BOOST_TEST(is_connected(g, is_connected_kind::weak) == true);
+
+        // now fill fewer edges, so one row is disconnected
+        undir_graph_t g2(size * (size + 1));
+        fill_square_graph(g2, size);
+
+        BOOST_TEST(is_connected(g2) == false);
+        BOOST_TEST(is_connected_undirected(g2) == false);
+        BOOST_TEST(is_connected(g2, is_connected_kind::strong) == false);
+        BOOST_TEST(is_connected(g2, is_connected_kind::weak) == false);
+
+    }
+
+    {
+        // test all is_connected kinds
+        typedef adjacency_list< vecS, vecS, bidirectionalS > bidir_graph_t;
+        bidir_graph_t g(size * size);
+        fill_square_graph(g, size);
+
+        BOOST_TEST(is_connected(g, is_connected_kind::weak) == true);
+        BOOST_TEST(is_weakly_connected(g) == true);
+
+        BOOST_TEST(is_connected(g, is_connected_kind::strong) == false);
+        BOOST_TEST(is_strongly_connected(g) == false);
+
+        BOOST_TEST(is_connected(g, is_connected_kind::unilateral) == false);
+        BOOST_TEST(is_unilaterally_connected(g) == false);
+
+        bidir_graph_t g2(2);
+        BOOST_TEST(is_connected(g2, is_connected_kind::weak) == false);
+        BOOST_TEST(is_connected(g2, is_connected_kind::strong) == false);
+        BOOST_TEST(is_connected(g2, is_connected_kind::unilateral) == false);
+
+        add_edge(0, 1, g2);
+        BOOST_TEST(is_connected(g2, is_connected_kind::weak) == true);
+        BOOST_TEST(is_connected(g2, is_connected_kind::strong) == false);
+        BOOST_TEST(is_connected(g2, is_connected_kind::unilateral) == true);
+
+
+        // test making a graph weakly, then unilaterally, then strongly connected
+        bidir_graph_t g3(3);
+        BOOST_TEST(is_connected(g3, is_connected_kind::weak) == false);
+        BOOST_TEST(is_connected(g3, is_connected_kind::unilateral) == false);
+        BOOST_TEST(is_connected(g3, is_connected_kind::strong) == false);
+        add_edge(0, 1, g3);
+        add_edge(2, 1, g3);
+        BOOST_TEST(is_connected(g3, is_connected_kind::weak) == true);
+        BOOST_TEST(is_connected(g3, is_connected_kind::unilateral) == false);
+        BOOST_TEST(is_connected(g3, is_connected_kind::strong) == false);
+        add_edge(0, 2, g3);
+        BOOST_TEST(is_connected(g3, is_connected_kind::weak) == true);
+        BOOST_TEST(is_connected(g3, is_connected_kind::unilateral) == true);
+        BOOST_TEST(is_connected(g3, is_connected_kind::strong) == false);
+        add_edge(1, 0, g3);
+        BOOST_TEST(is_connected(g3, is_connected_kind::weak) == true);
+        BOOST_TEST(is_connected(g3, is_connected_kind::unilateral) == true);
+        BOOST_TEST(is_connected(g3, is_connected_kind::strong) == true);
+
+        // Test the usage of the old interface with ColorMap as the second arg.
+        // This causes static assertion. I don't see a way to test for it, so
+        // it's commented out.
+        // BOOST_TEST(is_connected(g3, two_bit_color_map<>(0)) == false);
+    }
+
+    /*
+    {
+        // test that adjacency matrix implements bidirectional graph
+        // (see another PR [todo: link]
+        typedef boost::adjacency_matrix<> bidir_graph_t;
+        bidir_graph_t g(size * size);
+        fill_square_graph(g, size);
+
+        BOOST_TEST(is_connected(g, is_connected_kind::weak) == true);
+        BOOST_TEST(is_weakly_connected(g) == true);
+
+        BOOST_TEST(is_connected(g, is_connected_kind::strong) == false);
+        BOOST_TEST(is_strongly_connected(g) == false);
+
+        BOOST_TEST(is_connected(g, is_connected_kind::unilateral) == false);
+        BOOST_TEST(is_unilaterally_connected(g) == false);
+
+        bidir_graph_t g2(2);
+        BOOST_TEST(is_connected(g2, is_connected_kind::weak) == false);
+        BOOST_TEST(is_weakly_connected(g2) == false);
+        BOOST_TEST(is_connected(g2, is_connected_kind::strong) == false);
+        BOOST_TEST(is_strongly_connected(g2) == false);
+        BOOST_TEST(is_connected(g2, is_connected_kind::unilateral) == false);
+        BOOST_TEST(is_unilaterally_connected(g2) == false);
+
+        add_edge(0, 1, g2);
+        BOOST_TEST(is_connected(g2, is_connected_kind::weak) == true);
+        BOOST_TEST(is_weakly_connected(g2) == true);
+        BOOST_TEST(is_connected(g2, is_connected_kind::strong) == false);
+        BOOST_TEST(is_strongly_connected(g2) == false);
+        BOOST_TEST(is_connected(g2, is_connected_kind::unilateral) == true);
+        BOOST_TEST(is_unilaterally_connected(g2) == true);
+
+        bidir_graph_t g3(3);
+        BOOST_TEST(is_connected(g3, is_connected_kind::unilateral) == false);
+        add_edge(0, 1, g3);
+        add_edge(2, 1, g3);
+        BOOST_TEST(is_connected(g3, is_connected_kind::unilateral) == false);
+        add_edge(0, 2, g3);
+        BOOST_TEST(is_connected(g3, is_connected_kind::unilateral) == true);
+    }
+    */
+
+    // consider testing it if we decide to preserve the old interface
+    // test_colormap_reuse(size);
 
     return boost::report_errors();
 }

--- a/test/is_connected.cpp
+++ b/test/is_connected.cpp
@@ -53,19 +53,17 @@ int main(int argc, char* argv[])
         // the directed graph is not strongly connected
         fill_square_graph(g, size);
 
-        BOOST_TEST(is_connected(g) == false);
-        BOOST_TEST(is_connected(g, is_connected_kind::strong) == false);
+        BOOST_TEST(is_connected(g, connected_kind::strong) == false);
         BOOST_TEST(is_strongly_connected(g) == false);
-        BOOST_TEST(is_connected(g, is_connected_kind::unilateral) == false);
+        BOOST_TEST(is_connected(g, connected_kind::unilateral) == false);
 
         // now make it strongly connected with one more edge from the last vertex
         // to the first
         add_edge(coord_to_idx(size, size - 1, size - 1), 0, g);
 
-        BOOST_TEST(is_connected(g) == true);
-        BOOST_TEST(is_connected(g, is_connected_kind::strong) == true);
+        BOOST_TEST(is_connected(g, connected_kind::strong) == true);
         BOOST_TEST(is_strongly_connected(g) == true);
-        BOOST_TEST(is_connected(g, is_connected_kind::unilateral) == true);
+        BOOST_TEST(is_connected(g, connected_kind::unilateral) == true);
     }
 
     {
@@ -74,20 +72,20 @@ int main(int argc, char* argv[])
         bidir_graph_t g(size * size);
         fill_square_graph(g, size);
         // the directed graph is not strongly connected
-        BOOST_TEST(is_connected(g, is_connected_kind::strong) == false);
+        BOOST_TEST(is_connected(g, connected_kind::strong) == false);
         BOOST_TEST(is_strongly_connected(g) == false);
         // but it is weakly connected
-        BOOST_TEST(is_connected(g, is_connected_kind::weak) == true);
+        BOOST_TEST(is_connected(g, connected_kind::weak) == true);
         BOOST_TEST(is_weakly_connected(g) == true);
 
         // another graph, 2 disconnected vertices
         bidir_graph_t g2(2);
-        BOOST_TEST(is_connected(g2, is_connected_kind::weak) == false);
+        BOOST_TEST(is_connected(g2, connected_kind::weak) == false);
 
         // make it weakly connected
         add_edge(0, 1, g2);
-        BOOST_TEST(is_connected(g2, is_connected_kind::weak) == true);
-        BOOST_TEST(is_connected(g2, is_connected_kind::strong) == false);
+        BOOST_TEST(is_connected(g2, connected_kind::weak) == true);
+        BOOST_TEST(is_connected(g2, connected_kind::strong) == false);
     }
 
     {
@@ -99,8 +97,9 @@ int main(int argc, char* argv[])
 
         BOOST_TEST(is_connected(g) == true);
         BOOST_TEST(is_connected_undirected(g) == true);
-        BOOST_TEST(is_connected(g, is_connected_kind::strong) == true);
-        BOOST_TEST(is_connected(g, is_connected_kind::weak) == true);
+        BOOST_TEST(is_connected(g, connected_kind::strong) == true);
+        BOOST_TEST(is_connected(g, connected_kind::unilateral) == true);
+        BOOST_TEST(is_connected(g, connected_kind::weak) == true);
 
         // now fill fewer edges, so one row is disconnected
         undir_graph_t g2(size * (size + 1));
@@ -108,8 +107,8 @@ int main(int argc, char* argv[])
 
         BOOST_TEST(is_connected(g2) == false);
         BOOST_TEST(is_connected_undirected(g2) == false);
-        BOOST_TEST(is_connected(g2, is_connected_kind::strong) == false);
-        BOOST_TEST(is_connected(g2, is_connected_kind::weak) == false);
+        BOOST_TEST(is_connected(g2, connected_kind::strong) == false);
+        BOOST_TEST(is_connected(g2, connected_kind::weak) == false);
 
     }
 
@@ -119,49 +118,59 @@ int main(int argc, char* argv[])
         bidir_graph_t g(size * size);
         fill_square_graph(g, size);
 
-        BOOST_TEST(is_connected(g, is_connected_kind::weak) == true);
+        BOOST_TEST(is_connected(g, connected_kind::weak) == true);
         BOOST_TEST(is_weakly_connected(g) == true);
 
-        BOOST_TEST(is_connected(g, is_connected_kind::strong) == false);
+        BOOST_TEST(is_connected(g, connected_kind::strong) == false);
         BOOST_TEST(is_strongly_connected(g) == false);
 
-        BOOST_TEST(is_connected(g, is_connected_kind::unilateral) == false);
+        BOOST_TEST(is_connected(g, connected_kind::unilateral) == false);
         BOOST_TEST(is_unilaterally_connected(g) == false);
 
         bidir_graph_t g2(2);
-        BOOST_TEST(is_connected(g2, is_connected_kind::weak) == false);
-        BOOST_TEST(is_connected(g2, is_connected_kind::strong) == false);
-        BOOST_TEST(is_connected(g2, is_connected_kind::unilateral) == false);
+        BOOST_TEST(is_connected(g2, connected_kind::weak) == false);
+        BOOST_TEST(is_connected(g2, connected_kind::strong) == false);
+        BOOST_TEST(is_connected(g2, connected_kind::unilateral) == false);
 
         add_edge(0, 1, g2);
-        BOOST_TEST(is_connected(g2, is_connected_kind::weak) == true);
-        BOOST_TEST(is_connected(g2, is_connected_kind::strong) == false);
-        BOOST_TEST(is_connected(g2, is_connected_kind::unilateral) == true);
+        BOOST_TEST(is_connected(g2, connected_kind::weak) == true);
+        BOOST_TEST(is_connected(g2, connected_kind::strong) == false);
+        BOOST_TEST(is_connected(g2, connected_kind::unilateral) == true);
 
 
         // test making a graph weakly, then unilaterally, then strongly connected
         bidir_graph_t g3(3);
-        BOOST_TEST(is_connected(g3, is_connected_kind::weak) == false);
-        BOOST_TEST(is_connected(g3, is_connected_kind::unilateral) == false);
-        BOOST_TEST(is_connected(g3, is_connected_kind::strong) == false);
+        BOOST_TEST(is_connected(g3, connected_kind::weak) == false);
+        BOOST_TEST(is_connected(g3, connected_kind::unilateral) == false);
+        BOOST_TEST(is_connected(g3, connected_kind::strong) == false);
         add_edge(0, 1, g3);
         add_edge(2, 1, g3);
-        BOOST_TEST(is_connected(g3, is_connected_kind::weak) == true);
-        BOOST_TEST(is_connected(g3, is_connected_kind::unilateral) == false);
-        BOOST_TEST(is_connected(g3, is_connected_kind::strong) == false);
+        BOOST_TEST(is_connected(g3, connected_kind::weak) == true);
+        BOOST_TEST(is_connected(g3, connected_kind::unilateral) == false);
+        BOOST_TEST(is_connected(g3, connected_kind::strong) == false);
         add_edge(0, 2, g3);
-        BOOST_TEST(is_connected(g3, is_connected_kind::weak) == true);
-        BOOST_TEST(is_connected(g3, is_connected_kind::unilateral) == true);
-        BOOST_TEST(is_connected(g3, is_connected_kind::strong) == false);
+        BOOST_TEST(is_connected(g3, connected_kind::weak) == true);
+        BOOST_TEST(is_connected(g3, connected_kind::unilateral) == true);
+        BOOST_TEST(is_connected(g3, connected_kind::strong) == false);
         add_edge(1, 0, g3);
-        BOOST_TEST(is_connected(g3, is_connected_kind::weak) == true);
-        BOOST_TEST(is_connected(g3, is_connected_kind::unilateral) == true);
-        BOOST_TEST(is_connected(g3, is_connected_kind::strong) == true);
+        BOOST_TEST(is_connected(g3, connected_kind::weak) == true);
+        BOOST_TEST(is_connected(g3, connected_kind::unilateral) == true);
+        BOOST_TEST(is_connected(g3, connected_kind::strong) == true);
 
         // Test the usage of the old interface with ColorMap as the second arg.
         // This causes static assertion. I don't see a way to test for it, so
         // it's commented out.
         // BOOST_TEST(is_connected(g3, two_bit_color_map<>(0)) == false);
+
+        // Test that connected_kind is required for directed graph.
+        // This causes static assertion to fail as well.
+        // BOOST_TEST(is_connected(g3) == false);
+    }
+
+    {
+        // check that we don't need the vertex_index
+        typedef adjacency_list< listS, listS, bidirectionalS > bidir_graph_t;
+        
     }
 
     /*
@@ -172,38 +181,38 @@ int main(int argc, char* argv[])
         bidir_graph_t g(size * size);
         fill_square_graph(g, size);
 
-        BOOST_TEST(is_connected(g, is_connected_kind::weak) == true);
+        BOOST_TEST(is_connected(g, connected_kind::weak) == true);
         BOOST_TEST(is_weakly_connected(g) == true);
 
-        BOOST_TEST(is_connected(g, is_connected_kind::strong) == false);
+        BOOST_TEST(is_connected(g, connected_kind::strong) == false);
         BOOST_TEST(is_strongly_connected(g) == false);
 
-        BOOST_TEST(is_connected(g, is_connected_kind::unilateral) == false);
+        BOOST_TEST(is_connected(g, connected_kind::unilateral) == false);
         BOOST_TEST(is_unilaterally_connected(g) == false);
 
         bidir_graph_t g2(2);
-        BOOST_TEST(is_connected(g2, is_connected_kind::weak) == false);
+        BOOST_TEST(is_connected(g2, connected_kind::weak) == false);
         BOOST_TEST(is_weakly_connected(g2) == false);
-        BOOST_TEST(is_connected(g2, is_connected_kind::strong) == false);
+        BOOST_TEST(is_connected(g2, connected_kind::strong) == false);
         BOOST_TEST(is_strongly_connected(g2) == false);
-        BOOST_TEST(is_connected(g2, is_connected_kind::unilateral) == false);
+        BOOST_TEST(is_connected(g2, connected_kind::unilateral) == false);
         BOOST_TEST(is_unilaterally_connected(g2) == false);
 
         add_edge(0, 1, g2);
-        BOOST_TEST(is_connected(g2, is_connected_kind::weak) == true);
+        BOOST_TEST(is_connected(g2, connected_kind::weak) == true);
         BOOST_TEST(is_weakly_connected(g2) == true);
-        BOOST_TEST(is_connected(g2, is_connected_kind::strong) == false);
+        BOOST_TEST(is_connected(g2, connected_kind::strong) == false);
         BOOST_TEST(is_strongly_connected(g2) == false);
-        BOOST_TEST(is_connected(g2, is_connected_kind::unilateral) == true);
+        BOOST_TEST(is_connected(g2, connected_kind::unilateral) == true);
         BOOST_TEST(is_unilaterally_connected(g2) == true);
 
         bidir_graph_t g3(3);
-        BOOST_TEST(is_connected(g3, is_connected_kind::unilateral) == false);
+        BOOST_TEST(is_connected(g3, connected_kind::unilateral) == false);
         add_edge(0, 1, g3);
         add_edge(2, 1, g3);
-        BOOST_TEST(is_connected(g3, is_connected_kind::unilateral) == false);
+        BOOST_TEST(is_connected(g3, connected_kind::unilateral) == false);
         add_edge(0, 2, g3);
-        BOOST_TEST(is_connected(g3, is_connected_kind::unilateral) == true);
+        BOOST_TEST(is_connected(g3, connected_kind::unilateral) == true);
     }
     */
 

--- a/test/is_connected.cpp
+++ b/test/is_connected.cpp
@@ -1,0 +1,68 @@
+#include <boost/core/lightweight_test.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/graph_utility.hpp>
+#include <boost/graph/two_bit_color_map.hpp>
+
+using namespace std;
+using namespace boost;
+
+// todo: consider mdspan when it's widely implemented
+inline size_t coord_to_idx(size_t height, size_t x, size_t y) {
+    return y * height + x;
+}
+
+template <class Graph>
+void fill_square_graph(Graph& graph, size_t size) {
+    const size_t W = size, H = size;
+
+    for (size_t i = 0; i < W; ++i) {
+        for (size_t j = 0; j < H; ++j) {
+            size_t idx = coord_to_idx(H, i, j);
+            if (i > 0)
+                add_edge(coord_to_idx(H, i - 1, j), idx, graph);
+            if (j > 0)
+                add_edge(coord_to_idx(H, i, j - 1), idx, graph);
+        }
+    }
+}
+
+template <typename Graph>
+void run_test(const Graph& g, bool exp_result) {
+    bool result = is_connected(g, boost::make_two_bit_color_map(num_vertices(g), get(boost::vertex_index, g)));
+    BOOST_TEST(exp_result == result);
+}
+
+int main(int argc, char* argv[])
+{
+    // the side length of the square graph
+    size_t size = 20;
+    if (argc > 1)
+    {
+        size = lexical_cast< int >(argv[1]);
+    }
+
+    typedef adjacency_list<> dir_graph_t;
+    dir_graph_t g(size * size);
+    // the directed graph is not strongly connected
+    fill_square_graph(g, size);
+    run_test(g, false);
+
+    // now make it connected with one more edge from the last vertex to the first
+    add_edge(coord_to_idx(size, size - 1, size - 1), 0, g);
+    run_test(g, true);
+
+    typedef adjacency_list<vecS, vecS, undirectedS> undir_graph_t;
+    undir_graph_t ug(size * size);
+    // the undirected graph is already strongly connected
+    fill_square_graph(g, size);
+    run_test(g, true);
+
+    // now fill fewer edges, so one row is disconnected
+    undir_graph_t ug2(size * (size + 1));
+    fill_square_graph(ug2, size);
+    run_test(ug2, false);
+
+    return boost::report_errors();
+}
+

--- a/test/is_connected.cpp
+++ b/test/is_connected.cpp
@@ -37,6 +37,28 @@ void fill_square_graph(Graph& graph, size_t size)
     }
 }
 
+template <typename Graph>
+void test_directed_graph() {
+		// todo: call this function
+        Graph g3(3);
+        BOOST_TEST(is_connected(g3, connected_kind::weak) == false);
+        BOOST_TEST(is_connected(g3, connected_kind::unilateral) == false);
+        BOOST_TEST(is_connected(g3, connected_kind::strong) == false);
+        add_edge(0, 1, g3);
+        add_edge(2, 1, g3);
+        BOOST_TEST(is_connected(g3, connected_kind::weak) == true);
+        BOOST_TEST(is_connected(g3, connected_kind::unilateral) == false);
+        BOOST_TEST(is_connected(g3, connected_kind::strong) == false);
+        add_edge(0, 2, g3);
+        BOOST_TEST(is_connected(g3, connected_kind::weak) == true);
+        BOOST_TEST(is_connected(g3, connected_kind::unilateral) == true);
+        BOOST_TEST(is_connected(g3, connected_kind::strong) == false);
+        add_edge(1, 0, g3);
+        BOOST_TEST(is_connected(g3, connected_kind::weak) == true);
+        BOOST_TEST(is_connected(g3, connected_kind::unilateral) == true);
+        BOOST_TEST(is_connected(g3, connected_kind::strong) == true);
+}
+
 int main(int argc, char* argv[])
 {
     // the side length of the square graph
@@ -137,7 +159,6 @@ int main(int argc, char* argv[])
         BOOST_TEST(is_connected(g2, connected_kind::strong) == false);
         BOOST_TEST(is_connected(g2, connected_kind::unilateral) == true);
 
-
         // test making a graph weakly, then unilaterally, then strongly connected
         bidir_graph_t g3(3);
         BOOST_TEST(is_connected(g3, connected_kind::weak) == false);
@@ -168,14 +189,50 @@ int main(int argc, char* argv[])
     }
 
     {
-        // check that we don't need the vertex_index
+        // test with an external vertex_index
         typedef adjacency_list< listS, listS, bidirectionalS > bidir_graph_t;
-        
+        bidir_graph_t g(size * size);
+
+        map<typename bidir_graph_t::vertex_descriptor, size_t> vertex_index_map;
+        size_t n = 0;
+		for (auto [v, ve] = vertices(g); v != ve; ++v) {
+			vertex_index_map[*v] = n++;
+		}
+
+		auto vertex_index = make_assoc_property_map(vertex_index_map);
+
+        BOOST_TEST(is_connected(g, vertex_index, connected_kind::weak) == false);
+        BOOST_TEST(is_connected(g, vertex_index, connected_kind::unilateral) == false);
+        BOOST_TEST(is_connected(g, vertex_index, connected_kind::strong) == false);
+
+        BOOST_TEST(is_weakly_connected(g, vertex_index) == false);
+        BOOST_TEST(is_strongly_connected(g, vertex_index) == false);
+        BOOST_TEST(is_unilaterally_connected(g, vertex_index) == false);
     }
+
+	{
+		// test undirected graph with an external vertex_index
+        typedef adjacency_list< listS, listS, undirectedS > undir_graph_t;
+        undir_graph_t g(size * size);
+
+        map<typename undir_graph_t::vertex_descriptor, size_t> vertex_index_map;
+        size_t n = 0;
+		for (auto [v, ve] = vertices(g); v != ve; ++v) {
+			vertex_index_map[*v] = n++;
+		}
+
+		auto vertex_index = make_assoc_property_map(vertex_index_map);
+
+        // BOOST_TEST(is_connected(g, vertex_index) == false);
+        BOOST_TEST(is_connected(g, vertex_index, connected_kind::unspecified) == false);
+        BOOST_TEST(is_connected(g, vertex_index, connected_kind::weak) == false);
+        BOOST_TEST(is_connected(g, vertex_index, connected_kind::unilateral) == false);
+        BOOST_TEST(is_connected(g, vertex_index, connected_kind::strong) == false);
+	}
+
 
     {
         // test that adjacency matrix implements bidirectional graph
-        // (see another PR [todo: link]
         typedef boost::adjacency_matrix<> bidir_graph_t;
         bidir_graph_t g(size * size);
         fill_square_graph(g, size);
@@ -213,9 +270,6 @@ int main(int argc, char* argv[])
         add_edge(0, 2, g3);
         BOOST_TEST(is_connected(g3, connected_kind::unilateral) == true);
     }
-
-    // consider testing it if we decide to preserve the old interface
-    // test_colormap_reuse(size);
 
     return boost::report_errors();
 }

--- a/test/is_connected.cpp
+++ b/test/is_connected.cpp
@@ -173,7 +173,6 @@ int main(int argc, char* argv[])
         
     }
 
-    /*
     {
         // test that adjacency matrix implements bidirectional graph
         // (see another PR [todo: link]
@@ -214,7 +213,6 @@ int main(int argc, char* argv[])
         add_edge(0, 2, g3);
         BOOST_TEST(is_connected(g3, connected_kind::unilateral) == true);
     }
-    */
 
     // consider testing it if we decide to preserve the old interface
     // test_colormap_reuse(size);


### PR DESCRIPTION
The `is_connected()` function is implemented in terms of `is_rechable()`, effectively checking if each vertex is reachable from each other vertex in a nested loop. This quickly becomes terribly slow as the number of vertices and edges grow, becoming roughly unusable with a square connected graph of size 20x20.

This request fixes the issue by
- using a single DFS walk for undirected graphs
- employing the Tarjan's SCC algorithm for directed graphs

This reduces the algorithm complexity from cubic to linear and makes it possible to use it on large graphs. See also the commit message in https://github.com/boostorg/graph/commit/80ae041e652130cfdcbeee72c2fd91fbf97e14b7

This change is fully backward compatible with the previous implementation. 

It also adds a new `is_connected.cpp` test. Feel free to run this test on the previous implementation. This test passes without the new algorithm, but picks the size of 20x20 square to be considerably slow. This test also accepts an integer as argv[1],  the size of the square, so it is possible to observe the slow-down growing as the size increases (the default is 20).

Please see an excerpt of my measurement below (I can upload this program as well). The previous implementation quickly becomes impracticably slow.

I note, that `is_connected` is not documented and is not widely used. Still I consider it to be important to fully adhere to the interface specified in comment and preserve the compatibility, as it could have been used in non-public projects. In short one important decision here is to avoid any breaking changes.

I foresee a few concerns with this request, which I'll be happy to discuss and address if possible:
* the `graph_utility.hpp` header file seems to be designed as low-dependency. Including < vector > and <strong_components.hpp> there seems to violate that choice. But I think the practical aspect of this is reasonably minimal; while fixing the issue fully preserving the backward compatibility is important in practice.
* the colormap is not used for directed graphs. `strong_components` do not accept the colormap and pass it to DFS. I don't see this as a big concern. This can be addressed in 2 ways: updating SCC interface to pass the colormap to DFS, or (probably better) provide the version of `is_connected` with a single argument and no colormap.
* the version for directed graphs seems to now require `VertexIndexGraph` concept. (I think) This can be fixed by using `map` instead of `vector` for the component map (`comp_map`) in case the graph is not VertexIndexGraph. I'm not sure, how important is this, but this seems to be a deviation from the full backward compatibility.

I consider a bit of follow-up work on this, which can also be done in a separate pull request:
* provide single-argument `is_connected(const Graph& g)`. This will require including the colormap header into the graph_utility 
* document `is_connected` (and other utility functions like `is_reachable`)
* add examples of the above

fixes #398

Measurement:
```
=== Testing size 1
= Testing undirected, connected
time: undirected, connected - prev implementation - elapsed     3.299e-06s
time: undirected, connected - new  implementation - elapsed     1.179e-06s
= Testing undirected, not connected
time: undirected, not connected - prev implementation - elapsed         8.62e-07s
time: undirected, not connected - new  implementation - elapsed         5.39e-07s
= Testing directed, connected
time: directed, connected - prev implementation - elapsed       8.22e-07s
time: directed, connected - new  implementation - elapsed       2.636e-06s
= Testing directed, not connected
time: directed, not connected - prev implementation - elapsed   1.64e-06s
time: directed, not connected - new  implementation - elapsed   1.555e-06s

...
=== Testing size 10
= Testing undirected, connected
time: undirected, connected - prev implementation - elapsed     0.0409115s
time: undirected, connected - new  implementation - elapsed     5.703e-06s
= Testing undirected, not connected
time: undirected, not connected - prev implementation - elapsed         0.000392494s
time: undirected, not connected - new  implementation - elapsed         4.8e-06s
= Testing directed, connected
time: directed, connected - prev implementation - elapsed       0.0240339s
time: directed, connected - new  implementation - elapsed       7.925e-06s
= Testing directed, not connected
time: directed, not connected - prev implementation - elapsed   0.000261854s
time: directed, not connected - new  implementation - elapsed   6.209e-06s

...
=== Testing size 24
= Testing undirected, connected
time: undirected, connected - prev implementation - elapsed     16.458s
time: undirected, connected - new  implementation - elapsed     6.1249e-05s
= Testing undirected, not connected
time: undirected, not connected - prev implementation - elapsed         0.0312753s
time: undirected, not connected - new  implementation - elapsed         6.9342e-05s
= Testing directed, connected
time: directed, connected - prev implementation - elapsed       7.45684s
time: directed, connected - new  implementation - elapsed       4.9894e-05s
= Testing directed, not connected
time: directed, not connected - prev implementation - elapsed   0.01372s
time: directed, not connected - new  implementation - elapsed   0.000215756s
```
  

