### PR TITLE
examples: C++11: Use std::begin() and std::end()

### DIFF
--- a/example/bellman-ford-internet.cpp
+++ b/example/bellman-ford-internet.cpp
@@ -25,19 +25,18 @@ int main()
         H,
         n_vertices
     };
-    const int n_edges = 11;
     typedef std::pair< int, int > Edge;
 
     // The list of connections between routers stored in an array.
-    Edge edges[] = { Edge(A, B), Edge(A, C), Edge(B, D), Edge(B, E), Edge(C, E),
-        Edge(C, F), Edge(D, H), Edge(D, E), Edge(E, H), Edge(F, G),
+    Edge edges[] = { Edge(A, B), Edge(A, C), Edge(B, D), Edge(B, E),
+        Edge(C, E), Edge(C, F), Edge(D, H), Edge(D, E), Edge(E, H), Edge(F, G),
         Edge(G, H) };
 
     // Specify the graph type and declare a graph object
     typedef edge_list< Edge*, Edge, std::ptrdiff_t,
         std::random_access_iterator_tag >
         Graph;
-    Graph g(edges, edges + n_edges);
+    Graph g(std::begin(edges), std::end(edges));
 
     // The transmission delay values for each edge.
     float delay[] = { 5.0, 1.0, 1.3, 3.0, 10.0, 2.0, 6.3, 0.4, 1.3, 1.2, 0.5 };

--- a/example/min_max_paths.cpp
+++ b/example/min_max_paths.cpp
@@ -52,8 +52,8 @@ int main(int, char*[])
     const char name[] = "abcdef";
 
     const int num_nodes = 6;
-    E edges[] = { E(0, 2), E(1, 1), E(1, 3), E(1, 4), E(2, 1), E(2, 3), E(3, 4),
-        E(4, 0), E(4, 1) };
+    const auto edges = { E(0, 2), E(1, 1), E(1, 3), E(1, 4), E(2, 1), E(2, 3),
+        E(3, 4), E(4, 0), E(4, 1) };
     int weights[] = { 1, 2, 1, 2, 7, 3, 1, 1, 1 };
     const int n_edges = sizeof(edges) / sizeof(E);
 #if defined(BOOST_MSVC) && BOOST_MSVC <= 1300
@@ -68,8 +68,8 @@ int main(int, char*[])
         weightmap[e] = weights[j];
     }
 #else
-    Graph G(edges, edges + n_edges, weights, num_nodes);
-    auto weightmap = get(edge_weight, G);
+    Graph G(std::begin(edges), std::end(edges), weights, num_nodes);
+    auto = get(edge_weight, G);
 #endif
 
     std::vector< Vertex > p(num_vertices(G));

--- a/example/prim-example.cpp
+++ b/example/prim-example.cpp
@@ -18,7 +18,7 @@ int main()
         Graph;
     typedef std::pair< int, int > E;
     const int num_nodes = 5;
-    E edges[]
+    const auto edges
         = { E(0, 2), E(1, 3), E(1, 4), E(2, 1), E(2, 3), E(3, 4), E(4, 0) };
     int weights[] = { 1, 1, 2, 7, 3, 1, 1 };
 #if defined(BOOST_MSVC) && BOOST_MSVC <= 1300
@@ -32,7 +32,7 @@ int main()
         weightmap[e] = weights[j];
     }
 #else
-    Graph g(edges, edges + sizeof(edges) / sizeof(E), weights, num_nodes);
+    Graph g(std::begin(edges), std::end(edges), weights, num_nodes);
 #endif
     std::vector< graph_traits< Graph >::vertex_descriptor > p(num_vertices(g));
 

--- a/example/remove_edge_if_dir.cpp
+++ b/example/remove_edge_if_dir.cpp
@@ -41,17 +41,10 @@ typedef adjacency_list< vecS, vecS, directedS > Graph;
 int main()
 {
     typedef std::pair< std::size_t, std::size_t > Edge;
-    Edge edges[6] = { Edge(0, 3), Edge(0, 2), Edge(0, 3), Edge(1, 3),
+    const auto edges = { Edge(0, 3), Edge(0, 2), Edge(0, 3), Edge(1, 3),
         Edge(2, 0), Edge(3, 2) };
 
-#if defined(BOOST_MSVC) && BOOST_MSVC <= 1300
-    // VC++ can't handle iterator constructor
-    Graph g(4);
-    for (std::size_t j = 0; j < 6; ++j)
-        add_edge(edges[j].first, edges[j].second, g);
-#else
-    Graph g(edges, edges + 6, 4);
-#endif
+    Graph g(std::begin(edges), std::end(edges), 4);
 
     std::cout << "original graph:" << std::endl;
     print_graph(g, get(vertex_index, g));

--- a/example/stoer_wagner.cpp
+++ b/example/stoer_wagner.cpp
@@ -45,7 +45,7 @@ int main()
 
     // construct the graph object. 8 is the number of vertices, which are
     // numbered from 0 through 7, and 16 is the number of edges.
-    undirected_graph g(edges, edges + 16, ws, 8, 16);
+    undirected_graph g(std::begin(edges), std::end(edges), ws, 8, 16);
 
     // define a property map, `parities`, that will store a boolean value for
     // each vertex. Vertices that have the same parity after

--- a/example/topo_sort.cpp
+++ b/example/topo_sort.cpp
@@ -43,16 +43,10 @@ int main(int, char*[])
         Graph;
 
     typedef boost::graph_traits< Graph >::vertex_descriptor Vertex;
-    Pair edges[6] = { Pair(0, 1), Pair(2, 4), Pair(2, 5), Pair(0, 3),
+    const auto edges = { Pair(0, 1), Pair(2, 4), Pair(2, 5), Pair(0, 3),
         Pair(1, 4), Pair(4, 3) };
-#if defined(BOOST_MSVC) && BOOST_MSVC <= 1300
-    // VC++ can't handle the iterator constructor
-    Graph G(6);
-    for (std::size_t j = 0; j < 6; ++j)
-        add_edge(edges[j].first, edges[j].second, G);
-#else
-    Graph G(edges, edges + 6, 6);
-#endif
+
+    Graph G(std::begin(edges), std::end(edges), 6 /* vertices count */);
 
     auto id = get(vertex_index, G);
 

--- a/example/visitor.cpp
+++ b/example/visitor.cpp
@@ -71,15 +71,9 @@ int main(int, char*[])
 
     typedef adjacency_list<> Graph;
     typedef std::pair< int, int > E;
-    E edges[] = { E(0, 2), E(1, 1), E(1, 3), E(2, 1), E(2, 3), E(3, 1), E(3, 4),
-        E(4, 0), E(4, 1) };
-#if defined(BOOST_MSVC) && BOOST_MSVC <= 1300
-    Graph G(5);
-    for (std::size_t j = 0; j < sizeof(edges) / sizeof(E); ++j)
-        add_edge(edges[j].first, edges[j].second, G);
-#else
-    Graph G(edges, edges + sizeof(edges) / sizeof(E), 5);
-#endif
+    const auto edges = { E(0, 2), E(1, 1), E(1, 3), E(2, 1), E(2, 3), E(3, 1),
+        E(3, 4), E(4, 0), E(4, 1) };
+    Graph G(std::begin(edges), std::end(edges), 5);
 
     typedef boost::graph_traits< Graph >::vertices_size_type size_type;
 


### PR DESCRIPTION
Instead of array + length.
And use initializer lists.