### PR TITLE
Implement topological_sort_levels

### DIFF
--- a/doc/table_of_contents.html
+++ b/doc/table_of_contents.html
@@ -158,6 +158,7 @@
           <li>Other Core Algorithms
             <ol>
               <LI><A href="topological_sort.html"><tt>topological_sort</tt></A>
+              <LI><A href="topological_sort_levels.html"><tt>topological_sort_levels</tt></A>
               <li><a href="transitive_closure.html"><tt>transitive_closure</tt></a>
               <li><a href="lengauer_tarjan_dominator.htm"><tt>lengauer_tarjan_dominator_tree</tt></a></li>
             </ol>

--- a/doc/topological_sort_levels.html
+++ b/doc/topological_sort_levels.html
@@ -1,0 +1,174 @@
+<HTML>
+<!--
+     Distributed under the Boost Software License, Version 1.0.
+     (See accompanying file LICENSE_1_0.txt or copy at
+     http://www.boost.org/LICENSE_1_0.txt)
+  -->
+<Head>
+<Title>Boost Graph Library: Topological Sort into Levels</Title>
+<BODY BGCOLOR="#ffffff" LINK="#0000ee" TEXT="#000000" VLINK="#551a8b"
+        ALINK="#ff0000">
+<IMG SRC="../../../boost.png"
+     ALT="C++ Boost" width="277" height="86">
+
+<BR Clear>
+
+
+<H1><A NAME="sec:topological-sort-levels">
+<TT>topological_sort_levels</TT>
+</H1>
+
+<PRE>
+// Property-map form. Returns the number of levels.
+template &lt;typename VertexListGraph, typename LevelMap&gt;
+typename graph_traits&lt;VertexListGraph&gt;::vertices_size_type
+topological_sort_levels(const VertexListGraph&amp; g, LevelMap level);
+
+template &lt;typename VertexListGraph, typename LevelMap,
+          typename P, typename T, typename R&gt;
+typename graph_traits&lt;VertexListGraph&gt;::vertices_size_type
+topological_sort_levels(const VertexListGraph&amp; g, LevelMap level,
+    const bgl_named_params&lt;P, T, R&gt;&amp; params = <i>all defaults</i>);
+
+// Convenience form. Fills <tt>levels</tt> so that <tt>levels[k]</tt> contains
+// every vertex assigned to level <i>k</i>.
+template &lt;typename VertexListGraph&gt;
+void topological_sort_levels(const VertexListGraph&amp; g,
+    std::vector&lt;std::vector&lt;
+        typename graph_traits&lt;VertexListGraph&gt;::vertex_descriptor&gt; &gt;&amp; levels);
+
+template &lt;typename VertexListGraph, typename P, typename T, typename R&gt;
+void topological_sort_levels(const VertexListGraph&amp; g,
+    std::vector&lt;std::vector&lt;
+        typename graph_traits&lt;VertexListGraph&gt;::vertex_descriptor&gt; &gt;&amp; levels,
+    const bgl_named_params&lt;P, T, R&gt;&amp; params = <i>all defaults</i>);
+</PRE>
+
+<P>
+A variant of <a href="./topological_sort.html"><tt>topological_sort</tt></a>
+that groups vertices into levels rather than producing a single linear
+ordering. Following BGL's edge convention, an edge <i>(u, v)</i> means <i>u</i>
+must precede <i>v</i>; equivalently <i>level(u) &lt; level(v)</i>. Level 0
+contains every vertex with no incoming edges. For <i>k &gt; 0</i>, level
+<i>k</i> contains every vertex whose deepest predecessor lies at level
+<i>k - 1</i>.
+</P>
+
+<P>
+The graph must be a directed acyclic graph (DAG). If it contains a cycle a
+<a href="./exception.html#not_a_dag"><tt>not_a_dag</tt></a> exception is
+thrown.
+</P>
+
+<P>
+Note on direction: <a href="./topological_sort.html"><tt>topological_sort</tt></a>
+emits its output in <b>reverse</b> topological order (sinks first when read in
+iteration order) and most users reverse the result to consume it forward.
+<tt>topological_sort_levels</tt> writes levels forward natively: <tt>levels[0]</tt>
+holds the sources and <tt>levels[n-1]</tt> the sinks.
+</P>
+
+<P>
+The implementation is Kahn's algorithm: it scans out-edges once to compute
+in-degrees, then peels off zero-in-degree vertices in waves.
+</P>
+
+<h3>Where Defined:</h3>
+<a href="../../../boost/graph/topological_sort_levels.hpp"><TT>boost/graph/topological_sort_levels.hpp</TT></a>
+
+<h3>Parameters</h3>
+
+IN: <tt>const VertexListGraph&amp; g</tt>
+<blockquote>
+  A directed acyclic graph (DAG). The graph type must be a model of
+  <a href="./VertexListGraph.html">Vertex List Graph</a> and
+  <a href="./IncidenceGraph.html">Incidence Graph</a>.
+  If the graph is not a DAG, a
+  <a href="./exception.html#not_a_dag"><tt>not_a_dag</tt></a> exception is
+  thrown and the contents of the output parameter are unspecified.
+</blockquote>
+
+OUT: <tt>LevelMap level</tt>
+<blockquote>
+  After the call, <tt>get(level, v)</tt> is the level of vertex <i>v</i>.
+  Must be a model of
+  <a href="../../property_map/doc/ReadWritePropertyMap.html">Read/Write
+  Property Map</a> whose key type is the graph's vertex descriptor and whose
+  value type is convertible from
+  <tt>graph_traits&lt;VertexListGraph&gt;::vertices_size_type</tt>.
+</blockquote>
+
+OUT: <tt>std::vector&lt;std::vector&lt;vertex_descriptor&gt; &gt;&amp; levels</tt>
+<blockquote>
+  (Convenience overload.) Resized to hold one inner vector per level. On
+  return, <tt>levels[k]</tt> contains every vertex at level <i>k</i>. The
+  order of vertices within a level is unspecified.
+</blockquote>
+
+<h3>Named Parameters</h3>
+
+IN: <tt>vertex_index_map(VertexIndexMap i_map)</tt>
+<blockquote>
+  Maps each vertex to an integer in <tt>[0, num_vertices(g))</tt>, used
+  internally to store running in-degrees. The type must be a model of
+  <a href="../../property_map/doc/ReadablePropertyMap.html">Readable Property
+  Map</a> whose key type is the graph's vertex descriptor and whose value
+  type is an integer.<br>
+  <b>Default:</b> <tt>get(vertex_index, g)</tt>. If you use this default,
+  make sure your graph has an internal <tt>vertex_index</tt> property
+  (e.g. <tt>adjacency_list&lt;…, vecS, …&gt;</tt>).
+</blockquote>
+
+<H3>Return Value</H3>
+
+The property-map overloads return the number of levels (one more than the
+longest path length in the DAG, or 0 if the graph is empty).
+
+<H3>Complexity</H3>
+
+<i>O(V + E)</i> time and <i>O(V)</i> auxiliary space.
+
+<H3>Example</H3>
+
+<P>
+A diamond DAG with edges <i>0 &rarr; 1, 0 &rarr; 2, 1 &rarr; 3, 2 &rarr; 3</i>
+has three levels: <i>{0}, {1, 2}, {3}</i>.
+</P>
+
+<PRE>
+  typedef boost::adjacency_list&lt;boost::vecS, boost::vecS, boost::directedS&gt; Graph;
+  typedef boost::graph_traits&lt;Graph&gt;::vertex_descriptor Vertex;
+
+  Graph g(4);
+  add_edge(0, 1, g);
+  add_edge(0, 2, g);
+  add_edge(1, 3, g);
+  add_edge(2, 3, g);
+
+  std::vector&lt;std::vector&lt;Vertex&gt; &gt; levels;
+  boost::topological_sort_levels(g, levels);
+
+  for (std::size_t k = 0; k &lt; levels.size(); ++k) {
+    std::cout &lt;&lt; "level " &lt;&lt; k &lt;&lt; ":";
+    for (std::size_t i = 0; i &lt; levels[k].size(); ++i)
+      std::cout &lt;&lt; ' ' &lt;&lt; levels[k][i];
+    std::cout &lt;&lt; '\n';
+  }
+</PRE>
+The output is:
+<PRE>
+  level 0: 0
+  level 1: 1 2
+  level 2: 3
+</PRE>
+
+<P>
+Motivation:
+<a href="https://github.com/boostorg/graph/issues/240">issue&nbsp;#240</a>.
+</P>
+
+<br>
+<HR>
+
+</BODY>
+</HTML>

--- a/include/boost/graph/topological_sort_levels.hpp
+++ b/include/boost/graph/topological_sort_levels.hpp
@@ -1,0 +1,195 @@
+//
+//=======================================================================
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//=======================================================================
+//
+#ifndef BOOST_GRAPH_TOPOLOGICAL_SORT_LEVELS_HPP
+#define BOOST_GRAPH_TOPOLOGICAL_SORT_LEVELS_HPP
+
+#include <vector>
+#include <boost/config.hpp>
+#include <boost/tuple/tuple.hpp>
+#include <boost/property_map/property_map.hpp>
+#include <boost/graph/graph_traits.hpp>
+#include <boost/graph/properties.hpp>
+#include <boost/graph/named_function_params.hpp>
+#include <boost/graph/exception.hpp>
+#include <boost/throw_exception.hpp>
+
+namespace boost
+{
+
+// Topological Sort into Levels
+//
+// Like topological_sort, but groups vertices by "level" rather than producing
+// a single linear ordering. Level 0 contains every vertex with no incoming
+// edges; level k > 0 contains every vertex whose longest incoming path comes
+// from a vertex at level k - 1.
+//
+// Edge convention follows the rest of BGL: an edge (u, v) means u must
+// precede v, so level(u) < level(v). Level numbering runs forward, from
+// sources at level 0 to sinks at the highest level.
+//
+// Implemented via Kahn's algorithm. Same concept requirements as
+// topological_sort: VertexListGraph + IncidenceGraph.
+
+namespace detail
+{
+
+    template < typename VertexListGraph, typename LevelMap,
+        typename VertexIndexMap >
+    typename graph_traits< VertexListGraph >::vertices_size_type
+    topological_sort_levels_impl(
+        const VertexListGraph& g, LevelMap level, VertexIndexMap index_map)
+    {
+        typedef typename graph_traits< VertexListGraph >::vertex_descriptor
+            Vertex;
+        typedef typename graph_traits< VertexListGraph >::vertices_size_type
+            size_type;
+        typedef typename graph_traits< VertexListGraph >::vertex_iterator
+            vertex_iter;
+        typedef typename graph_traits< VertexListGraph >::out_edge_iterator
+            out_edge_iter;
+
+        const size_type n = num_vertices(g);
+        std::vector< size_type > in_degree(n, 0);
+
+        vertex_iter vi, vi_end;
+        for (boost::tie(vi, vi_end) = vertices(g); vi != vi_end; ++vi)
+        {
+            out_edge_iter ei, ei_end;
+            for (boost::tie(ei, ei_end) = out_edges(*vi, g); ei != ei_end;
+                 ++ei)
+            {
+                ++in_degree[get(index_map, target(*ei, g))];
+            }
+        }
+
+        std::vector< Vertex > current_level;
+        for (boost::tie(vi, vi_end) = vertices(g); vi != vi_end; ++vi)
+        {
+            if (in_degree[get(index_map, *vi)] == 0)
+            {
+                current_level.push_back(*vi);
+                put(level, *vi, size_type(0));
+            }
+        }
+
+        size_type total_emitted = current_level.size();
+        size_type level_count = current_level.empty() ? size_type(0)
+                                                      : size_type(1);
+
+        std::vector< Vertex > next_level;
+        while (!current_level.empty())
+        {
+            next_level.clear();
+            for (typename std::vector< Vertex >::const_iterator it
+                 = current_level.begin();
+                 it != current_level.end(); ++it)
+            {
+                out_edge_iter ei, ei_end;
+                for (boost::tie(ei, ei_end) = out_edges(*it, g); ei != ei_end;
+                     ++ei)
+                {
+                    Vertex v = target(*ei, g);
+                    size_type vidx = get(index_map, v);
+                    if (--in_degree[vidx] == 0)
+                    {
+                        next_level.push_back(v);
+                        put(level, v, level_count);
+                    }
+                }
+            }
+            if (!next_level.empty())
+            {
+                ++level_count;
+                total_emitted += next_level.size();
+            }
+            current_level.swap(next_level);
+        }
+
+        if (total_emitted != n)
+        {
+            BOOST_THROW_EXCEPTION(not_a_dag());
+        }
+
+        return level_count;
+    }
+
+    template < typename VertexListGraph, typename VertexIndexMap >
+    void topological_sort_levels_to_buckets(const VertexListGraph& g,
+        VertexIndexMap index_map,
+        std::vector< std::vector< typename graph_traits<
+            VertexListGraph >::vertex_descriptor > >& levels)
+    {
+        typedef typename graph_traits< VertexListGraph >::vertices_size_type
+            size_type;
+
+        std::vector< size_type > level_of(num_vertices(g), size_type(0));
+
+        const size_type num_levels = topological_sort_levels_impl(g,
+            make_iterator_property_map(level_of.begin(), index_map),
+            index_map);
+
+        levels.clear();
+        levels.resize(num_levels);
+
+        typename graph_traits< VertexListGraph >::vertex_iterator vi, vi_end;
+        for (boost::tie(vi, vi_end) = vertices(g); vi != vi_end; ++vi)
+        {
+            levels[level_of[get(index_map, *vi)]].push_back(*vi);
+        }
+    }
+
+} // namespace detail
+
+// Property-map form. Writes level[v] = k for every vertex v and returns the
+// number of levels. LevelMap must be a writable property map keyed on the
+// graph's vertex descriptor with a value type convertible from
+// vertices_size_type.
+template < typename VertexListGraph, typename LevelMap, typename P, typename T,
+    typename R >
+typename graph_traits< VertexListGraph >::vertices_size_type
+topological_sort_levels(const VertexListGraph& g, LevelMap level,
+    const bgl_named_params< P, T, R >& params)
+{
+    return detail::topological_sort_levels_impl(g, level,
+        choose_const_pmap(get_param(params, vertex_index), g, vertex_index));
+}
+
+template < typename VertexListGraph, typename LevelMap >
+typename graph_traits< VertexListGraph >::vertices_size_type
+topological_sort_levels(const VertexListGraph& g, LevelMap level)
+{
+    return topological_sort_levels(
+        g, level, bgl_named_params< int, buffer_param_t >(0));
+}
+
+// Convenience form. Resizes <tt>levels</tt> to hold one inner vector per
+// level; on return, <tt>levels[k]</tt> contains every vertex assigned to
+// level k.
+template < typename VertexListGraph, typename P, typename T, typename R >
+void topological_sort_levels(const VertexListGraph& g,
+    std::vector< std::vector< typename graph_traits<
+        VertexListGraph >::vertex_descriptor > >& levels,
+    const bgl_named_params< P, T, R >& params)
+{
+    detail::topological_sort_levels_to_buckets(g,
+        choose_const_pmap(get_param(params, vertex_index), g, vertex_index),
+        levels);
+}
+
+template < typename VertexListGraph >
+void topological_sort_levels(const VertexListGraph& g,
+    std::vector< std::vector< typename graph_traits<
+        VertexListGraph >::vertex_descriptor > >& levels)
+{
+    topological_sort_levels(
+        g, levels, bgl_named_params< int, buffer_param_t >(0));
+}
+
+} // namespace boost
+
+#endif // BOOST_GRAPH_TOPOLOGICAL_SORT_LEVELS_HPP

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -174,6 +174,7 @@ alias graph_test_regular :
     [ run delete_edge.cpp ]
     [ run johnson-test.cpp ]
     [ run lvalue_pmap.cpp ]
+    [ run topological_sort_levels_test.cpp ]
     ;
 
 alias graph_test_with_filesystem : :

--- a/test/topological_sort_levels_test.cpp
+++ b/test/topological_sort_levels_test.cpp
@@ -1,0 +1,285 @@
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <algorithm>
+#include <utility>
+#include <vector>
+
+#include <boost/core/lightweight_test.hpp>
+#include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/exception.hpp>
+#include <boost/graph/topological_sort_levels.hpp>
+#include <boost/property_map/vector_property_map.hpp>
+
+typedef boost::adjacency_list< boost::vecS, boost::vecS, boost::directedS >
+    Graph;
+typedef boost::graph_traits< Graph >::vertex_descriptor Vertex;
+
+// Check that the level assignment is consistent with the graph: for every
+// edge (u, v) the level of u must be strictly less than the level of v,
+// and levels are tight (any vertex above level 0 has a predecessor exactly
+// one level below).
+template < typename G, typename Levels >
+static void check_levels_are_tight(const G& g, const Levels& levels)
+{
+    std::vector< std::size_t > level_of(num_vertices(g), 0);
+    for (std::size_t k = 0; k < levels.size(); ++k)
+    {
+        for (std::size_t i = 0; i < levels[k].size(); ++i)
+        {
+            level_of[levels[k][i]] = k;
+        }
+    }
+
+    std::size_t total = 0;
+    for (std::size_t k = 0; k < levels.size(); ++k)
+        total += levels[k].size();
+    BOOST_TEST_EQ(total, num_vertices(g));
+
+    typename boost::graph_traits< G >::edge_iterator ei, ei_end;
+    for (boost::tie(ei, ei_end) = edges(g); ei != ei_end; ++ei)
+    {
+        const std::size_t su = level_of[source(*ei, g)];
+        const std::size_t sv = level_of[target(*ei, g)];
+        BOOST_TEST_LT(su, sv);
+    }
+
+    for (std::size_t k = 1; k < levels.size(); ++k)
+    {
+        for (std::size_t i = 0; i < levels[k].size(); ++i)
+        {
+            const Vertex v = levels[k][i];
+            bool has_predecessor_at_prev_level = false;
+            typename boost::graph_traits< G >::edge_iterator e, e_end;
+            for (boost::tie(e, e_end) = edges(g); e != e_end; ++e)
+            {
+                if (target(*e, g) == v && level_of[source(*e, g)] == k - 1)
+                {
+                    has_predecessor_at_prev_level = true;
+                    break;
+                }
+            }
+            BOOST_TEST(has_predecessor_at_prev_level);
+        }
+    }
+}
+
+// Vertices 0..3 with edges 0->1, 0->2, 1->3, 2->3 form a diamond.
+// Following BGL's edge convention (u -> v means u precedes v in topological
+// order), the expected levels are {0}, {1, 2}, {3}.
+static void test_diamond()
+{
+    Graph g(4);
+    add_edge(0, 1, g);
+    add_edge(0, 2, g);
+    add_edge(1, 3, g);
+    add_edge(2, 3, g);
+
+    std::vector< std::vector< Vertex > > levels;
+    boost::topological_sort_levels(g, levels);
+
+    BOOST_TEST_EQ(levels.size(), std::size_t(3));
+    BOOST_TEST_EQ(levels[0].size(), std::size_t(1));
+    BOOST_TEST_EQ(levels[0][0], Vertex(0));
+    BOOST_TEST_EQ(levels[1].size(), std::size_t(2));
+    BOOST_TEST(std::find(levels[1].begin(), levels[1].end(), Vertex(1))
+        != levels[1].end());
+    BOOST_TEST(std::find(levels[1].begin(), levels[1].end(), Vertex(2))
+        != levels[1].end());
+    BOOST_TEST_EQ(levels[2].size(), std::size_t(1));
+    BOOST_TEST_EQ(levels[2][0], Vertex(3));
+
+    check_levels_are_tight(g, levels);
+}
+
+static void test_empty()
+{
+    Graph g(0);
+    std::vector< std::vector< Vertex > > levels;
+    boost::topological_sort_levels(g, levels);
+    BOOST_TEST_EQ(levels.size(), std::size_t(0));
+}
+
+static void test_single_vertex()
+{
+    Graph g(1);
+    std::vector< std::vector< Vertex > > levels;
+    boost::topological_sort_levels(g, levels);
+    BOOST_TEST_EQ(levels.size(), std::size_t(1));
+    BOOST_TEST_EQ(levels[0].size(), std::size_t(1));
+    BOOST_TEST_EQ(levels[0][0], Vertex(0));
+}
+
+static void test_isolated_vertices()
+{
+    Graph g(5);
+    std::vector< std::vector< Vertex > > levels;
+    boost::topological_sort_levels(g, levels);
+    BOOST_TEST_EQ(levels.size(), std::size_t(1));
+    BOOST_TEST_EQ(levels[0].size(), std::size_t(5));
+}
+
+static void test_chain()
+{
+    Graph g(5);
+    add_edge(0, 1, g);
+    add_edge(1, 2, g);
+    add_edge(2, 3, g);
+    add_edge(3, 4, g);
+
+    std::vector< std::vector< Vertex > > levels;
+    boost::topological_sort_levels(g, levels);
+
+    BOOST_TEST_EQ(levels.size(), std::size_t(5));
+    for (std::size_t k = 0; k < levels.size(); ++k)
+    {
+        BOOST_TEST_EQ(levels[k].size(), std::size_t(1));
+        BOOST_TEST_EQ(levels[k][0], Vertex(k));
+    }
+}
+
+static void test_disconnected_components()
+{
+    // Two independent chains: 0->1->2 and 3->4
+    Graph g(5);
+    add_edge(0, 1, g);
+    add_edge(1, 2, g);
+    add_edge(3, 4, g);
+
+    std::vector< std::vector< Vertex > > levels;
+    boost::topological_sort_levels(g, levels);
+
+    BOOST_TEST_EQ(levels.size(), std::size_t(3));
+    BOOST_TEST_EQ(levels[0].size(), std::size_t(2));
+    BOOST_TEST_EQ(levels[1].size(), std::size_t(2));
+    BOOST_TEST_EQ(levels[2].size(), std::size_t(1));
+    BOOST_TEST_EQ(levels[2][0], Vertex(2));
+
+    check_levels_are_tight(g, levels);
+}
+
+static void test_long_edge_skips_levels()
+{
+    // 0->1, 0->2, 1->2: vertex 2 has predecessors at both level 0 and level 1,
+    // so it must land at level 2, not level 1.
+    Graph g(3);
+    add_edge(0, 1, g);
+    add_edge(0, 2, g);
+    add_edge(1, 2, g);
+
+    std::vector< std::vector< Vertex > > levels;
+    boost::topological_sort_levels(g, levels);
+
+    BOOST_TEST_EQ(levels.size(), std::size_t(3));
+    BOOST_TEST_EQ(levels[0][0], Vertex(0));
+    BOOST_TEST_EQ(levels[1][0], Vertex(1));
+    BOOST_TEST_EQ(levels[2][0], Vertex(2));
+}
+
+static void test_cycle_throws()
+{
+    Graph g(3);
+    add_edge(0, 1, g);
+    add_edge(1, 2, g);
+    add_edge(2, 0, g);
+
+    std::vector< std::vector< Vertex > > levels;
+    bool threw = false;
+    try
+    {
+        boost::topological_sort_levels(g, levels);
+    }
+    catch (const boost::not_a_dag&)
+    {
+        threw = true;
+    }
+    BOOST_TEST(threw);
+}
+
+static void test_self_loop_throws()
+{
+    Graph g(1);
+    add_edge(0, 0, g);
+
+    std::vector< std::vector< Vertex > > levels;
+    bool threw = false;
+    try
+    {
+        boost::topological_sort_levels(g, levels);
+    }
+    catch (const boost::not_a_dag&)
+    {
+        threw = true;
+    }
+    BOOST_TEST(threw);
+}
+
+static void test_property_map_form()
+{
+    Graph g(4);
+    add_edge(0, 1, g);
+    add_edge(0, 2, g);
+    add_edge(1, 3, g);
+    add_edge(2, 3, g);
+
+    boost::vector_property_map< std::size_t > level_map(num_vertices(g));
+    const std::size_t num_levels = boost::topological_sort_levels(g, level_map);
+
+    BOOST_TEST_EQ(num_levels, std::size_t(3));
+    BOOST_TEST_EQ(level_map[0], std::size_t(0));
+    BOOST_TEST_EQ(level_map[1], std::size_t(1));
+    BOOST_TEST_EQ(level_map[2], std::size_t(1));
+    BOOST_TEST_EQ(level_map[3], std::size_t(2));
+}
+
+static void test_named_param_vertex_index()
+{
+    Graph g(4);
+    add_edge(0, 1, g);
+    add_edge(0, 2, g);
+    add_edge(1, 3, g);
+    add_edge(2, 3, g);
+
+    boost::vector_property_map< std::size_t > level_map(num_vertices(g));
+    const std::size_t num_levels = boost::topological_sort_levels(g, level_map,
+        boost::vertex_index_map(get(boost::vertex_index, g)));
+
+    BOOST_TEST_EQ(num_levels, std::size_t(3));
+    BOOST_TEST_EQ(level_map[0], std::size_t(0));
+    BOOST_TEST_EQ(level_map[3], std::size_t(2));
+}
+
+static void test_named_param_convenience_form()
+{
+    Graph g(4);
+    add_edge(0, 1, g);
+    add_edge(0, 2, g);
+    add_edge(1, 3, g);
+    add_edge(2, 3, g);
+
+    std::vector< std::vector< Vertex > > levels;
+    boost::topological_sort_levels(g, levels,
+        boost::vertex_index_map(get(boost::vertex_index, g)));
+
+    BOOST_TEST_EQ(levels.size(), std::size_t(3));
+    BOOST_TEST_EQ(levels[0][0], Vertex(0));
+    BOOST_TEST_EQ(levels[2][0], Vertex(3));
+}
+
+int main(int, char*[])
+{
+    test_diamond();
+    test_empty();
+    test_single_vertex();
+    test_isolated_vertices();
+    test_chain();
+    test_disconnected_components();
+    test_long_edge_skips_levels();
+    test_cycle_throws();
+    test_self_loop_throws();
+    test_property_map_form();
+    test_named_param_vertex_index();
+    test_named_param_convenience_form();
+    return boost::report_errors();
+}


### PR DESCRIPTION
This phab implements issue #240 .  Please note that I'm not a frequent contributor, and I may have made some noob mistakes.  Also, I used Claude to write this.  LMK if that's a foul.

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [ ] Bug fix
- [x] New feature or API addition
- [ ] Refactor (no behavior change)
- [x] Documentation
- [ ] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

Adds functions to toposort into levels.  There's a lower level function that uses a property map to output the vertex levels and a vector<vector> shorthand.

### Motivation

Fixes issue #240 

### Testing

I added new tests.  Here's what I ran
```
$ (cd libs/graph/test && ../../../b2 topological_sort_levels_test)
Performing configuration checks

    - default address-model    : 64-bit (cached) [1]
    - default architecture     : x86 (cached) [1]
    - symlinks supported       : yes (cached)

[1] gcc-10
...patience...
...patience...
...found 2402 targets...
...updating 4 targets...
gcc.compile.c++ ../../../bin.v2/libs/graph/test/topological_sort_levels_test.test/gcc-10/debug/x86_64/threading-multi/visibility-hidden/topological_sort_levels_test.o
gcc.link ../../../bin.v2/libs/graph/test/topological_sort_levels_test.test/gcc-10/debug/x86_64/threading-multi/visibility-hidden/topological_sort_levels_test
testing.capture-output ../../../bin.v2/libs/graph/test/topological_sort_levels_test.test/gcc-10/debug/x86_64/threading-multi/visibility-hidden/topological_sort_levels_test.run
**passed** ../../../bin.v2/libs/graph/test/topological_sort_levels_test.test/gcc-10/debug/x86_64/threading-multi/visibility-hidden/topological_sort_levels_test.test

...updated 4 targets...
```

### Checklist

- [x] Existing tests pass (`b2` in the `test/` directory).
- [x] New behavior is covered by a test, or this is a docs / build / refactor change.
- [x] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.
