### PR TITLE
Fix adjacency list serialise types

### DIFF
--- a/include/boost/graph/adj_list_serialize.hpp
+++ b/include/boost/graph/adj_list_serialize.hpp
@@ -45,8 +45,7 @@ namespace serialization
     {
         typedef adjacency_list< OEL, VL, D, VP, EP, GP, EL > Graph;
         typedef typename graph_traits< Graph >::vertex_descriptor Vertex;
-
-        typedef typename boost::graph_traits<Graph>::vertices_size_type VerticesSize;
+        typedef typename graph_traits< Graph >::vertices_size_type VerticesSize;
 
         VerticesSize V = num_vertices(graph);
         VerticesSize E = num_edges(graph);
@@ -86,10 +85,11 @@ namespace serialization
         typedef adjacency_list< OEL, VL, D, VP, EP, GP, EL > Graph;
         typedef typename graph_traits< Graph >::vertex_descriptor Vertex;
         typedef typename graph_traits< Graph >::edge_descriptor Edge;
+        typedef typename graph_traits< Graph >::vertices_size_type VerticesSize;
 
-        unsigned int V;
+        VerticesSize V;
         ar >> BOOST_SERIALIZATION_NVP(V);
-        unsigned int E;
+        VerticesSize E;
         ar >> BOOST_SERIALIZATION_NVP(E);
 
         std::vector< Vertex > verts(V);

--- a/include/boost/graph/adj_list_serialize.hpp
+++ b/include/boost/graph/adj_list_serialize.hpp
@@ -46,8 +46,8 @@ namespace serialization
         using Graph = adjacency_list< OEL, VL, D, VP, EP, GP, EL >;
         using Vertex = typename graph_traits< Graph >::vertex_descriptor;
 
-        unsigned int V = num_vertices(graph);
-        unsigned int E = num_edges(graph);
+        const auto V = num_vertices(graph);
+        const auto E = num_edges(graph);
         ar << BOOST_SERIALIZATION_NVP(V);
         ar << BOOST_SERIALIZATION_NVP(E);
 
@@ -84,7 +84,7 @@ namespace serialization
         using Graph = adjacency_list< OEL, VL, D, VP, EP, GP, EL >;
         using Vertex = typename graph_traits< Graph >::vertex_descriptor;
         using Edge = typename graph_traits< Graph >::edge_descriptor;
-        
+
         unsigned int V;
         ar >> BOOST_SERIALIZATION_NVP(V);
         unsigned int E;

--- a/include/boost/graph/adj_list_serialize.hpp
+++ b/include/boost/graph/adj_list_serialize.hpp
@@ -46,14 +46,16 @@ namespace serialization
         typedef adjacency_list< OEL, VL, D, VP, EP, GP, EL > Graph;
         typedef typename graph_traits< Graph >::vertex_descriptor Vertex;
 
-        int V = num_vertices(graph);
-        int E = num_edges(graph);
+        typedef typename boost::graph_traits<Graph>::vertices_size_type VerticesSize;
+
+        VerticesSize V = num_vertices(graph);
+        VerticesSize E = num_edges(graph);
         ar << BOOST_SERIALIZATION_NVP(V);
         ar << BOOST_SERIALIZATION_NVP(E);
 
         // assign indices to vertices
-        std::map< Vertex, int > indices;
-        int num = 0;
+        std::map< Vertex, size_t > indices;
+        size_t num = 0;
         BGL_FORALL_VERTICES_T(v, graph, Graph)
         {
             indices[v] = num++;
@@ -91,7 +93,7 @@ namespace serialization
         ar >> BOOST_SERIALIZATION_NVP(E);
 
         std::vector< Vertex > verts(V);
-        int i = 0;
+        size_t i = 0;
         while (V-- > 0)
         {
             Vertex v = add_vertex(graph);
@@ -101,8 +103,8 @@ namespace serialization
         }
         while (E-- > 0)
         {
-            int u;
-            int v;
+            Vertex u;
+            Vertex v;
             ar >> BOOST_SERIALIZATION_NVP(u);
             ar >> BOOST_SERIALIZATION_NVP(v);
             Edge e;

--- a/include/boost/graph/adj_list_serialize.hpp
+++ b/include/boost/graph/adj_list_serialize.hpp
@@ -45,15 +45,16 @@ namespace serialization
     {
         using Graph = adjacency_list< OEL, VL, D, VP, EP, GP, EL >;
         using Vertex = typename graph_traits< Graph >::vertex_descriptor;
+        using SerializedInteger = unsigned int;
 
-        const auto V = num_vertices(graph);
-        const auto E = num_edges(graph);
+        const SerializedInteger V = num_vertices(graph);
+        const SerializedInteger E = num_edges(graph);
         ar << BOOST_SERIALIZATION_NVP(V);
         ar << BOOST_SERIALIZATION_NVP(E);
 
         // assign indices to vertices
-        std::map< Vertex, size_t > indices;
-        size_t num = 0;
+        std::map< Vertex, SerializedInteger > indices;
+        SerializedInteger num = 0;
         BGL_FORALL_VERTICES_T(v, graph, Graph)
         {
             indices[v] = num++;
@@ -84,31 +85,35 @@ namespace serialization
         using Graph = adjacency_list< OEL, VL, D, VP, EP, GP, EL >;
         using Vertex = typename graph_traits< Graph >::vertex_descriptor;
         using Edge = typename graph_traits< Graph >::edge_descriptor;
+        using SerializedInteger = unsigned int;
 
-        unsigned int V;
+        SerializedInteger V;
         ar >> BOOST_SERIALIZATION_NVP(V);
-        unsigned int E;
+        
+        SerializedInteger E;
         ar >> BOOST_SERIALIZATION_NVP(E);
 
         std::vector< Vertex > verts(V);
         size_t i = 0;
         while (V-- > 0)
         {
-            Vertex v = add_vertex(graph);
+            const auto v = add_vertex(graph);
             verts[i++] = v;
             ar >> serialization::make_nvp(
                 "vertex_property", get(vertex_all_t(), graph, v));
         }
         while (E-- > 0)
         {
-            Vertex u;
-            Vertex v;
+            SerializedInteger u;
+            SerializedInteger v;
             ar >> BOOST_SERIALIZATION_NVP(u);
             ar >> BOOST_SERIALIZATION_NVP(v);
-            
+            const auto uu = static_cast<Vertex>(u);
+            const auto vv = static_cast<Vertex>(v);
+
             Edge e;
             bool inserted;
-            boost::tie(e, inserted)= add_edge(verts[u], verts[v], graph);
+            boost::tie(e, inserted)= add_edge(verts[uu], verts[vv], graph);
             ar >> serialization::make_nvp(
                 "edge_property", get(edge_all_t(), graph, e));
         }

--- a/include/boost/graph/adj_list_serialize.hpp
+++ b/include/boost/graph/adj_list_serialize.hpp
@@ -83,7 +83,8 @@ namespace serialization
     {
         using Graph = adjacency_list< OEL, VL, D, VP, EP, GP, EL >;
         using Vertex = typename graph_traits< Graph >::vertex_descriptor;
-
+        using Edge = typename graph_traits< Graph >::edge_descriptor;
+        
         unsigned int V;
         ar >> BOOST_SERIALIZATION_NVP(V);
         unsigned int E;

--- a/include/boost/graph/adj_list_serialize.hpp
+++ b/include/boost/graph/adj_list_serialize.hpp
@@ -46,9 +46,10 @@ namespace serialization
         typedef adjacency_list< OEL, VL, D, VP, EP, GP, EL > Graph;
         typedef typename graph_traits< Graph >::vertex_descriptor Vertex;
         typedef typename graph_traits< Graph >::vertices_size_type VerticesSize;
+        typedef typename graph_traits< Graph >::edges_size_type EdgesSize;
 
         VerticesSize V = num_vertices(graph);
-        VerticesSize E = num_edges(graph);
+        EdgesSize E = num_edges(graph);
         ar << BOOST_SERIALIZATION_NVP(V);
         ar << BOOST_SERIALIZATION_NVP(E);
 
@@ -86,10 +87,11 @@ namespace serialization
         typedef typename graph_traits< Graph >::vertex_descriptor Vertex;
         typedef typename graph_traits< Graph >::edge_descriptor Edge;
         typedef typename graph_traits< Graph >::vertices_size_type VerticesSize;
+        typedef typename graph_traits< Graph >::edges_size_type EdgesSize;
 
         VerticesSize V;
         ar >> BOOST_SERIALIZATION_NVP(V);
-        VerticesSize E;
+        EdgesSize E;
         ar >> BOOST_SERIALIZATION_NVP(E);
 
         std::vector< Vertex > verts(V);

--- a/include/boost/graph/adj_list_serialize.hpp
+++ b/include/boost/graph/adj_list_serialize.hpp
@@ -105,7 +105,9 @@ namespace serialization
             ar >> BOOST_SERIALIZATION_NVP(u);
             ar >> BOOST_SERIALIZATION_NVP(v);
             
-            auto [e, inserted] = add_edge(verts[u], verts[v], graph);
+            Edge e;
+            bool inserted;
+            boost::tie(e, inserted)= add_edge(verts[u], verts[v], graph);
             ar >> serialization::make_nvp(
                 "edge_property", get(edge_all_t(), graph, e));
         }

--- a/include/boost/graph/adj_list_serialize.hpp
+++ b/include/boost/graph/adj_list_serialize.hpp
@@ -113,7 +113,7 @@ namespace serialization
 
             Edge e;
             bool inserted;
-            boost::tie(e, inserted)= add_edge(verts[u], verts[v], graph);
+            boost::tie(e, inserted) = add_edge(verts[u], verts[v], graph);
             ar >> serialization::make_nvp(
                 "edge_property", get(edge_all_t(), graph, e));
         }

--- a/include/boost/graph/adj_list_serialize.hpp
+++ b/include/boost/graph/adj_list_serialize.hpp
@@ -9,6 +9,8 @@
 #ifndef BOOST_GRAPH_ADJ_LIST_SERIALIZE_HPP
 #define BOOST_GRAPH_ADJ_LIST_SERIALIZE_HPP
 
+#include <unordered_map>
+
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/iteration_macros.hpp>
 #include <boost/pending/property_serialize.hpp>
@@ -45,16 +47,15 @@ namespace serialization
     {
         using Graph = adjacency_list< OEL, VL, D, VP, EP, GP, EL >;
         using Vertex = typename graph_traits< Graph >::vertex_descriptor;
-        using SerializedInteger = unsigned int;
 
-        const SerializedInteger V = num_vertices(graph);
-        const SerializedInteger E = num_edges(graph);
+        const auto V = num_vertices(graph);
+        const auto E = num_edges(graph);
         ar << BOOST_SERIALIZATION_NVP(V);
         ar << BOOST_SERIALIZATION_NVP(E);
 
         // assign indices to vertices
-        std::map< Vertex, SerializedInteger > indices;
-        SerializedInteger num = 0;
+        std::unordered_map< Vertex, Vertex > indices(V);
+        Vertex num = 0;
         BGL_FORALL_VERTICES_T(v, graph, Graph)
         {
             indices[v] = num++;
@@ -85,12 +86,12 @@ namespace serialization
         using Graph = adjacency_list< OEL, VL, D, VP, EP, GP, EL >;
         using Vertex = typename graph_traits< Graph >::vertex_descriptor;
         using Edge = typename graph_traits< Graph >::edge_descriptor;
-        using SerializedInteger = unsigned int;
+        using VertexSizeType = typename graph_traits< Graph >::vertices_size_type;
 
-        SerializedInteger V;
+        VertexSizeType V;
         ar >> BOOST_SERIALIZATION_NVP(V);
         
-        SerializedInteger E;
+        VertexSizeType E;
         ar >> BOOST_SERIALIZATION_NVP(E);
 
         std::vector< Vertex > verts(V);
@@ -102,18 +103,17 @@ namespace serialization
             ar >> serialization::make_nvp(
                 "vertex_property", get(vertex_all_t(), graph, v));
         }
+        
         while (E-- > 0)
         {
-            SerializedInteger u;
-            SerializedInteger v;
+            Vertex u;
+            Vertex v;
             ar >> BOOST_SERIALIZATION_NVP(u);
             ar >> BOOST_SERIALIZATION_NVP(v);
-            const auto uu = static_cast<Vertex>(u);
-            const auto vv = static_cast<Vertex>(v);
 
             Edge e;
             bool inserted;
-            boost::tie(e, inserted)= add_edge(verts[uu], verts[vv], graph);
+            boost::tie(e, inserted)= add_edge(verts[u], verts[v], graph);
             ar >> serialization::make_nvp(
                 "edge_property", get(edge_all_t(), graph, e));
         }

--- a/include/boost/graph/adj_list_serialize.hpp
+++ b/include/boost/graph/adj_list_serialize.hpp
@@ -43,13 +43,11 @@ namespace serialization
         const unsigned int /* file_version */
     )
     {
-        typedef adjacency_list< OEL, VL, D, VP, EP, GP, EL > Graph;
-        typedef typename graph_traits< Graph >::vertex_descriptor Vertex;
-        typedef typename graph_traits< Graph >::vertices_size_type VerticesSize;
-        typedef typename graph_traits< Graph >::edges_size_type EdgesSize;
+        using Graph = adjacency_list< OEL, VL, D, VP, EP, GP, EL >;
+        using Vertex = typename graph_traits< Graph >::vertex_descriptor;
 
-        VerticesSize V = num_vertices(graph);
-        EdgesSize E = num_edges(graph);
+        unsigned int V = num_vertices(graph);
+        unsigned int E = num_edges(graph);
         ar << BOOST_SERIALIZATION_NVP(V);
         ar << BOOST_SERIALIZATION_NVP(E);
 
@@ -83,15 +81,12 @@ namespace serialization
         const unsigned int /* file_version */
     )
     {
-        typedef adjacency_list< OEL, VL, D, VP, EP, GP, EL > Graph;
-        typedef typename graph_traits< Graph >::vertex_descriptor Vertex;
-        typedef typename graph_traits< Graph >::edge_descriptor Edge;
-        typedef typename graph_traits< Graph >::vertices_size_type VerticesSize;
-        typedef typename graph_traits< Graph >::edges_size_type EdgesSize;
+        using Graph = adjacency_list< OEL, VL, D, VP, EP, GP, EL >;
+        using Vertex = typename graph_traits< Graph >::vertex_descriptor;
 
-        VerticesSize V;
+        unsigned int V;
         ar >> BOOST_SERIALIZATION_NVP(V);
-        EdgesSize E;
+        unsigned int E;
         ar >> BOOST_SERIALIZATION_NVP(E);
 
         std::vector< Vertex > verts(V);
@@ -109,9 +104,8 @@ namespace serialization
             Vertex v;
             ar >> BOOST_SERIALIZATION_NVP(u);
             ar >> BOOST_SERIALIZATION_NVP(v);
-            Edge e;
-            bool inserted;
-            boost::tie(e, inserted) = add_edge(verts[u], verts[v], graph);
+            
+            auto [e, inserted] = add_edge(verts[u], verts[v], graph);
             ar >> serialization::make_nvp(
                 "edge_property", get(edge_all_t(), graph, e));
         }


### PR DESCRIPTION
This fixes #291.

According to [the offical docs](https://www.boost.org/doc/libs/latest/libs/graph/doc/graph_concepts.html) the type representing the number of vertices and edges in a graph can be deduced by the graph traits.

In this PR 

* read/write data types deduced from the graph traits
* small cleanup modernizing a bit the code
