### PR TITLE
Remove Boost.Bind usages.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,6 @@ target_link_libraries(boost_graph
     Boost::array
     Boost::assert
     Boost::bimap
-    Boost::bind
     Boost::concept_check
     Boost::config
     Boost::container_hash

--- a/include/boost/graph/howard_cycle_ratio.hpp
+++ b/include/boost/graph/howard_cycle_ratio.hpp
@@ -13,7 +13,6 @@
 #include <functional>
 #include <limits>
 
-#include <boost/bind/bind.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/type_traits/remove_const.hpp>
@@ -241,14 +240,10 @@ namespace detail
             typename graph_traits< Graph >::out_edge_iterator oei, oeie;
             for (boost::tie(vi, vie) = vertices(m_g); vi != vie; ++vi)
             {
-                using namespace boost::placeholders;
-
                 boost::tie(oei, oeie) = out_edges(*vi, m_g);
-                typename graph_traits< Graph >::out_edge_iterator mei
-                    = boost::first_max_element(oei, oeie,
-                        boost::bind(m_cmp,
-                            boost::bind(&EdgeWeight1::operator[], m_ew1m, _1),
-                            boost::bind(&EdgeWeight1::operator[], m_ew1m, _2)));
+                auto mei = boost::first_max_element(oei, oeie,
+                    [this](const auto& first, const auto& second)
+                    { return m_cmp(m_ew1m[first], m_ew1m[second]); });
                 if (mei == oeie)
                 {
                     if (m_sink == graph_traits< Graph >().null_vertex())
@@ -356,7 +351,7 @@ namespace detail
          */
         float_t policy_mcr()
         {
-            using namespace boost::placeholders;
+            using std::placeholders::_1;
 
             std::fill(m_col_bfs.begin(), m_col_bfs.end(), my_white);
             color_map_t vcm_ = color_map_t(m_col_bfs.begin(), m_vim);
@@ -364,8 +359,8 @@ namespace detail
             boost::tie(uv_itr, vie) = vertices(m_g);
             float_t mcr = m_bound;
             while ((uv_itr = std::find_if(uv_itr, vie,
-                        boost::bind(std::equal_to< my_color_type >(), my_white,
-                            boost::bind(&color_map_t::operator[], vcm_, _1))))
+                        std::bind(std::equal_to< my_color_type >(), my_white,
+                            std::bind(&color_map_t::operator[], vcm_, _1))))
                 != vie)
             /// While there are undiscovered vertices
             {

--- a/include/boost/graph/howard_cycle_ratio.hpp
+++ b/include/boost/graph/howard_cycle_ratio.hpp
@@ -351,16 +351,17 @@ namespace detail
          */
         float_t policy_mcr()
         {
-            using std::placeholders::_1;
-
             std::fill(m_col_bfs.begin(), m_col_bfs.end(), my_white);
             color_map_t vcm_ = color_map_t(m_col_bfs.begin(), m_vim);
             typename graph_traits< Graph >::vertex_iterator uv_itr, vie;
             boost::tie(uv_itr, vie) = vertices(m_g);
             float_t mcr = m_bound;
             while ((uv_itr = std::find_if(uv_itr, vie,
-                        std::bind(std::equal_to< my_color_type >(), my_white,
-                            std::bind(&color_map_t::operator[], vcm_, _1))))
+                        [this, &vcm_](const auto& uv)
+                        {
+                            return std::equal_to< my_color_type >()(
+                                my_white, vcm_[uv]);
+                        }))
                 != vie)
             /// While there are undiscovered vertices
             {

--- a/include/boost/graph/king_ordering.hpp
+++ b/include/boost/graph/king_ordering.hpp
@@ -48,9 +48,6 @@ namespace detail
         template < typename Vertex, typename Graph >
         void finish_vertex(Vertex, Graph& g)
         {
-            using std::placeholders::_1;
-            using std::placeholders::_2;
-
             typename graph_traits< Graph >::out_edge_iterator ei, ei_end;
             Vertex v, w;
 
@@ -61,7 +58,7 @@ namespace detail
             reverse_iterator rbegin = Qptr->rbegin();
 
             // heap the vertices already there
-            std::make_heap(rbegin, rend, std::bind(comp, _2, _1));
+            std::make_heap(rbegin, rend, [this](const auto& first, const auto& second) { return comp(second, first); });
 
             unsigned i = 0;
 

--- a/include/boost/graph/king_ordering.hpp
+++ b/include/boost/graph/king_ordering.hpp
@@ -15,7 +15,6 @@
 #include <vector>
 #include <algorithm>
 #include <boost/config.hpp>
-#include <boost/bind/bind.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/graph/detail/sparse_ordering.hpp>
 #include <boost/graph/graph_utility.hpp>
@@ -49,7 +48,8 @@ namespace detail
         template < typename Vertex, typename Graph >
         void finish_vertex(Vertex, Graph& g)
         {
-            using namespace boost::placeholders;
+            using std::placeholders::_1;
+            using std::placeholders::_2;
 
             typename graph_traits< Graph >::out_edge_iterator ei, ei_end;
             Vertex v, w;
@@ -61,7 +61,7 @@ namespace detail
             reverse_iterator rbegin = Qptr->rbegin();
 
             // heap the vertices already there
-            std::make_heap(rbegin, rend, boost::bind< bool >(comp, _2, _1));
+            std::make_heap(rbegin, rend, std::bind(comp, _2, _1));
 
             unsigned i = 0;
 

--- a/include/boost/graph/transitive_closure.hpp
+++ b/include/boost/graph/transitive_closure.hpp
@@ -13,7 +13,6 @@
 #include <algorithm> // for std::min and std::max
 #include <functional>
 #include <boost/config.hpp>
-#include <boost/bind/bind.hpp>
 #include <boost/graph/strong_components.hpp>
 #include <boost/graph/topological_sort.hpp>
 #include <boost/graph/graph_concepts.hpp>
@@ -130,16 +129,16 @@ void transitive_closure(const Graph& g, GraphTC& tc,
     std::vector< std::vector< cg_vertex > > CG_vec(num_vertices(CG));
     for (size_type i = 0; i < num_vertices(CG); ++i)
     {
-        using namespace boost::placeholders;
+        using namespace std::placeholders;
 
         typedef typename boost::graph_traits< CG_t >::adjacency_iterator
             cg_adj_iter;
         std::pair< cg_adj_iter, cg_adj_iter > pr = adjacent_vertices(i, CG);
         CG_vec[i].assign(pr.first, pr.second);
         std::sort(CG_vec[i].begin(), CG_vec[i].end(),
-            boost::bind(std::less< cg_vertex >(),
-                boost::bind(detail::subscript(topo_number), _1),
-                boost::bind(detail::subscript(topo_number), _2)));
+            std::bind(std::less< cg_vertex >(),
+                std::bind(detail::subscript(topo_number), _1),
+                std::bind(detail::subscript(topo_number), _2)));
     }
 
     std::vector< std::vector< cg_vertex > > chains;

--- a/include/boost/graph/transitive_closure.hpp
+++ b/include/boost/graph/transitive_closure.hpp
@@ -11,7 +11,7 @@
 
 #include <vector>
 #include <algorithm> // for std::min and std::max
-#include <functional>
+#include <functional> //for std::less
 #include <boost/config.hpp>
 #include <boost/graph/strong_components.hpp>
 #include <boost/graph/topological_sort.hpp>
@@ -129,16 +129,16 @@ void transitive_closure(const Graph& g, GraphTC& tc,
     std::vector< std::vector< cg_vertex > > CG_vec(num_vertices(CG));
     for (size_type i = 0; i < num_vertices(CG); ++i)
     {
-        using namespace std::placeholders;
-
         typedef typename boost::graph_traits< CG_t >::adjacency_iterator
             cg_adj_iter;
         std::pair< cg_adj_iter, cg_adj_iter > pr = adjacent_vertices(i, CG);
         CG_vec[i].assign(pr.first, pr.second);
         std::sort(CG_vec[i].begin(), CG_vec[i].end(),
-            std::bind(std::less< cg_vertex >(),
-                std::bind(detail::subscript(topo_number), _1),
-                std::bind(detail::subscript(topo_number), _2)));
+            [&topo_number](const auto& cg_0, const auto& cg_1)
+            {
+                return std::less< cg_vertex >()(
+                    topo_number[cg_0], topo_number[cg_1]);
+            });
     }
 
     std::vector< std::vector< cg_vertex > > chains;

--- a/test/graph.cpp
+++ b/test/graph.cpp
@@ -70,11 +70,8 @@ bool check_vertex_cleared(Graph& g, Vertex v, ID id)
                 found = ai;
                 break;
             }
-#elif defined(BOOST_NO_CXX98_BINDERS)
-        found
-            = std::find_if(ai, aiend, std::bind(cmp, v, std::placeholders::_1));
 #else
-        found = std::find_if(ai, aiend, std::bind1st(cmp, v));
+        found = std::find_if(ai, aiend, [&v, &cmp](const auto& el) { return cmp(v, el); });
 #endif
 
         if (found != aiend)


### PR DESCRIPTION
This PR replaces `boost::bind` usages with lambdas, so **Boost.Bind** can be removed from dependances.