### PR TITLE
Fix geometry bug in is_straight_line_drawing

### DIFF
--- a/include/boost/graph/is_straight_line_drawing.hpp
+++ b/include/boost/graph/is_straight_line_drawing.hpp
@@ -19,6 +19,8 @@
 #include <boost/geometry/algorithms/crosses.hpp>
 #include <boost/geometry/geometries/linestring.hpp>
 
+#include <boost/numeric/conversion/cast.hpp>
+
 #include <algorithm>
 #include <vector>
 #include <map>
@@ -113,10 +115,14 @@ bool is_straight_line_drawing(
                 vertex_t f_source(source(f, g));
                 vertex_t f_target(target(f, g));
 
-                linestring<point_xy<double>> source{{drawing[e_source].x, drawing[e_source].y},
-                                                    {drawing[e_target].x, drawing[e_target].y}};
-                linestring<point_xy<double>> target{{drawing[f_source].x, drawing[f_source].y},
-                                                    {drawing[f_target].x, drawing[f_target].y}};
+                linestring<point_xy<double>> source{{numeric_cast<double>(drawing[e_source].x),
+                                                     numeric_cast<double>(drawing[e_source].y)},
+                                                    {numeric_cast<double>(drawing[e_target].x),
+                                                     numeric_cast<double>(drawing[e_target].y)}};
+                linestring<point_xy<double>> target{{numeric_cast<double>(drawing[f_source].x),
+                                                     numeric_cast<double>(drawing[f_source].y)},
+                                                    {numeric_cast<double>(drawing[f_target].x),
+                                                     numeric_cast<double>(drawing[f_target].y)}};
 
                 if (crosses(source, target))
                     return false;
@@ -131,10 +137,14 @@ bool is_straight_line_drawing(
                 vertex_t f_source(source(f, g));
                 vertex_t f_target(target(f, g));
 
-                linestring<point_xy<double>> source{{drawing[e_source].x, drawing[e_source].y},
-                                                    {drawing[e_target].x, drawing[e_target].y}};
-                linestring<point_xy<double>> target{{drawing[f_source].x, drawing[f_source].y},
-                                                    {drawing[f_target].x, drawing[f_target].y}};
+                linestring<point_xy<double>> source{{numeric_cast<double>(drawing[e_source].x),
+                                                     numeric_cast<double>(drawing[e_source].y)},
+                                                    {numeric_cast<double>(drawing[e_target].x),
+                                                     numeric_cast<double>(drawing[e_target].y)}};
+                linestring<point_xy<double>> target{{numeric_cast<double>(drawing[f_source].x),
+                                                     numeric_cast<double>(drawing[f_source].y)},
+                                                    {numeric_cast<double>(drawing[f_target].x),
+                                                     numeric_cast<double>(drawing[f_target].y)}};
 
                 if (crosses(source, target))
                     return false;

--- a/test/is_straight_line_draw_test.cpp
+++ b/test/is_straight_line_draw_test.cpp
@@ -192,5 +192,32 @@ int main(int, char*[])
 
     BOOST_TEST(!is_straight_line_drawing(g, drawing));
 
+
+    // issue #388
+    g.clear();
+    add_edge(0, 1, g);
+    add_edge(2, 0, g);
+    add_edge(1, 2, g);
+
+    struct coord_t { size_t x, y; };
+    std::vector<coord_t> coordinates{
+        {4143438, 86426},
+        {4064945, 7932},
+	{4064944, 7931}
+    };
+/*
+   There is a very small angle between edge 0--1 and edge 2--0 at vertex 0,
+   with slope of edges 78494/78493 != 78495/78494, which cannot be
+   correctly handled by double type function "intersects()" called
+   by "is_straight_line_drawing()":
+
+4143438-4064945 = 78493
+86426-7932 = 78494
+
+4143438-4064944 = 78494
+86426-7931 = 78495
+*/
+    BOOST_TEST(is_straight_line_drawing(g, coordinates.data()));
+
     return boost::report_errors();
 }


### PR DESCRIPTION
Fix the geometry bug uncovered and documented by @Hermann-SW by replacing the custom function with one from Boost.Geometry.
`crosses` meets the requirement described in the old code for returning true for 'intersections' that don't include endpoints or self-intersection.
I decided to remove the tolerance altogether on the assumption that it was indicative of a poor implementation.