### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,6 @@ target_link_libraries(boost_graph
     Boost::serialization
     Boost::smart_ptr
     Boost::spirit
-    Boost::static_assert
     Boost::throw_exception
     Boost::tti
     Boost::tuple

--- a/build.jam
+++ b/build.jam
@@ -38,7 +38,6 @@ constant boost_dependencies :
     /boost/serialization//boost_serialization
     /boost/smart_ptr//boost_smart_ptr
     /boost/spirit//boost_spirit
-    /boost/static_assert//boost_static_assert
     /boost/throw_exception//boost_throw_exception
     /boost/tti//boost_tti
     /boost/tuple//boost_tuple


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.