### PR TITLE
remove narrowing conversion in `bandwidth.hpp`

### DIFF
--- a/include/boost/graph/bandwidth.hpp
+++ b/include/boost/graph/bandwidth.hpp
@@ -7,7 +7,7 @@
 #ifndef BOOST_GRAPH_BANDWIDTH_HPP
 #define BOOST_GRAPH_BANDWIDTH_HPP
 
-#include <algorithm> // for std::min and std::max
+#include <algorithm> // for std::max
 #include <boost/config.hpp>
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/properties.hpp>
@@ -22,17 +22,14 @@ typename graph_traits< Graph >::vertices_size_type ith_bandwidth(
     VertexIndexMap index)
 {
     BOOST_USING_STD_MAX();
-    using std::abs;
-    typedef
-        typename graph_traits< Graph >::vertices_size_type vertices_size_type;
+    using vertices_size_type = typename graph_traits< Graph >::vertices_size_type;
     vertices_size_type b = 0;
     typename graph_traits< Graph >::out_edge_iterator e, end;
     for (boost::tie(e, end) = out_edges(i, g); e != end; ++e)
     {
-        int f_i = get(index, i);
-        int f_j = get(index, target(*e, g));
-        b = max BOOST_PREVENT_MACRO_SUBSTITUTION(
-            b, vertices_size_type(abs(f_i - f_j)));
+        vertices_size_type f_i = get(index, i);
+        vertices_size_type f_j = get(index, target(*e, g));
+        b = max BOOST_PREVENT_MACRO_SUBSTITUTION( b, f_i < f_j ? f_j - f_i : f_i - f_j );
     }
     return b;
 }
@@ -49,17 +46,14 @@ typename graph_traits< Graph >::vertices_size_type bandwidth(
     const Graph& g, VertexIndexMap index)
 {
     BOOST_USING_STD_MAX();
-    using std::abs;
-    typedef
-        typename graph_traits< Graph >::vertices_size_type vertices_size_type;
+    using vertices_size_type = typename graph_traits< Graph >::vertices_size_type;
     vertices_size_type b = 0;
     typename graph_traits< Graph >::edge_iterator i, end;
     for (boost::tie(i, end) = edges(g); i != end; ++i)
     {
-        int f_i = get(index, source(*i, g));
-        int f_j = get(index, target(*i, g));
-        b = max BOOST_PREVENT_MACRO_SUBSTITUTION(
-            b, vertices_size_type(abs(f_i - f_j)));
+        vertices_size_type f_i = get(index, source(*i, g));
+        vertices_size_type f_j = get(index, target(*i, g));
+        b = max BOOST_PREVENT_MACRO_SUBSTITUTION( b, f_i < f_j ? f_j - f_i : f_i - f_j );
     }
     return b;
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

Refs #496 

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [x] Bug fix
- [ ] New feature or API addition
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

<!-- A short summary of the change. -->

Remove narrowing conversion in `bandwidth.hpp`

### Motivation

<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->

Too many warnings in MSVC.

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->

Same CI, less warnings:

| Job | Baseline (develop) | After fix | Δ |
|-----|--------------------|-----------|---|
| MSVC 14.3 | 1226 | 1190 | −36 |
| ubuntu gcc-14 (14/17/20/23) | 51 | 51 | 0 |
| ubuntu clang-19 (14/17/20/23) | 75 | 75 | 0 |
| macOS clang 14 | 75 | 75 | 0 |
| macOS clang 17 | 70 | 70 | 0 |
| macOS clang 20 | 70 | 70 | 0 |
| all cmake jobs | 0 | 0 | 0 |

### Checklist

- [x] Existing tests pass (`b2` in the `test/` directory).
- [x] New behavior is covered by a test, or this is a docs / build / refactor change.
- [x] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.
