### PR TITLE
Fixed wrong link in grid_graph documentation

### DIFF
--- a/doc/grid_graph.html
+++ b/doc/grid_graph.html
@@ -69,7 +69,7 @@
     <p>
       Defined in
       <a href="../../../boost/graph/grid_graph.hpp"><tt>boost/graph/grid_graph.hpp</tt></a>
-      with all functions in the <tt>boost</tt> namespace.  A simple examples of creating and iterating over a grid_graph is available here <a href="../../../libs/graph/example/grid_graph_example.cpp"><tt>libs/graph/example/grid_graph_example.cpp</tt></a>. An example of adding properties to a grid_graph is also available <a href="../../../libs/graph/example/grid_graph_example.cpp"><tt>libs/graph/example/grid_graph_properties.cpp</tt></a>
+      with all functions in the <tt>boost</tt> namespace.  A simple examples of creating and iterating over a grid_graph is available here <a href="../../../libs/graph/example/grid_graph_example.cpp"><tt>libs/graph/example/grid_graph_example.cpp</tt></a>. An example of adding properties to a grid_graph is also available <a href="../../../libs/graph/example/grid_graph_properties.cpp"><tt>libs/graph/example/grid_graph_properties.cpp</tt></a>
     </p>
 
     <h4>Template Parameters</h4>


### PR DESCRIPTION
There was an erroneous link in the `grid_graph` documentation.