### PR TITLE
Fix performance issues for vector-based storage

### DIFF
--- a/include/boost/graph/detail/adjacency_list.hpp
+++ b/include/boost/graph/detail/adjacency_list.hpp
@@ -2228,9 +2228,10 @@ inline typename Config::vertex_descriptor add_vertex(
     vec_adj_list_impl< Graph, Config, Base >& g_)
 {
     Graph& g = static_cast< Graph& >(g_);
-    g.m_vertices.resize(g.m_vertices.size() + 1);
-    g.added_vertex(g.m_vertices.size() - 1);
-    return g.m_vertices.size() - 1;
+    auto const added_descriptor = g.m_vertices.size();
+    g.m_vertices.emplace_back();
+    g.added_vertex(added_descriptor);
+    return added_descriptor;
 }
 
 template < class Graph, class Config, class Base >
@@ -2243,10 +2244,10 @@ inline typename Config::vertex_descriptor add_vertex(
     if (optional< vertex_descriptor > v
         = g.vertex_by_property(get_property_value(p, vertex_bundle)))
         return *v;
-    typedef typename Config::stored_vertex stored_vertex;
-    g.m_vertices.push_back(stored_vertex(p));
-    g.added_vertex(g.m_vertices.size() - 1);
-    return g.m_vertices.size() - 1;
+    auto const added_descriptor = g.m_vertices.size();
+    g.m_vertices.emplace_back(p);
+    g.added_vertex(added_descriptor);
+    return added_descriptor;
 }
 
 // Here we override the directed_graph_helper add_edge() function

--- a/include/boost/graph/named_graph.hpp
+++ b/include/boost/graph/named_graph.hpp
@@ -275,12 +275,12 @@ namespace graph
 
         /// Extract the name from a vertex property instance
         typename extract_name_type::result_type extract_name(
-            const bundled_vertex_property_type& property);
+            const bundled_vertex_property_type& property) const;
 
         /// Search for a vertex that has the given property (based on its
         /// name)
         optional< vertex_descriptor > vertex_by_property(
-            const bundled_vertex_property_type& property);
+            const bundled_vertex_property_type& property) const;
 
         /// Mapping from names to vertices
         named_vertices_type named_vertices;
@@ -340,7 +340,7 @@ namespace graph
 
     template < BGL_NAMED_GRAPH_PARAMS >
     typename BGL_NAMED_GRAPH::extract_name_type::result_type
-    BGL_NAMED_GRAPH::extract_name(const bundled_vertex_property_type& property)
+    BGL_NAMED_GRAPH::extract_name(const bundled_vertex_property_type& property) const
     {
         return named_vertices.key_extractor().extract(property);
     }
@@ -348,7 +348,7 @@ namespace graph
     template < BGL_NAMED_GRAPH_PARAMS >
     optional< typename BGL_NAMED_GRAPH::vertex_descriptor >
     BGL_NAMED_GRAPH::vertex_by_property(
-        const bundled_vertex_property_type& property)
+        const bundled_vertex_property_type& property) const
     {
         return find_vertex(extract_name(property), *this);
     }

--- a/include/boost/graph/transitive_closure.hpp
+++ b/include/boost/graph/transitive_closure.hpp
@@ -151,7 +151,7 @@ void transitive_closure(const Graph& g, GraphTC& tc,
             cg_vertex v = *i;
             if (!in_a_chain[v])
             {
-                chains.resize(chains.size() + 1);
+                chains.emplace_back();
                 std::vector< cg_vertex >& chain = chains.back();
                 for (;;)
                 {

--- a/include/boost/graph/vector_as_graph.hpp
+++ b/include/boost/graph/vector_as_graph.hpp
@@ -283,7 +283,7 @@ void remove_edge_if(Predicate p, std::vector< EdgeList, Allocator >& g)
 template < class EdgeList, class Allocator >
 typename EdgeList::value_type add_vertex(std::vector< EdgeList, Allocator >& g)
 {
-    g.resize(g.size() + 1);
+    g.emplace_back();
     return g.size() - 1;
 }
 


### PR DESCRIPTION
- None of the functions called inside `vertex_by_property()` required a mutable graph object, but `vertex_by_property()` itself did. This is now fixed.
- At several locations in the code base there was the equivalent of `container.reserve(container.size() + 1)`, e.g. `add_vertex()`. Calling such an `add_vertex()` in a loop with an `std::vector` backing the vertex storage results in O(N²) time complexity instead of the expected (amortized) O(N). This is fixed by allowing the container to grow as expected.