### PR TITLE
remove narrowing conversion in `random.hpp`

### DIFF
--- a/include/boost/graph/random.hpp
+++ b/include/boost/graph/random.hpp
@@ -41,8 +41,9 @@ typename graph_traits< Graph >::vertex_descriptor random_vertex(
 #if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x581))
         std::size_t n = std::random(num_vertices(g));
 #else
-        uniform_int<> distrib(0, num_vertices(g) - 1);
-        variate_generator< RandomNumGen&, uniform_int<> > rand_gen(
+        using vertices_size_type = typename graph_traits< Graph >::vertices_size_type;
+        uniform_int< vertices_size_type > distrib(0, num_vertices(g) - 1);
+        variate_generator< RandomNumGen&, uniform_int< vertices_size_type > > rand_gen(
             gen, distrib);
         std::size_t n = rand_gen();
 #endif
@@ -63,10 +64,11 @@ typename graph_traits< Graph >::edge_descriptor random_edge(
         typename graph_traits< Graph >::edges_size_type n
             = std::random(num_edges(g));
 #else
-        uniform_int<> distrib(0, num_edges(g) - 1);
-        variate_generator< RandomNumGen&, uniform_int<> > rand_gen(
+        using edges_size_type = typename graph_traits< Graph >::edges_size_type;
+        uniform_int< edges_size_type > distrib(0, num_edges(g) - 1);
+        variate_generator< RandomNumGen&, uniform_int< edges_size_type > > rand_gen(
             gen, distrib);
-        typename graph_traits< Graph >::edges_size_type n = rand_gen();
+        edges_size_type n = rand_gen();
 #endif
         typename graph_traits< Graph >::edge_iterator i = edges(g).first;
         return *(boost::next(i, n));


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

Refs #496 

### Before submitting

- [x] This PR targets the `develop` branch.
- [ ] I searched for an existing PR or issue covering the same change.
- [ ] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [x] Bug fix
- [ ] New feature or API addition
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

<!-- A short summary of the change. -->

Remove narrowing conversion in random header.

### Motivation

<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->

Parameterize `uniform_int` on the graph's `size_type` to remove the `size_t` > `int` narrowing in `random_vertex`/`random_edge`, clearing the MSVC C4267 warnings and fixing latent truncation for graphs larger than `INT_MAX`.

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->

Same CI, less warnings:

| Job | Baseline (develop) | After fix | Δ |
|-----|--------------------|-----------|---|
| MSVC 14.3 | 1226 | 1097 | −129 |
| ubuntu gcc-14 (14/17/20/23) | 51 | 51 | 0 |
| ubuntu clang-19 (14/17/20/23) | 75 | 75 | 0 |
| macOS clang 14 | 75 | 75 | 0 |
| macOS clang 17 | 70 | 70 | 0 |
| macOS clang 20 | 70 | 70 | 0 |
| all cmake jobs | 0 | 0 | 0 |

### Checklist

- [x] Existing tests pass (`b2` in the `test/` directory).
- [x] New behavior is covered by a test, or this is a docs / build / refactor change.
- [x] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.
