### PR TITLE
generate warnings counts in PR comment

### DIFF
--- a/.github/scripts/warn_table.py
+++ b/.github/scripts/warn_table.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Print a markdown table comparing compiler-warning counts between two CI log archives.
+
+Usage: warn_table.py BASELINE.zip AFTER.zip
+
+A warning is a line matching 'file:line:col: warning:' (clang/gcc) or 'warning Cxxxx'
+(msvc). Linker, "N warnings generated" summary, and CI-runner lines are not counted.
+"""
+import re
+import sys
+import zipfile
+
+WARNING = re.compile(r":\d+:\d+: warning:|warning C\d+")
+
+
+def counts(zip_path):
+    """Map each CI job to its warning count, read from the run's log archive."""
+    result = {}
+    with zipfile.ZipFile(zip_path) as archive:
+        for entry in archive.namelist():
+            # Top-level per-job logs are named like "12_ubuntu (gcc-14, 14).txt".
+            if "/" in entry or not entry.endswith(".txt"):
+                continue
+            job = re.sub(r"^\d+_", "", entry[:-4])
+            log = archive.read(entry).decode("utf-8", "replace")
+            result[job] = sum(1 for line in log.splitlines() if WARNING.search(line))
+    return result
+
+
+def main(baseline_zip, after_zip):
+    baseline = counts(baseline_zip)
+    after = counts(after_zip)
+    print("| Job | Baseline | After | Delta |")
+    print("|-----|---------:|------:|------:|")
+    for job in sorted(baseline.keys() | after.keys()):
+        if "cmake" in job:  # cmake jobs build only the library, they never warn
+            continue
+        before = baseline.get(job, 0)
+        now = after.get(job, 0)
+        diff = now - before
+        delta = f"{diff:+d}" if diff else "0"
+        print(f"| {job} | {before} | {now} | {delta} |")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        sys.exit("usage: warn_table.py BASELINE.zip AFTER.zip")
+    main(sys.argv[1], sys.argv[2])

--- a/.github/workflows/warning-count-comment.yml
+++ b/.github/workflows/warning-count-comment.yml
@@ -1,0 +1,54 @@
+name: warning-count-comment
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  actions: read
+  pull-requests: write
+  contents: read
+
+jobs:
+  comment:
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      PR_RUN: ${{ github.event.workflow_run.id }}
+      HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download this PR run's log archive
+        run: gh api "repos/$REPO/actions/runs/$PR_RUN/logs" > pr-logs.zip
+
+      - name: Download latest successful develop run's log archive
+        run: |
+          DEV=$(gh run list --workflow CI --branch develop --status success \
+                  --limit 1 --json databaseId --jq '.[0].databaseId')
+          if [ -z "$DEV" ]; then echo "no develop baseline run found" >&2; exit 1; fi
+          echo "DEV_RUN=$DEV" >> "$GITHUB_ENV"
+          gh api "repos/$REPO/actions/runs/$DEV/logs" > base-logs.zip
+
+      - name: Generate table
+        run: |
+          {
+            echo "Compiler-warning counts vs \`develop\` (auto-generated)."
+            echo "PR run \`$PR_RUN\` vs develop run \`$DEV_RUN\` (\`${HEAD_SHA:0:10}\`)."
+            echo
+            python3 .github/scripts/warn_table.py base-logs.zip pr-logs.zip
+          } > table.md
+
+      - name: Resolve PR number
+        id: pr
+        run: echo "num=$(gh api "repos/$REPO/commits/$HEAD_SHA/pulls" --jq '.[0].number')" >> "$GITHUB_OUTPUT"
+
+      - name: Post or update sticky comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: warning-counts
+          number: ${{ steps.pr.outputs.num }}
+          path: table.md


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

Refs #496 

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [ ] Bug fix
- [ ] New feature or API addition
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [x] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

<!-- A short summary of the change. -->

Adds a new git workflow to
1. Download the logs from develop (baseline) and the current PR
2. Compare warnings counts before/after
3. Trigger a bot to publish the count table before/after/delta in the PR conversation

### Motivation

<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->

It's not trivial for contributors to have a clear vision of the impacts of their contributions on the total warning counts.

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->

1. I made my fork branch the default
2. I tested it triggers on a louvain fix 
3. the table is correctly published

See: https://github.com/Becheler/graph/pull/1#issuecomment-4642831194

That generates the following comment :

```
Compiler-warning counts vs `develop` (auto-generated).
PR run `27095071066` vs develop run `27060632166` (`21cd4df091`).

| Job | Baseline | After | Delta |
|-----|---------:|------:|------:|
| macos (clang, 14) | 75 | 48 | -27 |
| macos (clang, 17) | 70 | 43 | -27 |
| macos (clang, 20) | 70 | 43 | -27 |
| ubuntu (clang-19, 14) | 75 | 48 | -27 |
| ubuntu (clang-19, 17) | 75 | 48 | -27 |
| ubuntu (clang-19, 20) | 75 | 48 | -27 |
| ubuntu (clang-19, 23) | 75 | 48 | -27 |
| ubuntu (gcc-14, 14) | 51 | 33 | -18 |
| ubuntu (gcc-14, 17) | 51 | 33 | -18 |
| ubuntu (gcc-14, 20) | 51 | 33 | -18 |
| ubuntu (gcc-14, 23) | 51 | 33 | -18 |
| windows_msvc_14_3 (msvc-14.3) | 1226 | 1226 | 0 |

<!-- Sticky Pull Request Commentwarning-counts -->
```

### Checklist

- [x] Existing tests pass (`b2` in the `test/` directory).
- [x] New behavior is covered by a test, or this is a docs / build / refactor change.
- [x] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.
