### PR TITLE
Remove Boost.Assign usages.

### DIFF
--- a/test/graphviz_test.cpp
+++ b/test/graphviz_test.cpp
@@ -13,8 +13,6 @@
 
 #define BOOST_GRAPHVIZ_USE_ISTREAM
 #include <boost/graph/graphviz.hpp>
-#include <boost/assign/std/map.hpp>
-#include <boost/assign.hpp>
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/compressed_sparse_row_graph.hpp>
 #include <boost/core/lightweight_test.hpp>
@@ -29,8 +27,6 @@ typedef float Mass;
 typedef double Weight;
 typedef std::map< node_t, Mass > expected_masses_t;
 typedef std::map< edge_t, Weight > expected_weights_t;
-#define MAP_MASSES boost::assign::list_of< std::pair< node_t, Mass > >
-#define MAP_WEIGHTS boost::assign::list_of< std::pair< edge_t, Weight > >
 
 struct Fixture
 {
@@ -47,14 +43,14 @@ namespace Directed
     static Fixture const basic {
         "digraph { a  node [mass = 7.7] c e [mass = 6.66] }",
         3,
-        MAP_MASSES("a", 0.0f)("c", 7.7f)("e", 6.66f),
+        { { "a", 0.0f }, { "c", 7.7f }, { "e", 6.66f } },
         expected_weights_t(),
     };
 
     static Fixture const basic_aliased {
         "digraph { a  node [mass = 7.7] \"a\" e [mass = 6.66] }",
         2,
-        MAP_MASSES("a", 0.0f)("e", 6.66f),
+        { { "a", 0.0f }, { "e", 6.66f } },
         expected_weights_t(),
     };
 
@@ -64,9 +60,11 @@ namespace Directed
         "d ->e->a [weight=.5]}",
         6,
         expected_masses_t(),
-        MAP_WEIGHTS(edge_t("a", "b"), 0.0)(edge_t("c", "d"), 7.7)(
-            edge_t("e", "f"), 6.66)(edge_t("d", "e"), 0.5)(
-            edge_t("e", "a"), 0.5),
+        {
+            { edge_t("a", "b"), 0.0 }, { edge_t("c", "d"), 7.7 },
+            { edge_t("e", "f"), 6.66 }, { edge_t("d", "e"), 0.5 },
+            { edge_t("e", "a"), 0.5 } //
+        },
     };
 }
 
@@ -75,7 +73,7 @@ namespace Undirected
     static Fixture const basic {
         "graph { a  nodE [mass = 7.7] c e [mass =\\\n6.66] }",
         3,
-        MAP_MASSES("a", 0.0f)("c", 7.7f)("e", 6.66f),
+        { { "a", 0.0f }, { "c", 7.7f }, { "e", 6.66f } },
         expected_weights_t(),
     };
 
@@ -84,8 +82,10 @@ namespace Undirected
         "c -- d e -- f [weight = 6.66] }",
         6,
         expected_masses_t(),
-        MAP_WEIGHTS(edge_t("a", "b"), 0.0)(edge_t("c", "d"), 7.7)(
-            edge_t("e", "f"), 6.66),
+        {
+            { edge_t("a", "b"), 0.0 }, { edge_t("c", "d"), 7.7 },
+            { edge_t("e", "f"), 6.66 } //
+        },
     };
 }
 
@@ -331,7 +331,7 @@ void test_parallel_edges()
         "diGraph { a -> b [weight = 7.7]  a -> b [weight = 7.7] }",
         2,
         expected_masses_t(),
-        MAP_WEIGHTS(edge_t("a", "b"), 7.7),
+        { { edge_t("a", "b"), 7.7 } },
     };
     TEST_GRAPH(Models::DiGraph, parallel);
     BOOST_TEST_THROWS(TEST_GRAPH(Models::DiGraphNoParallel, parallel),
@@ -345,7 +345,7 @@ void test_graph_property_test_1()
         "digraph { graph [name=\"foo \\\"escaped\\\"\"]  a  c e [mass = 6.66] "
         "}",
         3,
-        MAP_MASSES("a", 0.0f)("c", 0.0f)("e", 6.66f),
+        { { "a", 0.0f }, { "c", 0.0f }, { "e", 6.66f } },
         expected_weights_t(),
     };
     TEST_GRAPH(Models::DiGraph, named, "", "foo \"escaped\"");
@@ -357,7 +357,7 @@ void test_graph_property_test_2()
     Fixture named {
         "digraph { name=\"fo\"+ \"\\\no\"  a  c e [mass = 6.66] }",
         3,
-        MAP_MASSES("a", 0.0f)("c", 0.0f)("e", 6.66f),
+        { { "a", 0.0f }, { "c", 0.0f }, { "e", 6.66f } },
         expected_weights_t(),
     };
     TEST_GRAPH(Models::DiGraph, named, "", "foo"); // SEHE why not "foo\no"?
@@ -372,7 +372,7 @@ void test_graph_property_test_3()
     Fixture html_named {
         "digraph { name=" + graph_name + "  a  c e [mass = 6.66] }",
         3,
-        MAP_MASSES("a", 0.0f)("c", 0.0f)("e", 6.66f),
+        { { "a", 0.0f }, { "c", 0.0f }, { "e", 6.66f } },
         expected_weights_t(),
     };
     TEST_GRAPH(Models::DiGraph, html_named, "", graph_name);

--- a/test/two_graphs_common_spanning_trees_test.cpp
+++ b/test/two_graphs_common_spanning_trees_test.cpp
@@ -8,16 +8,11 @@
 //     Efficient Algorithm for Common Spanning Tree Problem
 // Electron. Lett., 28 April 1983, Volume 19, Issue 9, p.346-347
 
-#include <boost/type_traits.hpp>
 #include <boost/concept/requires.hpp>
-#include <boost/assign/std/vector.hpp>
 #include <boost/graph/adjacency_list.hpp>
-#include <boost/compressed_pair.hpp>
 #include <boost/core/lightweight_test.hpp>
 #include <boost/graph/two_graphs_common_spanning_trees.hpp>
 #include <vector>
-
-using namespace boost::assign;
 
 namespace boost
 {
@@ -32,13 +27,7 @@ typedef boost::adjacency_list< boost::vecS, // OutEdgeList
     >
     Graph;
 
-typedef boost::graph_traits< Graph >::vertex_descriptor vertex_descriptor;
-
 typedef boost::graph_traits< Graph >::edge_descriptor edge_descriptor;
-
-typedef boost::graph_traits< Graph >::vertex_iterator vertex_iterator;
-
-typedef boost::graph_traits< Graph >::edge_iterator edge_iterator;
 
 template < typename Coll, typename Seq > struct check_edge
 {
@@ -56,8 +45,8 @@ public:
     {
         bool found = false;
 
-        for (typename Coll::iterator iterator = coll.begin();
-             !found && iterator != coll.end(); ++iterator)
+        for (auto iterator = coll.begin(); !found && iterator != coll.end();
+            ++iterator)
         {
             Seq& coll_seq = *iterator;
 
@@ -65,7 +54,7 @@ public:
 
             found = true;
             for (typename Seq::size_type pos = 0; found && pos < seq.size();
-                 ++pos)
+                ++pos)
             {
                 found &= coll_seq[pos] == seq[pos];
             }
@@ -78,28 +67,17 @@ public:
 void two_graphs_common_spanning_trees_test()
 {
     Graph iG, vG;
-    std::vector< edge_descriptor > iG_o;
-    std::vector< edge_descriptor > vG_o;
+    std::vector< edge_descriptor > iG_o { boost::add_edge(0, 1, iG).first,
+        boost::add_edge(1, 3, iG).first, boost::add_edge(3, 2, iG).first,
+        boost::add_edge(1, 5, iG).first, boost::add_edge(5, 4, iG).first,
+        boost::add_edge(5, 6, iG).first, boost::add_edge(5, 3, iG).first,
+        boost::add_edge(3, 1, iG).first, boost::add_edge(1, 3, iG).first };
 
-    iG_o.push_back(boost::add_edge(0, 1, iG).first);
-    iG_o.push_back(boost::add_edge(1, 3, iG).first);
-    iG_o.push_back(boost::add_edge(3, 2, iG).first);
-    iG_o.push_back(boost::add_edge(1, 5, iG).first);
-    iG_o.push_back(boost::add_edge(5, 4, iG).first);
-    iG_o.push_back(boost::add_edge(5, 6, iG).first);
-    iG_o.push_back(boost::add_edge(5, 3, iG).first);
-    iG_o.push_back(boost::add_edge(3, 1, iG).first);
-    iG_o.push_back(boost::add_edge(1, 3, iG).first);
-
-    vG_o.push_back(boost::add_edge(0, 2, vG).first);
-    vG_o.push_back(boost::add_edge(0, 4, vG).first);
-    vG_o.push_back(boost::add_edge(0, 5, vG).first);
-    vG_o.push_back(boost::add_edge(5, 1, vG).first);
-    vG_o.push_back(boost::add_edge(5, 3, vG).first);
-    vG_o.push_back(boost::add_edge(5, 6, vG).first);
-    vG_o.push_back(boost::add_edge(5, 4, vG).first);
-    vG_o.push_back(boost::add_edge(5, 2, vG).first);
-    vG_o.push_back(boost::add_edge(2, 6, vG).first);
+    std::vector< edge_descriptor > vG_o { boost::add_edge(0, 2, vG).first,
+        boost::add_edge(0, 4, vG).first, boost::add_edge(0, 5, vG).first,
+        boost::add_edge(5, 1, vG).first, boost::add_edge(5, 3, vG).first,
+        boost::add_edge(5, 6, vG).first, boost::add_edge(5, 4, vG).first,
+        boost::add_edge(5, 2, vG).first, boost::add_edge(2, 6, vG).first };
 
     std::vector< std::vector< bool > > coll;
     boost::tree_collector< std::vector< std::vector< bool > >,
@@ -113,12 +91,10 @@ void two_graphs_common_spanning_trees_test()
         checker;
     std::vector< bool > check;
 
-    check.clear();
-    check += true, true, true, true, true, true, false, false, false;
+    check.assign({ true, true, true, true, true, true, false, false, false });
     checker(coll, check);
 
-    check.clear();
-    check += true, true, true, true, true, true, false, false, false;
+    check.assign({ true, true, true, true, true, true, false, false, false });
     checker(coll, check);
 }
 


### PR DESCRIPTION
Boost.Assign is not needed C++14 code. This PR removes this library usages. It is also suggested to use `std::vector` `std::initializer_list` constructor instead of series of `push_back` calls in test/two_graphs_common_spanning_trees_test.cpp.