### PR TITLE
Fix: labeled_graph pointer specialization remove_vertex not removing label

### DIFF
--- a/include/boost/graph/labeled_graph.hpp
+++ b/include/boost/graph/labeled_graph.hpp
@@ -501,6 +501,13 @@ public:
     /** Remove the vertex with the given label. */
     void remove_vertex(Label const& l)
     {
+        static_assert(
+            !is_same<
+                typename graph_detail::container_traits<map_type>::category,
+                graph_detail::vector_tag
+            >::value,
+            "remove_vertex is not supported with vecS label storage: erasing from the underlying vector invalidates all label-to-vertex mappings after the erased position"
+        );
         return graph_detail::remove_labeled_vertex(_map, _graph, l);
     }
 
@@ -642,6 +649,13 @@ public:
     /** Remove the vertex with the given label. */
     void remove_vertex(Label const& l)
     {
+        static_assert(
+            !is_same<
+                typename graph_detail::container_traits<map_type>::category,
+                graph_detail::vector_tag
+            >::value,
+            "remove_vertex is not supported with vecS label storage: erasing from the underlying vector invalidates all label-to-vertex mappings after the erased position"
+        );
         return boost::remove_vertex(vertex(l), *_graph);
     }
 

--- a/include/boost/graph/labeled_graph.hpp
+++ b/include/boost/graph/labeled_graph.hpp
@@ -508,6 +508,7 @@ public:
             >::value,
             "remove_vertex is not supported with vecS label storage: erasing from the underlying vector invalidates all label-to-vertex mappings after the erased position"
         );
+        // use dispatcher: removes the vertex from the graph and its label from _map
         return graph_detail::remove_labeled_vertex(_map, _graph, l);
     }
 
@@ -656,7 +657,8 @@ public:
             >::value,
             "remove_vertex is not supported with vecS label storage: erasing from the underlying vector invalidates all label-to-vertex mappings after the erased position"
         );
-        return boost::remove_vertex(vertex(l), *_graph);
+        // use dispatcher: removes the vertex from the graph and its label from _map
+        return graph_detail::remove_labeled_vertex(_map, *_graph, l);
     }
 
     /** Return a descriptor for the given label. */

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -31,7 +31,10 @@ alias graph_test_regular :
     # and implementation of graph data structures and adaptors.
     [ run test_graphs.cpp ]
     [ run index_graph.cpp ]     # TODO: Make this part of the test_graphs framework
+
+    [ compile-fail concept_tests/labeled_graph/compile_fail_remove_vertex_vecS.cpp ]
     [ run labeled_graph.cpp ]
+
     [ run finish_edge_bug.cpp ]
 
     [ run transitive_closure_test.cpp /boost/timer//boost_timer ]

--- a/test/concept_tests/labeled_graph/compile_fail_remove_vertex_vecS.cpp
+++ b/test/concept_tests/labeled_graph/compile_fail_remove_vertex_vecS.cpp
@@ -1,0 +1,29 @@
+//=======================================================================
+// Copyright 2026
+// Author: Becheler Arnaud
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//=======================================================================
+
+// This file must FAIL to compile.
+// remove_vertex is not supported when the label map uses vecS storage because 
+// erasing from the underlying vector invalidates all label-to-vertex mappings 
+// after the erased position.
+
+#include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/labeled_graph.hpp>
+
+int main()
+{
+    typedef boost::labeled_graph<
+        boost::adjacency_list<boost::listS, boost::listS, boost::directedS>,
+        unsigned,
+        boost::vecS
+    > Graph;
+
+    Graph g;
+    g.add_vertex(0u);
+    g.remove_vertex(0u);  // should trigger static_assert
+}

--- a/test/labeled_graph.cpp
+++ b/test/labeled_graph.cpp
@@ -385,9 +385,6 @@ void test_remove_vertex_all_types()
         labeled_graph<undirected_graph<>, string, hash_mapS>
     >("a", "b", "c");
 
-    // adjacency_list + vecS not supported (unstable removal would require remapping the map)
-    // TODO: fix or not but document
-
     // adjacency_list + listS (stable removal)
     test_remove_vertex_suite<
         labeled_graph<adjacency_list<listS, listS, directedS>, string, mapS>
@@ -397,13 +394,16 @@ void test_remove_vertex_all_types()
         labeled_graph<adjacency_list<listS, listS, undirectedS>, string, mapS>
     >("a", "b", "c");
 
-    // unsigned labels (vecS) : should not compile because static assert prevents removing vertices now
-    // test_remove_vertex_suite<
-    //     labeled_graph<adjacency_list<listS, listS, directedS>, unsigned, vecS>
-    // >(0u, 1u, 2u);
+    // adjacency_list + hash_multimapS
+    test_remove_vertex_suite<
+        labeled_graph<adjacency_list<listS, listS, directedS>, string, hash_multimapS>
+    >("a", "b", "c");
 
-    // Pointer specialization: 
-    // temporarily attach labels to it without copying.
+    test_remove_vertex_suite<
+        labeled_graph<adjacency_list<listS, listS, directedS>, string, multimapS>
+    >("a", "b", "c");
+
+    // Pointer specialization
 
     test_remove_vertex_suite_ptr_variant<
         directed_graph<>,
@@ -419,6 +419,35 @@ void test_remove_vertex_all_types()
         directed_graph<>,
         labeled_graph<directed_graph<>*, string, hash_mapS>
     >("a", "b", "c");
+
+    test_remove_vertex_suite_ptr_variant<
+        directed_graph<>,
+        labeled_graph<directed_graph<>*, string, mapS>
+    >("a", "b", "c");
+
+    test_remove_vertex_suite_ptr_variant<
+        adjacency_list<listS, listS, directedS>,
+        labeled_graph<adjacency_list<listS, listS, directedS>*, string, multimapS>
+    >("a", "b", "c");
+
+    test_remove_vertex_suite_ptr_variant<
+        adjacency_list<listS, listS, directedS>,
+        labeled_graph<adjacency_list<listS, listS, directedS>*, string, hash_multimapS>
+    >("a", "b", "c");
+
+    test_remove_vertex_suite_ptr_variant<
+        adjacency_list<listS, listS, directedS>,
+        labeled_graph<adjacency_list<listS, listS, directedS>*, string, mapS>
+    >("a", "b", "c");
+
+    // Unsupported cases
+
+    // adjacency_list + vecS not supported (unstable removal would require remapping the map)
+    
+    // unsigned labels (vecS) : should not compile because static assert prevents removing vertices now
+    // test_remove_vertex_suite<
+    //     labeled_graph<adjacency_list<listS, listS, directedS>, unsigned, vecS>
+    // >(0u, 1u, 2u);
 
     // unsigned labels (vecS) : should not compile because static assert prevents removing vertices now
     // test_remove_vertex_suite_ptr_variant<

--- a/test/labeled_graph.cpp
+++ b/test/labeled_graph.cpp
@@ -234,6 +234,8 @@ void test_remove_vertex_suite(Label l1, Label l2, Label l3)
         g.add_vertex(l3);
         BOOST_ASSERT(num_vertices(g) == 3);
 
+        // TODO: this is broken when backed by vecS + unsigned because
+        // erasing middle element invalidates others.
         g.remove_vertex(l2);
         BOOST_ASSERT(num_vertices(g) == 2);
         BOOST_ASSERT(g.vertex(l2) == LabeledGraph::null_vertex());
@@ -384,7 +386,8 @@ void test_remove_vertex_all_types()
     >("a", "b", "c");
 
     // adjacency_list + vecS not supported (unstable removal would require remapping the map)
-    
+    // TODO: fix or not but document
+
     // adjacency_list + listS (stable removal)
     test_remove_vertex_suite<
         labeled_graph<adjacency_list<listS, listS, directedS>, string, mapS>
@@ -394,10 +397,10 @@ void test_remove_vertex_all_types()
         labeled_graph<adjacency_list<listS, listS, undirectedS>, string, mapS>
     >("a", "b", "c");
 
-    // unsigned labels (vecS)
-    test_remove_vertex_suite<
-        labeled_graph<adjacency_list<listS, listS, directedS>, unsigned, vecS>
-    >(0u, 1u, 2u);
+    // unsigned labels (vecS) : should not compile because static assert prevents removing vertices now
+    // test_remove_vertex_suite<
+    //     labeled_graph<adjacency_list<listS, listS, directedS>, unsigned, vecS>
+    // >(0u, 1u, 2u);
 
     // Pointer specialization: 
     // temporarily attach labels to it without copying.
@@ -417,9 +420,9 @@ void test_remove_vertex_all_types()
         labeled_graph<directed_graph<>*, string, hash_mapS>
     >("a", "b", "c");
 
-    // unsigned labels
-    test_remove_vertex_suite_ptr_variant<
-        adjacency_list<listS, listS, directedS>,
-        labeled_graph<adjacency_list<listS, listS, directedS>*, unsigned, vecS>
-    >(0u, 1u, 2u);
+    // unsigned labels (vecS) : should not compile because static assert prevents removing vertices now
+    // test_remove_vertex_suite_ptr_variant<
+    //     adjacency_list<listS, listS, directedS>,
+    //     labeled_graph<adjacency_list<listS, listS, directedS>*, unsigned, vecS>
+    // >(0u, 1u, 2u);
 }

--- a/test/labeled_graph.cpp
+++ b/test/labeled_graph.cpp
@@ -194,23 +194,6 @@ void test_remove_labeled_vertex()
     BOOST_ASSERT(v2 == nullptr);
 }
 
-void test_multiple_associative_container()
-{
-    typedef labeled_graph<adjacency_list<listS, multisetS, directedS>, string, multimapS> Graph;
-
-    Graph g;
-    g.add_vertex("test");
-    g.add_vertex("test");
-
-    BOOST_ASSERT(num_vertices(g) == 2);
-
-    g.remove_vertex("test");
-    BOOST_ASSERT(num_vertices(g) == 1);
-
-    g.remove_vertex("test");
-    BOOST_ASSERT(num_vertices(g) == 0);
-}
-
 template <typename LabeledGraph, typename Label>
 void test_remove_vertex_suite(Label l1, Label l2, Label l3)
 {
@@ -454,4 +437,130 @@ void test_remove_vertex_all_types()
     //     adjacency_list<listS, listS, directedS>,
     //     labeled_graph<adjacency_list<listS, listS, directedS>*, unsigned, vecS>
     // >(0u, 1u, 2u);
+}
+
+template <typename LabeledGraph, typename Label>
+void test_multimap_suite(Label l1, Label l2)
+{
+    // Duplicate labels, remove one at a time
+    {
+        LabeledGraph g;
+        g.add_vertex(l1);
+        g.add_vertex(l1);
+        BOOST_ASSERT(num_vertices(g) == 2);
+
+        g.remove_vertex(l1);
+        BOOST_ASSERT(num_vertices(g) == 1);
+
+        g.remove_vertex(l1);
+        BOOST_ASSERT(num_vertices(g) == 0);
+    }
+
+    // Duplicates + unique mixed
+    {
+        LabeledGraph g;
+        g.add_vertex(l1);
+        g.add_vertex(l1);
+        g.add_vertex(l2);
+        BOOST_ASSERT(num_vertices(g) == 3);
+
+        g.remove_vertex(l1);
+        BOOST_ASSERT(num_vertices(g) == 2);
+        BOOST_ASSERT(g.vertex(l2) != LabeledGraph::null_vertex());
+
+        g.remove_vertex(l1);
+        BOOST_ASSERT(num_vertices(g) == 1);
+        BOOST_ASSERT(g.vertex(l2) != LabeledGraph::null_vertex());
+    }
+
+    // Reuse label after removing all duplicates
+    {
+        LabeledGraph g;
+        g.add_vertex(l1);
+        g.add_vertex(l1);
+        g.remove_vertex(l1);
+        g.remove_vertex(l1);
+        BOOST_ASSERT(num_vertices(g) == 0);
+
+        g.add_vertex(l1);
+        BOOST_ASSERT(num_vertices(g) == 1);
+        BOOST_ASSERT(g.vertex(l1) != LabeledGraph::null_vertex());
+    }
+}
+
+template <typename Graph, typename LabeledGraph, typename Label>
+void test_multimap_suite_ptr(Label l1, Label l2)
+{
+    // Duplicate labels, remove one at a time
+    {
+        Graph graph;
+        LabeledGraph g(&graph);
+        g.add_vertex(l1);
+        g.add_vertex(l1);
+        BOOST_ASSERT(num_vertices(g) == 2);
+
+        g.remove_vertex(l1);
+        BOOST_ASSERT(num_vertices(g) == 1);
+
+        g.remove_vertex(l1);
+        BOOST_ASSERT(num_vertices(g) == 0);
+    }
+
+    // Duplicates + unique mixed
+    {
+        Graph graph;
+        LabeledGraph g(&graph);
+        g.add_vertex(l1);
+        g.add_vertex(l1);
+        g.add_vertex(l2);
+        BOOST_ASSERT(num_vertices(g) == 3);
+
+        g.remove_vertex(l1);
+        BOOST_ASSERT(num_vertices(g) == 2);
+        BOOST_ASSERT(g.vertex(l2) != LabeledGraph::null_vertex());
+
+        g.remove_vertex(l1);
+        BOOST_ASSERT(num_vertices(g) == 1);
+        BOOST_ASSERT(g.vertex(l2) != LabeledGraph::null_vertex());
+    }
+
+    // Reuse label after removing all duplicates
+    {
+        Graph graph;
+        LabeledGraph g(&graph);
+        g.add_vertex(l1);
+        g.add_vertex(l1);
+        g.remove_vertex(l1);
+        g.remove_vertex(l1);
+        BOOST_ASSERT(num_vertices(g) == 0);
+
+        g.add_vertex(l1);
+        BOOST_ASSERT(num_vertices(g) == 1);
+        BOOST_ASSERT(g.vertex(l1) != LabeledGraph::null_vertex());
+    }
+}
+
+void test_multiple_associative_container()
+{
+    // Owning multimapS
+    test_multimap_suite<
+        labeled_graph<adjacency_list<listS, multisetS, directedS>, string, multimapS>
+    >("a", "b");
+
+    // Owning hash_multimapS
+    test_multimap_suite<
+        labeled_graph<adjacency_list<listS, multisetS, directedS>, string, hash_multimapS>
+    >("a", "b");
+
+    // Pointer multimapS
+    test_multimap_suite_ptr<
+        adjacency_list<listS, multisetS, directedS>,
+        labeled_graph<adjacency_list<listS, multisetS, directedS>*, string, multimapS>
+    >("a", "b");
+
+    // Pointer hash_multimapS
+    test_multimap_suite_ptr<
+        adjacency_list<listS, multisetS, directedS>,
+        labeled_graph<adjacency_list<listS, multisetS, directedS>*, string, hash_multimapS>
+    >("a", "b");
 }

--- a/test/labeled_graph.cpp
+++ b/test/labeled_graph.cpp
@@ -26,6 +26,7 @@ void test_temp();
 void test_bacon();
 void test_remove_labeled_vertex();
 void test_multiple_associative_container();
+void test_remove_vertex_all_types();
 
 int main()
 {
@@ -35,6 +36,7 @@ int main()
     test_bacon();
     test_remove_labeled_vertex();
     test_multiple_associative_container();
+    test_remove_vertex_all_types();
 }
 
 //////////////////////////////////////
@@ -207,4 +209,217 @@ void test_multiple_associative_container()
 
     g.remove_vertex("test");
     BOOST_ASSERT(num_vertices(g) == 0);
+}
+
+template <typename LabeledGraph, typename Label>
+void test_remove_vertex_suite(Label l1, Label l2, Label l3)
+{
+    // remove + label cleanup
+    {
+        LabeledGraph g;
+        g.add_vertex(l1);
+        BOOST_ASSERT(num_vertices(g) == 1);
+        BOOST_ASSERT(g.vertex(l1) != LabeledGraph::null_vertex());
+
+        g.remove_vertex(l1);
+        BOOST_ASSERT(num_vertices(g) == 0);
+        BOOST_ASSERT(g.vertex(l1) == LabeledGraph::null_vertex());
+    }
+
+    // remove one + keep others
+    {
+        LabeledGraph g;
+        g.add_vertex(l1);
+        g.add_vertex(l2);
+        g.add_vertex(l3);
+        BOOST_ASSERT(num_vertices(g) == 3);
+
+        g.remove_vertex(l2);
+        BOOST_ASSERT(num_vertices(g) == 2);
+        BOOST_ASSERT(g.vertex(l2) == LabeledGraph::null_vertex());
+        BOOST_ASSERT(g.vertex(l1) != LabeledGraph::null_vertex());
+        BOOST_ASSERT(g.vertex(l3) != LabeledGraph::null_vertex());
+    }
+
+    // reuse label after removal
+    {
+        LabeledGraph g;
+        g.add_vertex(l1);
+        g.remove_vertex(l1);
+        g.add_vertex(l1);
+        BOOST_ASSERT(num_vertices(g) == 1);
+        BOOST_ASSERT(g.vertex(l1) != LabeledGraph::null_vertex());
+    }
+
+    // Remove all
+    {
+        LabeledGraph g;
+        g.add_vertex(l1);
+        g.add_vertex(l2);
+        g.add_vertex(l3);
+
+        g.remove_vertex(l1);
+        g.remove_vertex(l2);
+        g.remove_vertex(l3);
+        BOOST_ASSERT(num_vertices(g) == 0);
+    }
+
+    // Remove vertex with incident edges
+    {
+        LabeledGraph g;
+        g.add_vertex(l1);
+        g.add_vertex(l2);
+        add_edge_by_label(l1, l2, g);
+        BOOST_ASSERT(num_edges(g) == 1);
+
+        // BGL requires clearing edges before removing a vertex
+        clear_vertex_by_label(l1,g);
+        g.remove_vertex(l1);
+        BOOST_ASSERT(g.vertex(l1) == LabeledGraph::null_vertex());
+        BOOST_ASSERT(num_edges(g) == 0);
+    }    
+}
+
+template <typename Graph, typename LabeledGraph, typename Label>
+void test_remove_vertex_suite_ptr_variant(Label l1, Label l2, Label l3)
+{
+    // remove + label cleanup
+    {
+        Graph graph;
+        LabeledGraph g(&graph);
+        g.add_vertex(l1);
+        BOOST_ASSERT(num_vertices(g) == 1);
+        BOOST_ASSERT(g.vertex(l1) != LabeledGraph::null_vertex());
+
+        g.remove_vertex(l1);
+        BOOST_ASSERT(num_vertices(g) == 0);
+        BOOST_ASSERT(g.vertex(l1) == LabeledGraph::null_vertex());
+    }
+
+    // remove one + keep others
+    {
+        Graph graph;
+        LabeledGraph g(&graph);
+        g.add_vertex(l1);
+        g.add_vertex(l2);
+        g.add_vertex(l3);
+        BOOST_ASSERT(num_vertices(g) == 3);
+
+        g.remove_vertex(l2);
+        BOOST_ASSERT(num_vertices(g) == 2);
+        BOOST_ASSERT(g.vertex(l2) == LabeledGraph::null_vertex());
+        BOOST_ASSERT(g.vertex(l1) != LabeledGraph::null_vertex());
+        BOOST_ASSERT(g.vertex(l3) != LabeledGraph::null_vertex());
+    }
+
+    // reuse label after removal
+    {
+        Graph graph;
+        LabeledGraph g(&graph);
+        g.add_vertex(l1);
+        g.remove_vertex(l1);
+        g.add_vertex(l1);
+        BOOST_ASSERT(num_vertices(g) == 1);
+        BOOST_ASSERT(g.vertex(l1) != LabeledGraph::null_vertex());
+    }
+
+    // Remove all
+    {
+        Graph graph;
+        LabeledGraph g(&graph);
+        g.add_vertex(l1);
+        g.add_vertex(l2);
+        g.add_vertex(l3);
+
+        g.remove_vertex(l1);
+        g.remove_vertex(l2);
+        g.remove_vertex(l3);
+        BOOST_ASSERT(num_vertices(g) == 0);
+    }
+
+    // Remove vertex with incident edges
+    {
+        Graph graph;
+        LabeledGraph g(&graph);
+        g.add_vertex(l1);
+        g.add_vertex(l2);
+        add_edge_by_label(l1, l2, g);
+        BOOST_ASSERT(num_edges(g) == 1);
+
+        // BGL requires clearing edges before removing a vertex
+        clear_vertex_by_label(l1,g); 
+        g.remove_vertex(l1);
+        BOOST_ASSERT(g.vertex(l1) == LabeledGraph::null_vertex());
+        BOOST_ASSERT(num_edges(g) == 0);
+    }    
+}
+
+void test_remove_vertex_all_types()
+{
+    // defaultS
+    test_remove_vertex_suite<
+        labeled_graph<directed_graph<>, string>
+    >("a", "b", "c");
+
+    test_remove_vertex_suite<
+        labeled_graph<undirected_graph<>, string>
+    >("a", "b", "c");
+
+    // mapS
+    test_remove_vertex_suite<
+        labeled_graph<directed_graph<>, string, mapS>
+    >("a", "b", "c");
+
+    test_remove_vertex_suite<
+        labeled_graph<undirected_graph<>, string, mapS>
+    >("a", "b", "c");
+
+    // hash_mapS
+    test_remove_vertex_suite<
+        labeled_graph<directed_graph<>, string, hash_mapS>
+    >("a", "b", "c");
+
+    test_remove_vertex_suite<
+        labeled_graph<undirected_graph<>, string, hash_mapS>
+    >("a", "b", "c");
+
+    // adjacency_list + vecS not supported (unstable removal would require remapping the map)
+    
+    // adjacency_list + listS (stable removal)
+    test_remove_vertex_suite<
+        labeled_graph<adjacency_list<listS, listS, directedS>, string, mapS>
+    >("a", "b", "c");
+
+    test_remove_vertex_suite<
+        labeled_graph<adjacency_list<listS, listS, undirectedS>, string, mapS>
+    >("a", "b", "c");
+
+    // unsigned labels (vecS)
+    test_remove_vertex_suite<
+        labeled_graph<adjacency_list<listS, listS, directedS>, unsigned, vecS>
+    >(0u, 1u, 2u);
+
+    // Pointer specialization: 
+    // temporarily attach labels to it without copying.
+
+    test_remove_vertex_suite_ptr_variant<
+        directed_graph<>,
+        labeled_graph<directed_graph<>*, string>
+    >("a", "b", "c");
+
+    test_remove_vertex_suite_ptr_variant<
+        undirected_graph<>,
+        labeled_graph<undirected_graph<>*, string>
+    >("a", "b", "c");
+
+    test_remove_vertex_suite_ptr_variant<
+        directed_graph<>,
+        labeled_graph<directed_graph<>*, string, hash_mapS>
+    >("a", "b", "c");
+
+    // unsigned labels
+    test_remove_vertex_suite_ptr_variant<
+        adjacency_list<listS, listS, directedS>,
+        labeled_graph<adjacency_list<listS, listS, directedS>*, unsigned, vecS>
+    >(0u, 1u, 2u);
 }

--- a/test/test_graphs.cpp
+++ b/test/test_graphs.cpp
@@ -159,7 +159,9 @@ int main()
         test_graph(g);
     }
     {
-        typedef labeled_graph< directed_graph<>, unsigned > Graph;
+        // @note: must not use defaultS/vecS label storage because vertex
+        // removal invalidates label-to-vertex mappings in vector-backed maps
+        typedef labeled_graph< directed_graph<>, unsigned, mapS > Graph;
         BOOST_META_ASSERT(is_directed_graph< Graph >);
         BOOST_META_ASSERT(is_multigraph< Graph >);
         BOOST_META_ASSERT(is_incidence_graph< Graph >);


### PR DESCRIPTION
Fixes #167

- [x] `labeled_graph.hpp` : pointer specialization `remove_vertex` now uses `graph_detail::remove_labeled_vertex(_map, *_graph, l)`. This fixes #167 as label was not removed from `_map`
- [x] `labeled_graph.hpp` both specializations (graph owning and non-owning): `static_assert` blocking `remove_vertex` for `vecS` label storage. When `remove_vertex` called `vector::erase`, it shifts all indices of the labels after the erase point. It was preferred over documentation-only (silent corruption) or runtime error (damage already done before check or pay for a check before every `vector::erase` call) because the combination is fundamentally broken for any non-trailing removal. 
- [x] `labeled_graph.cpp`: added `test_remove_vertex_suite` + `_ptr_variant` : 5 scenarios across all selector/graph/ownership combos
- [x] `labeled_graph.cpp`: added `test_multimap_suite` + `_ptr` : 3 duplicate-label scenarios for `multimapS`/`hash_multimapS`, owning + pointer
- [x] `test_graphs.cpp`: changed `defaultS` to `mapS` for `unsigned` labeled graph : `defaultS` picks vector, now blocked by `static_assert` because it invalidates labels
- [x] `compile_fail_remove_vertex_vecS.cpp`: new file, verifies `static_assert` rejects `vecS` removal at compile time
