### PR TITLE
Adding and editing github plumbing files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# Code owners for Boost.Graph
+#
+# When a PR is opened, GitHub automatically requests review from the matching
+# owners listed below. The order of rules matters: later, more specific rules
+# override earlier, more general ones.
+#
+# Authoritative maintainer list: meta/libraries.json
+# Contact details: CONTRIBUTING.md#maintainers
+
+# Default reviewers for everything
+*                       @jeremy-murphy @becheler
+
+# Documentation, contributor-facing files, and CI configuration
+/doc/                   @becheler
+/README.md              @becheler
+/CONTRIBUTING.md        @becheler
+/SECURITY.md            @becheler
+/CODE_OF_CONDUCT.md     @becheler
+/.github/               @becheler

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,83 @@
+---
+name: Bug report
+about: Report a defect or unexpected behavior in Boost.Graph
+title: ''
+labels: bug
+assignees: ''
+---
+
+<!--
+Thank you for taking the time to file a bug report. Please fill in as much
+of the template below as you can. Reports without a reproducer or
+environment details are very hard to triage.
+-->
+
+### Before filing
+
+- [ ] I searched the [existing issues](https://github.com/boostorg/graph/issues?q=is%3Aissue) and did not find a duplicate.
+- [ ] I have reproduced the bug against the `develop` branch or the latest Boost release.
+- [ ] I have a minimal reproducer (or I will paste my full failing code below).
+
+### Boost version
+
+<!--
+You can find the version number in `<boost/version.hpp>`, or by running
+`git log -1` in your local Boost.Graph checkout.
+-->
+
+### Compiler family
+
+- [ ] GCC / g++
+- [ ] Clang / clang++
+- [ ] MSVC (Visual Studio)
+- [ ] Intel / oneAPI
+- [ ] Other (specify below)
+
+Exact compiler version: <!-- e.g. g++ 13.2.0, clang 17.0.6, MSVC 19.39 -->
+
+### Standard library
+
+- [ ] libstdc++
+- [ ] libc++
+- [ ] MSVC STL
+- [ ] Other (specify below)
+
+### Operating system
+
+- [ ] Linux
+- [ ] macOS
+- [ ] Windows
+- [ ] Other (specify below)
+
+### Kind of component affected
+
+- [ ] Graph data structure (e.g. `adjacency_list`, `adjacency_matrix`)
+- [ ] Algorithm (e.g. `dijkstra_shortest_paths`, `breadth_first_search`)
+- [ ] Property map
+- [ ] I/O or file-format reader (e.g. `read_graphml`, `read_graphviz`)
+- [ ] Visitor / event hooks
+- [ ] Other (specify below)
+
+Exact name of the affected component: <!-- e.g. dijkstra_shortest_paths -->
+
+### Steps to reproduce
+
+<!--
+A minimal compiling program that demonstrates the problem is ideal.
+A [Compiler Explorer](https://godbolt.org/z/9Esszr9Ga) link is even better.
+-->
+
+### Expected behavior
+
+### Actual behavior
+
+<!--
+Include compiler error messages or runtime output verbatim, with file and
+line numbers where applicable.
+-->
+
+### Are you willing to help?
+
+- [ ] I'd like to submit a fix as a pull request.
+- [ ] I can help diagnose or test a candidate fix.
+- [ ] I'm only reporting the issue.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Report a defect or unexpected behavior in Boost.Graph
 title: ''
-labels: bug
+type: Bug
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,6 +2,7 @@
 name: Bug report
 about: Report a defect or unexpected behavior in Boost.Graph
 title: ''
+labels: ''
 type: Bug
 assignees: ''
 ---

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Design discussion or open-ended question
+    url: https://github.com/boostorg/graph/discussions
+    about: |
+      For "should we...?" questions, design exploration, or anything not
+      yet a concrete proposal, please start a GitHub Discussion. Issues
+      are reserved for bugs, feature requests with a concrete proposal,
+      and documentation problems.

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 <!--
-Documentation problems are real bugs. Thanks for taking the time to
+Documentation problems are real issues. Thanks for taking the time to
 report one.
 -->
 

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,58 @@
+---
+name: Documentation issue
+about: Report missing, incorrect, or unclear documentation
+title: ''
+labels: docs
+assignees: ''
+---
+
+<!--
+Documentation problems are real bugs. Thanks for taking the time to
+report one.
+-->
+
+### Before filing
+
+- [ ] I searched the [existing issues](https://github.com/boostorg/graph/issues?q=is%3Aissue+label%3Adocs) and did not find a duplicate.
+- [ ] I checked the latest version of the documentation on `develop`.
+
+### Kind of problem
+
+- [ ] Documentation is missing entirely
+- [ ] Documentation is incorrect or out of date
+- [ ] Explanation is unclear or confusing
+- [ ] Example does not compile
+- [ ] Example compiles but does not produce the documented result
+- [ ] Dead link or broken cross-reference
+- [ ] Other (specify below)
+
+### Where is the issue?
+
+<!--
+A link to the page, or the path to the file (for example,
+`doc/quick_tour.html` or `include/boost/graph/dijkstra_shortest_paths.hpp`).
+-->
+
+### What is wrong, missing, or unclear?
+
+<!--
+For example: an example does not compile, an algorithm's complexity is
+not stated, a parameter is undocumented, an explanation is confusing.
+-->
+
+### What did you expect to find?
+
+<!-- What information would have helped you? -->
+
+### Suggested wording (optional)
+
+<!--
+If you already have an idea of what the docs should say, paste a draft
+here.
+-->
+
+### Are you willing to help?
+
+- [ ] I'd like to submit a docs pull request.
+- [ ] I can review a candidate fix.
+- [ ] I'm only reporting the issue.

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -3,6 +3,7 @@ name: Documentation issue
 about: Report missing, incorrect, or unclear documentation
 title: ''
 labels: docs
+type: Task
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,71 @@
+---
+name: Feature request
+about: Suggest a new algorithm, API addition, or enhancement
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+<!--
+Thanks for proposing an addition to Boost.Graph.
+
+If you want to explore an idea or discuss whether a feature would be
+worthwhile before committing to a concrete proposal, please start a
+GitHub Discussion instead:
+https://github.com/boostorg/graph/discussions
+
+This template is for requests with a clear, actionable proposal: a
+specific algorithm, API, or enhancement that a maintainer could
+reasonably implement or review.
+-->
+
+### Before filing
+
+- [ ] I searched the [existing issues](https://github.com/boostorg/graph/issues?q=is%3Aissue) and did not find a duplicate.
+- [ ] This is a concrete proposal, not an open-ended design question.
+
+### Kind of addition
+
+- [ ] New algorithm
+- [ ] New data structure
+- [ ] New property map or utility
+- [ ] New I/O format reader or writer
+- [ ] Extension to an existing component
+- [ ] Performance improvement
+- [ ] Other (specify below)
+
+### Motivation
+
+<!--
+What problem does this feature solve? Who would use it, and in what
+context?
+-->
+
+### Proposed addition
+
+<!--
+A new algorithm, a new data structure, an extension to an existing
+component, or something else? If you have a rough API sketch, paste it
+here.
+-->
+
+### Relation to existing Boost.Graph components
+
+<!--
+Does this overlap with or build on something that already exists in the
+library (for example, an existing algorithm or property map)?
+-->
+
+### Prior art
+
+- [ ] Reference paper or textbook (cite below)
+- [ ] Implementation in another library (link below)
+- [ ] None / original idea
+
+References: <!-- paste DOI, ISBN, or URL -->
+
+### Are you willing to contribute?
+
+- [ ] I'd like to submit the implementation as a pull request.
+- [ ] I can help with review or testing, but not the implementation.
+- [ ] I'm only proposing the idea.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,8 @@
 name: Feature request
 about: Suggest a new algorithm, API addition, or enhancement
 title: ''
-labels: enhancement
+labels: ''
+type: Feature
 assignees: ''
 ---
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,50 @@
+<!--
+Thanks for contributing to Boost.Graph! A few notes before you fill this in:
+
+* Target the `develop` branch.
+* New contributions must be licensed under the
+  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
+* Please link any related issue with `Fixes #N` or `Refs #N`.
+-->
+
+### Before submitting
+
+- [ ] This PR targets the `develop` branch.
+- [ ] I searched for an existing PR or issue covering the same change.
+- [ ] My contribution is licensed under the Boost Software License 1.0.
+
+### Type of change
+
+- [ ] Bug fix
+- [ ] New feature or API addition
+- [ ] Refactor (no behavior change)
+- [ ] Documentation
+- [ ] Build, CI, or tooling
+- [ ] Other (specify below)
+
+### Does this PR introduce a breaking change?
+
+- [ ] Yes (describe migration impact below)
+- [ ] No
+
+### What this PR does
+
+<!-- A short summary of the change. -->
+
+### Motivation
+
+<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->
+
+### Testing
+
+<!--
+How did you verify the change? Which compilers and standard libraries did
+you build against? Were new tests added under `test/`?
+-->
+
+### Checklist
+
+- [ ] Existing tests pass (`b2` in the `test/` directory).
+- [ ] New behavior is covered by a test, or this is a docs / build / refactor change.
+- [ ] Documentation was updated if user-facing behavior changed.
+- [ ] No new compiler warnings on the platforms I built against.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,84 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at `arnaud.becheler -at- gmail.com`. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,21 +53,97 @@ BGL follows the standard Boost / STL conventions:
 | Kind | Style | Example |
 |---|---|---|
 | Functions, types, variables, files | `snake_case` | `dijkstra_visitor`, `add_edge`, `adjacency_list.hpp` |
+| Member functions / methods | `snake_case` (same as free functions) | `get_edge`, `out_edges` |
+| Private member variables | `m_` prefix + `snake_case` | `m_matrix`, `m_num_edges`, `m_property` |
 | Concept names | `PascalCase` | `IncidenceGraph`, `VertexListGraph` |
 | Template parameters | `PascalCase` | `template <class Graph, class WeightMap>` |
 | Tag-dispatch types | `snake_case` + `S` suffix | `vecS`, `directedS` |
 | Macros | `BOOST_GRAPH_` prefix, `SCREAMING_SNAKE_CASE` | `BOOST_GRAPH_DECLARE_EDGE_PROPERTY` |
 
+### Formatting
+
+Low-level formatting (braces, column width, spaces in angle brackets, etc.) is captured by the [`.clang-format`](.clang-format) file at the repo root (WebKit preset with BGL-specific overrides: Allman braces, 80-column limit, `Cpp03`). It is **not** enforced by CI, but contributors are encouraged to run `clang-format -i` on files they touch before opening a PR.
+
 ## Using other Boost libraries
 
 When writing new code:
 
-- **Prefer `std::`** when the supported C++ standard has an equivalent. Use `std::function`, `std::shared_ptr`, `std::tuple` over their Boost counterparts.
+- **Prefer `std::`** when the supported C++ standard has an equivalent. Use `std::function`, `std::shared_ptr`, `std::tuple` over their Boost counterparts. Exceptions are welcome with justification in the PR description, in particular Boost containers with no std equivalent in our standard window (e.g. `boost::unordered_flat_map`, `boost::bimap`, `boost::multi_index_container`).
 - **Avoid pulling in new heavy dependencies** (Spirit, property_tree, xpressive, etc.) without justification: BGL is gradually migrating away from heavy Boost dependencies. Open a discussion before adding one.
 - **Concept checks** (`boost::concept`) are encouraged for any new public template. New public APIs should respect the existing concept hierarchy. 
 - Track BGL's position in the Boost dependency DAG via [boostdep](https://github.com/boostorg/boostdep)'s hosted reports. The long-term goal is to reduce BGL's level over time:
     - **[Module levels](https://pdimov.github.io/boostdep-report/master/module-levels.html#graph)** shows BGL's depth in the global DAG. A rising level means new transitive Boost dependencies have been pulled in.
     - **[Per-library page](https://pdimov.github.io/boostdep-report/develop/graph.html)** shows BGL's direct deps and per-dep `#include` counts.
+
+## Boost macro usage
+
+BGL has accumulated a wide vocabulary of `BOOST_*` macros from its pre-C++14 days. The table below captures the current guidance for each one used in the codebase: **Keep** as-is, **Replace** with a language or std equivalent, or **Remove** along with the dead `#if defined(...)` branch the macro guards. When in doubt, follow the recommendation here or ask before introducing new uses.
+
+| Macro | Recommendation |
+|---|---|
+| `BOOST_ASSERT` | Keep, more useful and configurable than `assert` |
+| `BOOST_BORLANDC` | Remove |
+| `BOOST_CONCEPT_ASSERT` | Keep (pre C++20) |
+| `BOOST_CONCEPT_REQUIRES` | Keep (pre C++20) |
+| `BOOST_CONCEPT_USAGE` | Keep (pre C++20) |
+| `BOOST_DEDUCED_TYPENAME` | Remove |
+| `BOOST_FOREACH` | Replace with an appropriate algorithm or range-based `for` loop |
+| `BOOST_FWD_REF` | Replace with `T&&` |
+| `BOOST_JOIN` | Keep |
+| `BOOST_MPL_HAS_XXX_TRAIT_DEF` | Consider writing the same utility without dependency on MPL |
+| `BOOST_MSVC` | Keep |
+| `BOOST_NO_ARGUMENT_DEPENDENT_LOOKUP` | Remove |
+| `BOOST_NO_AUTO_PTR` | Remove and assume `auto_ptr` is not available |
+| `BOOST_NO_CXX11_ALLOCATOR` | Remove |
+| `BOOST_NO_CXX11_RVALUE_REFERENCES` | Remove |
+| `BOOST_NO_CXX11_SMART_PTR` | Remove |
+| `BOOST_NO_CXX17_STRUCTURED_BINDINGS` | Keep |
+| `BOOST_NO_MEMBER_TEMPLATE_FRIENDS` | Remove |
+| `BOOST_NO_SFINAE` | Remove |
+| `BOOST_NO_STDC_NAMESPACE` | Possibly keep |
+| `BOOST_NO_STD_ALLOCATOR` | Remove |
+| `BOOST_NO_STD_ITERATOR_TRAITS` | Remove |
+| `BOOST_NO_TEMPLATED_ITERATOR_CONSTRUCTORS` | Remove |
+| `BOOST_OVERRIDE` | Possibly remove |
+| `BOOST_PARAMETER_KEYWORD` | Keep |
+| `BOOST_PARAMETER_NAME` | Keep |
+| `BOOST_PP_CAT` | Use if Boost.PP can't be replaced with variadics |
+| `BOOST_PP_COMMA_IF` | Use if Boost.PP can't be replaced with variadics |
+| `BOOST_PP_DEC` | Use if Boost.PP can't be replaced with variadics |
+| `BOOST_PP_ENUM_BINARY_PARAMS` | Use if Boost.PP can't be replaced with variadics |
+| `BOOST_PP_ENUM_BINARY_PARAMS_Z` | Use if Boost.PP can't be replaced with variadics |
+| `BOOST_PP_ENUM_PARAMS` | Use if Boost.PP can't be replaced with variadics |
+| `BOOST_PP_ENUM_PARAMS_Z` | Use if Boost.PP can't be replaced with variadics |
+| `BOOST_PP_ENUM_TRAILING_BINARY_PARAMS_Z` | Use if Boost.PP can't be replaced with variadics |
+| `BOOST_PP_ENUM_TRAILING_PARAMS_Z` | Use if Boost.PP can't be replaced with variadics |
+| `BOOST_PP_EXPR_IF` | Use if Boost.PP can't be replaced with variadics |
+| `BOOST_PP_INC` | Use if Boost.PP can't be replaced with variadics |
+| `BOOST_PP_LPAREN_IF` | Use if Boost.PP can't be replaced with variadics |
+| `BOOST_PP_REPEAT` | Use if Boost.PP can't be replaced with variadics |
+| `BOOST_PP_REPEAT_FROM_TO` | Use if Boost.PP can't be replaced with variadics |
+| `BOOST_PP_RPAREN_IF` | Use if Boost.PP can't be replaced with variadics |
+| `BOOST_PP_SEQ_ELEM` | Use if Boost.PP can't be replaced with variadics |
+| `BOOST_PP_SUB` | Use if Boost.PP can't be replaced with variadics |
+| `BOOST_PP_TUPLE_EAT` | Use if Boost.PP can't be replaced with variadics |
+| `BOOST_PREVENT_MACRO_SUBSTITUTION` | Keep |
+| `BOOST_SERIALIZATION_NVP` | Consider removing if you can eliminate the dependency on Boost.Serialization via `<boost/core/serialization.hpp>` |
+| `BOOST_SPIRIT_CLOSURE_LIMIT` | Keep |
+| `BOOST_SPIRIT_DEBUG` | Keep |
+| `BOOST_SPIRIT_DEBUG_RULE` | Keep |
+| `BOOST_STATIC_ASSERT` | Replace with `static_assert(..., msg)` |
+| `BOOST_STATIC_ASSERT_MSG` | Replace with `static_assert(..., msg)` |
+| `BOOST_STATIC_CONSTANT` | Remove in favour of in-class `static constexpr` initialization |
+| `BOOST_SYMBOL_EXPORT` | Keep |
+| `BOOST_SYMBOL_IMPORT` | Keep |
+| `BOOST_SYMBOL_VISIBLE` | Keep |
+| `BOOST_TESTED_AT` | Keep |
+| `BOOST_THROW_EXCEPTION` | Keep |
+| `BOOST_TTI_HAS_MEMBER_FUNCTION` | Consider writing the same utility without dependency on TTI |
+| `BOOST_USING_STD_MAX` | Replace with `(std::max)(...)` |
+| `BOOST_USING_STD_MIN` | Replace with `(std::min)(...)` |
+| `BOOST_WORKAROUND` | Keep |
+
+When you mark a `BOOST_NO_*` flag as **Remove**, also delete the `#if defined(...)` block it gates — the alternate branch is always taken on the supported toolchains.
 
 ## Pull request process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,106 @@
+# Contributing to Boost.Graph
+
+## We are welcoming contributions
+
+- Bug fixes and test cases for them
+- New algorithms (with tests, documentation, complexity notes, and a reference)
+- Documentation, examples, performance work
+- Concept refinements (handle with care as these are API-visible)
+
+## Maintainers
+
+| Maintainer | Role | Focus | Availability | Contact |
+|---|---|---|---|---|
+| **Jeremy W. Murphy** | Principal maintainer. Holds merge authority and final say on design decisions. | Algorithms, technical review, library architecture. 10+ years on BGL. | Part-time, best-effort. | `jeremy.william.murphy -at- gmail.com` |
+| **Arnaud Becheler** | Assistant maintainer. Triage, review, and contributor support; defers to Jeremy on merge decisions. | Documentation, modernization, contributor onboarding. | Full-time, funded by the [C++ Alliance](https://cppalliance.org) to assist Jeremy. | `arnaud.becheler -at- gmail.com` |
+
+The authoritative maintainer list lives in [meta/libraries.json](meta/libraries.json); keep this section in sync with it. Maintainers aim to provide first-pass review on new PRs within two weeks.
+
+## Getting set up
+
+Clone the [Boost superproject](https://github.com/boostorg/boost):
+
+```bash
+git clone --depth 1 https://github.com/boostorg/boost
+cd boost
+git submodule update --init --depth 1
+./bootstrap.sh
+./b2 headers
+```
+
+Then replace `libs/graph/` with your fork:
+
+```bash
+rm -rf libs/graph
+git clone https://github.com/<you>/graph libs/graph
+cd libs/graph
+git remote add upstream https://github.com/boostorg/graph
+```
+
+## Building and testing
+
+- Headers only: `./b2 headers` from boost root
+- Compiled components: `./b2` from `libs/graph`
+- All tests: `./b2` from `libs/graph/test` (takes ~10 min)
+- Single test: `./b2 cycle_canceling_test` from `libs/graph/test`
+- Different C++ standard: `./b2 cxxstd=20`
+- Different compiler: `./b2 toolset=clang`
+
+### Naming conventions
+
+BGL follows the standard Boost / STL conventions:
+
+| Kind | Style | Example |
+|---|---|---|
+| Functions, types, variables, files | `snake_case` | `dijkstra_visitor`, `add_edge`, `adjacency_list.hpp` |
+| Concept names | `PascalCase` | `IncidenceGraph`, `VertexListGraph` |
+| Template parameters | `PascalCase` | `template <class Graph, class WeightMap>` |
+| Tag-dispatch types | `snake_case` + `S` suffix | `vecS`, `directedS` |
+| Macros | `BOOST_GRAPH_` prefix, `SCREAMING_SNAKE_CASE` | `BOOST_GRAPH_DECLARE_EDGE_PROPERTY` |
+
+## Using other Boost libraries
+
+When writing new code:
+
+- **Prefer `std::`** when the supported C++ standard has an equivalent. Use `std::function`, `std::shared_ptr`, `std::tuple` over their Boost counterparts.
+- **Avoid pulling in new heavy dependencies** (Spirit, property_tree, xpressive, etc.) without justification: BGL is gradually migrating away from heavy Boost dependencies. Open a discussion before adding one.
+- **Concept checks** (`boost::concept`) are encouraged for any new public template. New public APIs should respect the existing concept hierarchy. 
+- Track BGL's position in the Boost dependency DAG via [boostdep](https://github.com/boostorg/boostdep)'s hosted reports. The long-term goal is to reduce BGL's level over time:
+    - **[Module levels](https://pdimov.github.io/boostdep-report/master/module-levels.html#graph)** shows BGL's depth in the global DAG. A rising level means new transitive Boost dependencies have been pulled in.
+    - **[Per-library page](https://pdimov.github.io/boostdep-report/develop/graph.html)** shows BGL's direct deps and per-dep `#include` counts.
+
+## Pull request process
+
+- Fork, branch from `develop`, PR back to `develop`
+- One logical change per PR; rebase before requesting review
+- Tests required for new features and bug fixes
+- **Open (non-draft) PRs are assumed ready for review.** Use GitHub's Draft state while iterating, then mark the PR as *Ready for review* when you want maintainers to look at it.
+- A maintainer will review within ~2 weeks (see Maintainers below)
+- Squash on merge by default
+
+## Merge criteria
+
+Before a PR is merged, all of the following must hold:
+
+1. CI is green on the full matrix (gcc-14 + clang-19, C++14/17/20/23).
+2. New behavior has tests.
+3. Bug fixes have a regression test.
+4. Documentation under [doc/](doc/) is updated if the public API changed.
+5. No new compiler warnings on the supported toolchains.
+6. The PR is rebased on current `develop` with a clean commit history.
+7. The principal maintainer has approved.
+
+## Reporting bugs
+
+1. Search [existing issues](https://github.com/boostorg/graph/issues) first
+2. Note compiler, version, OS, Boost version
+3. Minimal reproducer on [Compiler Explorer](https://godbolt.org/z/37dPWd5bs)
+4. Expected Output versus Actual Output is explained.
+
+## Security
+
+See [SECURITY.md](SECURITY.md).
+
+## License
+
+By contributing, you agree your contribution is licensed under the [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).

--- a/README.md
+++ b/README.md
@@ -1,57 +1,106 @@
 # Boost Graph Library
 
-===================
+[![Docs](https://img.shields.io/badge/docs-boost.org-blue.svg)](https://www.boost.org/doc/libs/release/libs/graph/doc/index.html)
+[![C++14](https://img.shields.io/badge/C%2B%2B-14-blue.svg)](https://en.cppreference.com/w/cpp/14)
+[![CI](https://github.com/boostorg/graph/actions/workflows/ci.yml/badge.svg)](https://github.com/boostorg/graph/actions/workflows/ci.yml)
+[![License: BSL-1.0](https://img.shields.io/badge/License-BSL_1.0-blue.svg)](https://www.boost.org/LICENSE_1_0.txt)
+[![Boost release](https://img.shields.io/github/v/release/boostorg/boost?label=Boost&color=orange)](https://github.com/boostorg/boost/releases)
 
-A generic interface for traversing graphs, using C++ templates.
+The Boost Graph Library (BGL) is a generic library that allows users to:
 
-The full documentation is available on [boost.org](http://www.boost.org/doc/libs/release/libs/graph/doc/index.html).
+1. Represent graph data using different structures (adjacency matrix, adjacency list, compressed sparse row, vectors of vectors, user-defined data structures).
+2. Attach user-defined data to vertices, edges, or the graph itself.
+3. Run a large number of algorithms on the graph.
+4. Inject user logic into algorithms using visitor hooks.
 
-## Support, bugs and feature requests
+## Example
 
-Bugs and feature requests can be reported through the [Github issue page](https://github.com/boostorg/graph/issues).
+[Try it on Compiler Explorer](https://godbolt.org/z/9Esszr9Ga)
 
-See also:
+```cpp
+#include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/dijkstra_shortest_paths.hpp>
+#include <boost/graph/visitors.hpp>
+#include <iostream>
+#include <limits>
+#include <vector>
 
-* [Current open issues](https://github.com/boostorg/graph/issues)
-* [Closed issues](https://github.com/boostorg/graph/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed)
-* Old issues still open on [Trac](https://svn.boost.org/trac/boost/query?status=!closed&component=graph&desc=1&order=id)
-* Closed issues on [Trac](https://svn.boost.org/trac/boost/query?status=closed&component=graph&col=id&col=summary&col=status&col=owner&col=type&col=milestone&col=version&desc=1&order=id)
+struct City {};
+struct Road { int cost; };
 
-You can submit your changes through a [pull request](https://github.com/boostorg/graph/pulls). One of the maintainers will take a look (remember that it can take some time).
+using namespace boost;
+using Graph = adjacency_list<vecS, vecS, directedS, City, Road>;
+using Vertex = graph_traits<Graph>::vertex_descriptor;
 
-There is no mailing-list specific to Boost Graph, although you can use the general-purpose Boost [mailing-list](http://lists.boost.org/mailman/listinfo.cgi/boost-users) using the tag [graph].
+int main() {
+    Graph g(4);
+    add_edge(0, 1, Road{1}, g);
+    add_edge(1, 2, Road{2}, g);
+    add_edge(0, 2, Road{10}, g);
+    add_edge(2, 3, Road{1}, g);
 
+    // Storage: you control allocation, lifetime, and container type
+    std::vector<Vertex> storage_pred(num_vertices(g));
+    std::vector<int>    storage_dist(num_vertices(g));
 
-### Build Status
+    // Property maps: lightweight views into the storage
+    auto index_map       = get(vertex_index, g);
+    auto costs_map       = get(&Road::cost, g);
+    auto predecessor_map = make_iterator_property_map(storage_pred.begin(), index_map);
+    auto distance_map    = make_iterator_property_map(storage_dist.begin(), index_map);
 
-|                  |  Master  |   Develop   |
-|------------------|----------|-------------|
-| Github Actions | [![Build Status](https://github.com/boostorg/graph/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/boostorg/graph/actions) | [![Build Status](https://github.com/boostorg/graph/actions/workflows/ci.yml/badge.svg?branch=develop)](https://github.com/boostorg/graph/actions) |
-|Drone | [![Build Status](https://drone.cpp.al/api/badges/boostorg/graph/status.svg?ref=refs/heads/master)](https://drone.cpp.al/boostorg/graph) | [![Build Status](https://drone.cpp.al/api/badges/boostorg/graph/status.svg)](https:/drone.cpp.al/boostorg/graph) |
+    dijkstra_shortest_paths(g, vertex(0, g),
+        predecessor_map, distance_map,
+        costs_map, index_map,
+        std::less<int>(), std::plus<int>(),
+        std::numeric_limits<int>::max(), 0,
+        dijkstra_visitor<null_visitor>());
 
-## Development
+    for (auto v : make_iterator_range(vertices(g)))
+        std::cout << "distance to " << v << " = " << storage_dist[v] << "\n";
+}
+```
+```
+distance to 0 = 0
+distance to 1 = 1
+distance to 2 = 3
+distance to 3 = 4
+```
 
-Clone the whole boost project, which includes the individual Boost projects as submodules ([see boost+git doc](https://github.com/boostorg/boost/wiki/Getting-Started)):
+## Algorithms
 
-    git clone https://github.com/boostorg/boost
-    cd boost
-    git submodule update --init
+BGL ships dozens of graph algorithms: shortest paths (Dijkstra, Bellman-Ford, A*, Floyd-Warshall, Johnson), spanning trees (Kruskal, Prim), maximum flow (Edmonds-Karp, push-relabel, Boykov-Kolmogorov), traversal (BFS, DFS, topological sort), planarity testing, isomorphism, component decomposition, and more.
 
-The Boost Graph Library is located in `libs/graph/`.
+See the [full algorithm reference](https://becheler.github.io/graph/graph/algorithms/overview.html) for the complete catalogue.
 
-Boost Graph Library is mostly made of headers but also contains some compiled components. Here are the build commands:
+## Help and feedback
 
-    ./bootstrap.sh            <- compile b2
-    ./b2 headers              <- just installs headers
-    ./b2                      <- build compiled components
+* **[GitHub Issues](https://github.com/boostorg/graph/issues)** for bug reports. Search before opening a new one.
+* **[GitHub Discussions](https://github.com/boostorg/graph/discussions)** for questions, design ideas, and general conversation about the library.
+* **[Boost mailing list](http://lists.boost.org/mailman/listinfo.cgi/boost-users)** for general Boost development. Use the `[graph]` tag in the subject line.
+* **CppLang Slack** for real-time chat. [Request an invite](https://cppalliance.org/slack/), then join the `#boost` channel.
+* **Direct contact with maintainers**: see [CONTRIBUTING.md#maintainers](CONTRIBUTING.md#maintainers).
 
-**Note:** The Boost Graph Library cannot currently be built outside of Boost itself.
+## Using BGL
 
-### Running tests
-First, make sure you are in `libs/graph/test`.
-You can either run all the 300+ tests listed in `Jamfile.v2` or run a single test:
+Install Boost via your package manager:
 
-    ../../../b2                        <- run all tests
-    ../../../b2 cycle_canceling_test   <- single test
+| Manager | Command |
+|---|---|
+| [vcpkg](https://vcpkg.io) | `vcpkg install boost-graph` |
+| [Conan](https://conan.io) | `conan install --requires=boost/[*]` |
+| apt (Debian/Ubuntu) | `sudo apt install libboost-graph-dev` |
+| Homebrew (macOS) | `brew install boost` |
 
-You can also check the [regression tests reports](http://beta.boost.org/development/tests/develop/developer/graph.html).
+Then wire it into CMake:
+
+```cmake
+find_package(Boost REQUIRED COMPONENTS graph)
+target_link_libraries(my_app PRIVATE Boost::graph)
+```
+
+Most of BGL is header-only. Linking `Boost::graph` is only required for the GraphViz and GraphML parsers.
+
+## Building from source
+
+For working on BGL itself (building Boost from source, running the test suite), see [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security Policy
+
+Boost.Graph is a header-only C++ template library. Most issues that look
+like security problems are caused by misuse of the API, undefined behavior
+in caller code, or violating a documented precondition. Those should be
+filed as regular GitHub issues.
+
+If you believe you have found a genuine vulnerability in the library
+itself, please report it privately through GitHub's
+[private vulnerability reporting](https://github.com/boostorg/graph/security/advisories/new)
+rather than opening a public issue.
+
+Fixes land on the `develop` branch and ship with the next Boost release.
+No back-porting to older releases is guaranteed.

--- a/meta/libraries.json
+++ b/meta/libraries.json
@@ -11,7 +11,8 @@
         "Iterators"
     ],
     "maintainers": [
-        "Jeremy W. Murphy <jeremy.william.murphy -at- gmail.com>"
+        "Jeremy W. Murphy <jeremy.william.murphy -at- gmail.com>",
+        "Arnaud Becheler <arnaud.becheler -at- gmail.com>"
     ],
     "cxxstd": "14"
 }


### PR DESCRIPTION
## Summary

Adds the standard GitHub community files for Boost.Graph so that:

1. contributors land on clear templates and oriented towards actionable items
2. open ended conversations are oriented towards Github Discussions
3. the repo passes the [GitHub community profile check](https://github.com/boostorg/graph/community)

## What's added

### Repo-root community files

Those are required for the repo to pass the [GitHub community profile check](https://github.com/boostorg/graph/community):

- `README.md` refreshed for clarity and consistency
- `CONTRIBUTING.md` show how to build, test, and submit changes, it shows up automatically in Github contributions flows (issue or PR filed)
- `CODE_OF_CONDUCT.md` : Contributor Covenant 2.1 
- `SECURITY.md` : minimal. Reports via [GitHub private vulnerability reporting](https://github.com/boostorg/graph/security) that would need to be enabled.

### `.github/` plumbing

- `CODEOWNERS` : review routing so @jeremy-murphy and @Becheler are automatically assigned as reviewers (make code ownership clear to contributors but we can adjust notifications if this becomes overwhelming)
- `ISSUE_TEMPLATE/bug_report.md` : focused on actionable stuff.
- `ISSUE_TEMPLATE/feature_request.md` focus on actionable stuff, redirects to Discussions for open-ended stuff
- `ISSUE_TEMPLATE/documentation.md` for docs bugs, missing pages, broken examples.
- `ISSUE_TEMPLATE/config.yml` disables blank issues and redirects design questions to GitHub Discussions.
- `PULL_REQUEST_TEMPLATE.md` some checks for triaging and testing.
