### PR TITLE
Make adjacency_matrix implement BidirectionalGraph concept

### DIFF
--- a/include/boost/graph/adjacency_matrix.hpp
+++ b/include/boost/graph/adjacency_matrix.hpp
@@ -433,7 +433,8 @@ struct adj_matrix_traversal_tag : public virtual adjacency_matrix_tag,
                                   public virtual vertex_list_graph_tag,
                                   public virtual incidence_graph_tag,
                                   public virtual adjacency_graph_tag,
-                                  public virtual edge_list_graph_tag
+                                  public virtual edge_list_graph_tag,
+                                  public virtual bidirectional_graph_tag
 {
 };
 
@@ -824,6 +825,26 @@ typename adjacency_matrix< D, VP, EP, GP, A >::degree_size_type in_degree(
     for (boost::tie(f, l) = in_edges(u, g); f != l; ++f)
         ++n;
     return n;
+}
+
+// degree
+template < typename VP, typename EP, typename GP, typename A >
+typename adjacency_matrix< directedS, VP, EP, GP, A >::degree_size_type
+degree(
+    typename adjacency_matrix< directedS, VP, EP, GP, A >::vertex_descriptor u,
+    const adjacency_matrix< directedS, VP, EP, GP, A >& g)
+{
+    return in_degree(u, g) + out_degree(u, g);
+}
+
+template < typename VP, typename EP, typename GP, typename A >
+typename adjacency_matrix< undirectedS, VP, EP, GP, A >::degree_size_type
+degree(
+    typename adjacency_matrix< undirectedS, VP, EP, GP, A >::vertex_descriptor
+        u,
+    const adjacency_matrix< undirectedS, VP, EP, GP, A >& g)
+{
+    return out_degree(u, g);
 }
 
 //=========================================================================

--- a/include/boost/graph/adjacency_matrix.hpp
+++ b/include/boost/graph/adjacency_matrix.hpp
@@ -827,7 +827,7 @@ typename adjacency_matrix< D, VP, EP, GP, A >::degree_size_type in_degree(
     return n;
 }
 
-// degree
+// O(N)
 template < typename VP, typename EP, typename GP, typename A >
 typename adjacency_matrix< directedS, VP, EP, GP, A >::degree_size_type
 degree(
@@ -837,6 +837,7 @@ degree(
     return in_degree(u, g) + out_degree(u, g);
 }
 
+// O(N)
 template < typename VP, typename EP, typename GP, typename A >
 typename adjacency_matrix< undirectedS, VP, EP, GP, A >::degree_size_type
 degree(

--- a/test/adj_matrix_cc.cpp
+++ b/test/adj_matrix_cc.cpp
@@ -21,6 +21,7 @@ int main(int, char*[])
         BOOST_CONCEPT_ASSERT((EdgeListGraphConcept< Graph >));
         BOOST_CONCEPT_ASSERT((IncidenceGraphConcept< Graph >));
         BOOST_CONCEPT_ASSERT((AdjacencyGraphConcept< Graph >));
+        BOOST_CONCEPT_ASSERT((BidirectionalGraphConcept< Graph >));
         BOOST_CONCEPT_ASSERT((MutableGraphConcept< Graph >));
         BOOST_CONCEPT_ASSERT((AdjacencyMatrixConcept< Graph >));
     }
@@ -30,6 +31,7 @@ int main(int, char*[])
         BOOST_CONCEPT_ASSERT((EdgeListGraphConcept< Graph >));
         BOOST_CONCEPT_ASSERT((IncidenceGraphConcept< Graph >));
         BOOST_CONCEPT_ASSERT((AdjacencyGraphConcept< Graph >));
+        BOOST_CONCEPT_ASSERT((BidirectionalGraphConcept< Graph >));
         BOOST_CONCEPT_ASSERT((MutableGraphConcept< Graph >));
         BOOST_CONCEPT_ASSERT((AdjacencyMatrixConcept< Graph >));
     }
@@ -44,6 +46,7 @@ int main(int, char*[])
         BOOST_CONCEPT_ASSERT((EdgeListGraphConcept< Graph >));
         BOOST_CONCEPT_ASSERT((IncidenceGraphConcept< Graph >));
         BOOST_CONCEPT_ASSERT((AdjacencyGraphConcept< Graph >));
+        BOOST_CONCEPT_ASSERT((BidirectionalGraphConcept< Graph >));
         BOOST_CONCEPT_ASSERT((AdjacencyMatrixConcept< Graph >));
         BOOST_CONCEPT_ASSERT((VertexMutablePropertyGraphConcept< Graph >));
         BOOST_CONCEPT_ASSERT((EdgeMutablePropertyGraphConcept< Graph >));
@@ -64,6 +67,7 @@ int main(int, char*[])
         BOOST_CONCEPT_ASSERT((EdgeListGraphConcept< Graph >));
         BOOST_CONCEPT_ASSERT((IncidenceGraphConcept< Graph >));
         BOOST_CONCEPT_ASSERT((AdjacencyGraphConcept< Graph >));
+        BOOST_CONCEPT_ASSERT((BidirectionalGraphConcept< Graph >));
         BOOST_CONCEPT_ASSERT((AdjacencyMatrixConcept< Graph >));
         BOOST_CONCEPT_ASSERT((VertexMutablePropertyGraphConcept< Graph >));
         BOOST_CONCEPT_ASSERT((EdgeMutablePropertyGraphConcept< Graph >));

--- a/test/reverse_graph_cc.cpp
+++ b/test/reverse_graph_cc.cpp
@@ -9,6 +9,7 @@
 #include <boost/graph/graph_concepts.hpp>
 #include <boost/graph/graph_archetypes.hpp>
 #include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/adjacency_matrix.hpp>
 #include <boost/graph/reverse_graph.hpp>
 #include <boost/concept/assert.hpp>
 #include <string>
@@ -58,6 +59,27 @@ int main(int, char*[])
         Graph gr(g);
         get_property(gr, graph_name_t());
         set_property(gr, graph_name_t(), "foo");
+    }
+    // Check matrix
+    {
+        typedef adjacency_matrix< directedS,
+            property< vertex_color_t, int >, property< edge_weight_t, int >,
+            property< graph_name_t, std::string > >
+            AdjMatrix;
+        typedef reverse_graph< AdjMatrix > Graph;
+        BOOST_CONCEPT_ASSERT((VertexListGraphConcept< Graph >));
+        BOOST_CONCEPT_ASSERT((BidirectionalGraphConcept< Graph >));
+        typedef graph_traits< Graph >::vertex_descriptor Vertex;
+        typedef graph_traits< Graph >::edge_descriptor Edge;
+        BOOST_CONCEPT_ASSERT(
+            (ReadablePropertyGraphConcept< Graph, Vertex, vertex_color_t >));
+        BOOST_CONCEPT_ASSERT(
+            (ReadablePropertyGraphConcept< Graph, Edge, edge_weight_t >));
+        BOOST_CONCEPT_ASSERT(
+            (ReadablePropertyGraphConcept< Graph, Edge, edge_underlying_t >));
+        AdjMatrix g(42);
+        Graph gr(g);
+        get_property(gr, graph_name_t());
     }
     return 0;
 }

--- a/test/test_graphs.cpp
+++ b/test/test_graphs.cpp
@@ -132,6 +132,8 @@ int main()
             Graph;
         BOOST_META_ASSERT(is_directed_graph< Graph >);
         BOOST_META_ASSERT(!is_multigraph< Graph >);
+        BOOST_META_ASSERT(is_bidirectional_graph< Graph >);
+        BOOST_META_ASSERT(is_directed_bidirectional_graph< Graph >);
         BOOST_META_ASSERT(has_vertex_property< Graph >);
         BOOST_META_ASSERT(has_bundled_vertex_property< Graph >);
         BOOST_META_ASSERT(has_edge_property< Graph >);
@@ -145,6 +147,8 @@ int main()
         typedef adjacency_matrix< directedS, VertexBundle, EdgeBundle > Graph;
         BOOST_META_ASSERT(is_directed_graph< Graph >);
         BOOST_META_ASSERT(!is_multigraph< Graph >);
+        BOOST_META_ASSERT(is_bidirectional_graph< Graph >);
+        BOOST_META_ASSERT(is_directed_bidirectional_graph< Graph >);
         BOOST_META_ASSERT(has_vertex_property< Graph >);
         BOOST_META_ASSERT(has_bundled_vertex_property< Graph >);
         BOOST_META_ASSERT(has_edge_property< Graph >);


### PR DESCRIPTION
Adjacency matrix is by nature bidirectional and one can see that the concept was mostly implemented before. That implementation missed the degree function(s). These functions are implemented in this commit and the traversal_category is updated to meet the concept requirements.

Tests are also added, though they are a bit shallow in the sense that they seem to omit intensive algorithms.

This PR is a consequence of work on https://github.com/boostorg/graph/pull/397 -- that one contains a test commented out, that ends up running `neighbor_bfs` on an adjacency matrix.

Fixes #404 
