### PR TITLE
Specify path of weighted_matching.dat via Jamfile

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -19,6 +19,8 @@ path-constant CYCLE_RATIO_INPUT_FILE : ./cycle_ratio_s382.90.dot ;
 
 path-constant METIS_INPUT_FILE : ./weighted_graph.gr ;
 
+path-constant WEIGHTED_MATCHING_INPUT_FILE : ./weighted_matching.dat ;
+
 alias graph_test_regular :
     # test_graphs will eventually defined a framework for testing the structure
     # and implementation of graph data structures and adaptors.
@@ -113,7 +115,7 @@ alias graph_test_regular :
     [ run cuthill_mckee_ordering.cpp ]
     [ run king_ordering.cpp ]
     [ run matching_test.cpp ]
-    [ run weighted_matching_test.cpp ]
+    [ run weighted_matching_test.cpp : $(WEIGHTED_MATCHING_INPUT_FILE) ]
     [ run weighted_matching_test2.cpp ]
     [ run max_flow_test.cpp ]
     [ run boykov_kolmogorov_max_flow_test.cpp ]

--- a/test/weighted_matching_test.cpp
+++ b/test/weighted_matching_test.cpp
@@ -136,9 +136,12 @@ Graph make_graph(typename graph_traits< Graph >::vertices_size_type num_v,
     return g;
 }
 
-int main(int, char*[])
+int main(int argc, char* argv[])
 {
-    std::ifstream in_file("weighted_matching.dat");
+    const char* filename = "weighted_matching.dat";
+    if (argc > 1)
+        filename = argv[1];
+    std::ifstream in_file(filename);
     BOOST_TEST(in_file.good());
     std::string line;
     while (std::getline(in_file, line))


### PR DESCRIPTION
Test `weighted_matching_test.cpp` currently expects its input file `weighted_matching.dat` in the current working directory. As a result, testing fails when invoked via `b2` from another working directory.

In previous releases, `weighted_matching_test.cpp` would silently skip all tests when it failed to open its input file. I "fixed" this in commit f98edae416607751b907f58ef47d6c2117c23b76 , thus causing the issue.

This commit fixes the issue by specifying the path of `weighted_matching.dat` via the Jamfile.

Fixes: #426
