### PR TITLE
Personalized page rank

### DIFF
--- a/include/boost/graph/personalized_page_rank.hpp
+++ b/include/boost/graph/personalized_page_rank.hpp
@@ -185,7 +185,7 @@ namespace graph
                 }
                 l1_norm += l1_accumulated_norm;
             }
-            BGL_FORALL_VERTICES_T(v, g, Graph) put(to_rank, v, get(to_rank, v)/l1_norm);
+            for (auto v : boost::make_iterator_range(vertices(g))) put(to_rank, v, get(to_rank, v)/l1_norm);
         }
 
         template <
@@ -194,7 +194,7 @@ namespace graph
             typename PersonalizationMap,
             typename RankMap,
             typename RankMap2 >
-        void page_rank_step(
+        void personalized_page_rank_step(
             const Graph& g,
             WeightMap weight_map,
             PersonalizationMap personalization_map,
@@ -205,15 +205,16 @@ namespace graph
         {
             typedef typename property_traits< RankMap >::value_type damping_type;
             damping_type l1_norm(0); // Computing the norm simultaneously avoids an extra summing iteration.
-            BGL_FORALL_VERTICES_T(v, g, Graph)
+            for (auto v : boost::make_iterator_range(vertices(g)))
             {
                 typename property_traits< RankMap >::value_type rank(0);
-                BGL_FORALL_INEDGES_T(v, e, g, Graph) rank += get(from_rank, source(e, g))*get(weight_map, e);//get(from_rank, source(e, g)) / out_degree(source(e, g), g);
+                for (auto e : boost::make_iterator_range(in_edges(v, g))) 
+                    rank += get(from_rank, source(e, g))*get(weight_map, e);
                 auto v_score = (damping_type(1) - damping) * get(personalization_map, v) + damping * rank;
                 put(to_rank, v, v_score);
                 l1_norm += v_score;
             }
-            BGL_FORALL_VERTICES_T(v, g, Graph) put(to_rank, v, get(to_rank, v)/l1_norm);
+            for (auto v : boost::make_iterator_range(vertices(g))) put(to_rank, v, get(to_rank, v)/l1_norm);
         }
     } // end namespace detail
 
@@ -238,12 +239,12 @@ namespace graph
         typedef typename property_traits< PersonalizationMap >::value_type rank_type;
 
         rank_type personalization_norm(0);
-        BGL_FORALL_VERTICES_T(v, g, Graph) personalization_norm += get(personalization_map, v);
+        for (auto v : boost::make_iterator_range(vertices(g))) personalization_norm += get(personalization_map, v);
 
         // TBD: This implementation couples iterators when possible under reduced L1 cache invalidation assumptions,
         // but this is not necessarily the case because we may be grabbing 2x memory lanes each time to write there.
         // Should investigate which pattern is faster.
-        BGL_FORALL_VERTICES_T(v, g, Graph)
+        for (auto v : boost::make_iterator_range(vertices(g)))
         {
             rank_type value = get(personalization_map, v)/personalization_norm;
             put(personalization_map, v, value);

--- a/include/boost/graph/personalized_page_rank.hpp
+++ b/include/boost/graph/personalized_page_rank.hpp
@@ -22,125 +22,23 @@ namespace boost
 {
 namespace graph
 {
-    namespace personalized_page_rank_detail
+    struct rank_convergence
     {
-        template < typename Graph>
-        std::size_t in_or_out_degree(
-            typename boost::graph_traits<Graph>::vertex_descriptor v,
-            const Graph& g,
-            bidirectional_graph_tag)
-        {
-            return in_degree(v, g);
-        }
-        template < typename Graph>
-        std::size_t in_or_out_degree(
-            typename boost::graph_traits<Graph>::vertex_descriptor v,
-            const Graph& g,
-            incidence_graph_tag)
-        {
-            return out_degree(v, g);
-        }
-    }
-
-    template <typename Graph>
-    boost::function_property_map<
-        std::function<double(typename boost::graph_traits<Graph>::edge_descriptor)>,
-        typename boost::graph_traits<Graph>::edge_descriptor>
-    markovian_weights(const Graph& g)
-    {
-        using Edge = typename boost::graph_traits<Graph>::edge_descriptor;
-        using Func = std::function<double(Edge)>;
-        Func f = [&g](Edge e)
-        {
-            auto u = source(e, g);
-            std::size_t denom;
-            denom = out_degree(u, g) ;
-            return 1.0 / denom;
-        };
-        return make_function_property_map<Edge, double>(f);
-    }
-
-    template <typename Graph>
-    boost::function_property_map<
-        std::function<double(typename boost::graph_traits<Graph>::edge_descriptor)>,
-        typename boost::graph_traits<Graph>::edge_descriptor>
-    spectral_weights(const Graph& g)
-    {
-        using Edge = typename boost::graph_traits<Graph>::edge_descriptor;
-        using Func = std::function<double(Edge)>;
-        Func f = [&g](Edge e)
-        {
-            typedef typename boost::graph_traits<Graph>::traversal_category category;
-            auto u = source(e, g);
-            auto v = target(e, g);
-            std::size_t denom;
-            denom = out_degree(u, g) * personalized_page_rank_detail::in_or_out_degree(v, g, category());
-            return 1.0 / std::sqrt(denom);
-        };
-        return make_function_property_map<Edge, double>(f);
-    }
-
-    template <typename Graph>
-    boost::function_property_map<
-        std::function<double(typename boost::graph_traits<Graph>::edge_descriptor)>,
-        typename boost::graph_traits<Graph>::edge_descriptor>
-    renormalized_weights(const Graph& g)
-    {
-        using Edge = typename boost::graph_traits<Graph>::edge_descriptor;
-        using Func = std::function<double(Edge)>;
-        Func f = [&g](Edge e)
-        {
-            typedef typename boost::graph_traits<Graph>::traversal_category category;
-            auto u = source(e, g);
-            auto v = target(e, g);
-            std::size_t denom;
-            denom = (1+out_degree(u, g)) * (1+personalized_page_rank_detail::in_or_out_degree(v, g, category()));
-            return 1.0 / std::sqrt(denom);
-        };
-        return make_function_property_map<Edge, double>(f);
-    }
-
-    struct vertex_map_convergence
-    {
-        explicit vertex_map_convergence(std::size_t n, double tol=0) : n(n), tol(tol) {} // allowing tolerance for early stopping
-
+        explicit rank_convergence(std::size_t iters, double tol=0) : iters(iters), tol(tol) {} // allowing tolerance for early stopping
         template < typename RankMap, typename RankMap2, typename Graph >
-        bool operator()(
-            const RankMap& current,
-            const RankMap2& previous,
-            const Graph& g)
+        bool operator()(const RankMap& current, const RankMap2& previous, const Graph& g)
         {
-            if ( n-- == 0 )
-            {
+            if (--iters == 0)
                 return true;
-            }
             if (!tol)
-            {
                 return false;
-            }
-
-            typedef typename property_traits< RankMap >::value_type rank_type;
+            using rank_type = typename property_traits< RankMap >::value_type;
             rank_type sum_abs(0);
             for (auto v : boost::make_iterator_range(vertices(g)))
-            {
-                rank_type difference = get(current, v)-get(previous, v);
-                sum_abs += std::abs(difference);
-            }
+                sum_abs += std::abs(get(current, v) - get(previous, v));
             return sum_abs*num_vertices(g)<tol;
         }
-
-        std::size_t get_remaining_iters() const
-        {
-            return n;
-        }
-
-        bool has_converged() const 
-        {
-            return n || !tol;
-        }
-
-    private:
-        std::size_t n;
+        std::size_t iters;
         double tol;
     };
 
@@ -161,17 +59,18 @@ namespace graph
             typename property_traits< RankMap >::value_type damping,
             incidence_graph_tag)
         {
-            typedef typename property_traits< RankMap >::value_type rank_type;
+            using rank_type = typename property_traits< RankMap >::value_type;
             rank_type l1_norm(0); // Computing the norm simultaneously avoids an extra summing iteration.
 
-            // Initialize the constant part of maps
+            // Initialize the constant part of maps.
             for (auto v : boost::make_iterator_range(vertices(g))) 
             {
                 auto v_constant = rank_type(1 - damping) * get(personalization_map, v);
                 put(to_rank, v, v_constant);
                 l1_norm += v_constant;
             }
-
+            
+            // Maintenance comment:
             for (auto u : boost::make_iterator_range(vertices(g)))
             {
                 rank_type u_rank_factor = damping * get(from_rank, u);
@@ -185,7 +84,11 @@ namespace graph
                 }
                 l1_norm += l1_accumulated_norm;
             }
-            for (auto v : boost::make_iterator_range(vertices(g))) put(to_rank, v, get(to_rank, v)/l1_norm);
+            // If there are negative edge weights, or if negative damping is used, l1_norm could be zero or near-zero. 
+            // Division in those cases is conceptually correct for floating point weights, and actually expected behavior. 
+            // That said, such edge cases are impossible to arise for all typical algorithm uses.
+            for (auto v : boost::make_iterator_range(vertices(g))) 
+                put(to_rank, v, get(to_rank, v)/l1_norm); 
         }
 
         template <
@@ -203,20 +106,22 @@ namespace graph
             typename property_traits< RankMap >::value_type damping,
             bidirectional_graph_tag)
         {
-            typedef typename property_traits< RankMap >::value_type damping_type;
+            using damping_type = typename property_traits< RankMap >::value_type;
             damping_type l1_norm(0); // Computing the norm simultaneously avoids an extra summing iteration.
             for (auto v : boost::make_iterator_range(vertices(g)))
             {
-                typename property_traits< RankMap >::value_type rank(0);
+                damping_type rank(0);
                 for (auto e : boost::make_iterator_range(in_edges(v, g))) 
                     rank += get(from_rank, source(e, g))*get(weight_map, e);
                 auto v_score = (damping_type(1) - damping) * get(personalization_map, v) + damping * rank;
                 put(to_rank, v, v_score);
                 l1_norm += v_score;
             }
-            for (auto v : boost::make_iterator_range(vertices(g))) put(to_rank, v, get(to_rank, v)/l1_norm);
+            // See above function for potential division by zero comments.
+            for (auto v : boost::make_iterator_range(vertices(g))) 
+                put(to_rank, v, get(to_rank, v)/l1_norm);
         }
-    } // end namespace detail
+    } // end namespace personalized_page_rank_detail
 
     template <
         typename Graph,
@@ -232,25 +137,24 @@ namespace graph
         RankMap rank_map,
         Done done,
         typename property_traits< RankMap >::value_type damping,
-        typename graph_traits< Graph >::vertices_size_type n,
         RankMap2 rank_map2
         BOOST_GRAPH_ENABLE_IF_MODELS_PARM(Graph, vertex_list_graph_tag))
     {
-        typedef typename property_traits< PersonalizationMap >::value_type rank_type;
-
+        using rank_type = typename property_traits< PersonalizationMap >::value_type;
         rank_type personalization_norm(0);
-        for (auto v : boost::make_iterator_range(vertices(g))) personalization_norm += get(personalization_map, v);
+        for (auto v : boost::make_iterator_range(vertices(g))) 
+            personalization_norm += get(personalization_map, v);
 
         // TBD: This implementation couples iterators when possible under reduced L1 cache invalidation assumptions,
         // but this is not necessarily the case because we may be grabbing 2x memory lanes each time to write there.
-        // Should investigate which pattern is faster.
+        // Could investigate which pattern is faster in the future.
         for (auto v : boost::make_iterator_range(vertices(g)))
         {
             rank_type value = get(personalization_map, v)/personalization_norm;
             put(personalization_map, v, value);
             put(rank_map, v, value);
         }
-
+        
         bool to_map_2 = true;
         do
         {
@@ -260,10 +164,12 @@ namespace graph
             else
                 personalized_page_rank_detail::personalized_page_rank_step(g, weight_map, personalization_map, rank_map2, rank_map, damping, category());
             to_map_2 = !to_map_2;
-        } while ((to_map_2  && !done(rank_map,  rank_map2, g)) || (!to_map_2 && !done(rank_map2, rank_map,  g)));
+        } 
+        while ((to_map_2  && !done(rank_map,  rank_map2, g)) || (!to_map_2 && !done(rank_map2, rank_map,  g))); // Done may not be symmetric.
         
         // Now multiply the result with personalization_norm to restore the order of magnitude and store it in rank_map.
-        // Also restore the original personalization_map's magnitude for reuse (this is lossy up to numerical tolerance but leaner).'
+        // Also restore the original personalization_map's magnitude for reuse (this is lossy up to numerical tolerance 
+        // but leaner than making a copy).
         if (!to_map_2)
         {
             for (auto v : boost::make_iterator_range(vertices(g)))
@@ -295,61 +201,33 @@ namespace graph
         PersonalizationMap personalization_map,
         RankMap rank_map,
         Done done,
-        typename property_traits< RankMap >::value_type damping,
-        typename graph_traits< Graph >::vertices_size_type n)
+        typename property_traits< RankMap >::value_type damping)
     {
-        typedef typename property_traits< RankMap >::value_type rank_type;
-
+        using rank_type = typename property_traits< RankMap >::value_type;
         std::vector< rank_type > ranks2(num_vertices(g));
-        return personalized_page_rank(g, weight_map, personalization_map, rank_map, done, damping, n,
+        return personalized_page_rank(g, weight_map, personalization_map, rank_map, done, damping,
             make_iterator_property_map(ranks2.begin(), get(vertex_index, g)));
     }
 
-    template <
-        typename Graph,
-        typename WeightMap,
-        typename PersonalizationMap,
-        typename RankMap,
-        typename Done >
-    inline Done personalized_page_rank(
-        const Graph& g,
-        WeightMap weight_map,
-        PersonalizationMap personalization_map,
-        RankMap rank_map,
-        Done done,
-        typename property_traits< RankMap >::value_type damping = 0.85)
-    {
-        return personalized_page_rank(g, weight_map, personalization_map, rank_map, done, damping, num_vertices(g));
-    }
-
-    template <
-        typename Graph,
-        typename WeightMap,
-        typename PersonalizationMap,
-        typename RankMap >
-    inline vertex_map_convergence personalized_page_rank(
-        const Graph& g,
-        WeightMap weight_map,
-        PersonalizationMap personalization_map,
-        RankMap rank_map,
-        typename property_traits< RankMap >::value_type damping = 0.85)
-    {
-        std::size_t n_iters(1.0/(1-damping)+0.5); // accounts for "most" random walks
-        auto convergence = vertex_map_convergence(n_iters);
-        return personalized_page_rank(g, weight_map, personalization_map, rank_map, convergence, damping, num_vertices(g));
-    }
-
-    template <
-        typename Graph,
-        typename PersonalizationMap,
-        typename RankMap >
-    inline vertex_map_convergence personalized_page_rank(
+    template < typename Graph, typename PersonalizationMap, typename RankMap >
+    rank_convergence personalized_page_rank(
         const Graph& g,
         PersonalizationMap personalization_map,
         RankMap rank_map,
-        typename property_traits< RankMap >::value_type damping = 0.85)
+        typename property_traits< RankMap >::value_type damping=0.85)
     {
-        return personalized_page_rank(g, asymmetric_normalization(g), personalization_map, rank_map);
+        // This is the most traditional personalized PageRank implementation, with minimized signature.
+        using Edge = graph_traits<Graph>::edge_descriptor;
+        using rank_type = typename property_traits< RankMap >::value_type;
+        std::vector< rank_type > ranks2(num_vertices(g));
+        auto markovian_weights = make_function_property_map<Edge, double>([&g](Edge e){ return 1.0 / out_degree(source(e, g), g); });
+        return personalized_page_rank(g,
+            markovian_weights, 
+            personalization_map, 
+            rank_map, 
+            rank_convergence(100, 1.E-9), 
+            damping,
+            make_iterator_property_map(ranks2.begin(), get(vertex_index, g)));
     }
 
 }

--- a/include/boost/graph/personalized_page_rank.hpp
+++ b/include/boost/graph/personalized_page_rank.hpp
@@ -70,7 +70,7 @@ namespace graph
                 l1_norm += v_constant;
             }
             
-            // Maintenance comment:
+            // Accumulate from neighbors.
             for (auto u : boost::make_iterator_range(vertices(g)))
             {
                 rank_type u_rank_factor = damping * get(from_rank, u);
@@ -217,7 +217,7 @@ namespace graph
         typename property_traits< RankMap >::value_type damping=0.85)
     {
         // This is the most traditional personalized PageRank implementation, with minimized signature.
-        using Edge = graph_traits<Graph>::edge_descriptor;
+        using Edge = typename graph_traits<Graph>::edge_descriptor;
         using rank_type = typename property_traits< RankMap >::value_type;
         std::vector< rank_type > ranks2(num_vertices(g));
         auto markovian_weights = make_function_property_map<Edge, double>([&g](Edge e){ return 1.0 / out_degree(source(e, g), g); });

--- a/include/boost/graph/personalized_page_rank.hpp
+++ b/include/boost/graph/personalized_page_rank.hpp
@@ -20,333 +20,338 @@
 
 namespace boost
 {
-    namespace graph
+namespace graph
+{
+    namespace personalized_page_rank_detail
     {
-        namespace detail {
-            template < typename Graph>
-            std::size_t proxy_in_degree(
-                typename boost::graph_traits<Graph>::vertex_descriptor v,
-                const Graph& g
-                BOOST_GRAPH_ENABLE_IF_MODELS_PARM(Graph, vertex_list_graph_tag))
-            {
-                return out_degree(v, g);
-            }
-            template < typename Graph>
-            std::size_t proxy_in_degree(
-                typename boost::graph_traits<Graph>::vertex_descriptor v,
-                const Graph& g
-                BOOST_GRAPH_ENABLE_IF_MODELS_PARM(Graph, bidirectional_graph_tag))
-            {
-                return in_degree(v, g);
-            }
+        template < typename Graph>
+        std::size_t in_or_out_degree(
+            typename boost::graph_traits<Graph>::vertex_descriptor v,
+            const Graph& g,
+            bidirectional_graph_tag)
+        {
+            return in_degree(v, g);
         }
+        template < typename Graph>
+        std::size_t in_or_out_degree(
+            typename boost::graph_traits<Graph>::vertex_descriptor v,
+            const Graph& g,
+            incidence_graph_tag)
+        {
+            return out_degree(v, g);
+        }
+    }
 
-        template <typename Graph>
-        boost::function_property_map<
+    template <typename Graph>
+    boost::function_property_map<
         std::function<double(typename boost::graph_traits<Graph>::edge_descriptor)>,
         typename boost::graph_traits<Graph>::edge_descriptor>
-        markovian_weights(const Graph& g)
+    markovian_weights(const Graph& g)
+    {
+        using Edge = typename boost::graph_traits<Graph>::edge_descriptor;
+        using Func = std::function<double(Edge)>;
+        Func f = [&g](Edge e)
         {
-            using Edge = typename boost::graph_traits<Graph>::edge_descriptor;
-            using Func = std::function<double(Edge)>;
-            Func f = [&g](Edge e)
-            {
-                auto u = source(e, g);
-                std::size_t denom;
-                denom = out_degree(u, g) ;
-                return 1.0 / std::sqrt(denom);
-            };
-            return make_function_property_map<Edge, double>(f);
-        }
-
-        template <typename Graph>
-        boost::function_property_map<
-        std::function<double(typename boost::graph_traits<Graph>::edge_descriptor)>,
-        typename boost::graph_traits<Graph>::edge_descriptor>
-        spectral_weights(const Graph& g)
-        {
-            using Edge = typename boost::graph_traits<Graph>::edge_descriptor;
-            using Func = std::function<double(Edge)>;
-            Func f = [&g](Edge e)
-            {
-                auto u = source(e, g);
-                auto v = target(e, g);
-                std::size_t denom;
-                denom = out_degree(u, g) * detail::proxy_in_degree(v, g);
-                return 1.0 / std::sqrt(denom);
-            };
-            return make_function_property_map<Edge, double>(f);
-        }
-
-        template <typename Graph>
-        boost::function_property_map<
-        std::function<double(typename boost::graph_traits<Graph>::edge_descriptor)>,
-        typename boost::graph_traits<Graph>::edge_descriptor>
-        renormalized_weights(const Graph& g)
-        {
-            using Edge = typename boost::graph_traits<Graph>::edge_descriptor;
-            using Func = std::function<double(Edge)>;
-            Func f = [&g](Edge e)
-            {
-                auto u = source(e, g);
-                auto v = target(e, g);
-                std::size_t denom;
-                denom = (1+out_degree(u, g)) * (1+detail::proxy_in_degree(v, g));
-                return 1.0 / std::sqrt(denom);
-            };
-            return make_function_property_map<Edge, double>(f);
-        }
-
-        struct vertex_map_convergence
-        {
-            explicit vertex_map_convergence(std::size_t n, double tol=0) : n(n), tol(tol) {} // allowing tolerance for early stopping
-
-            template < typename RankMap, typename RankMap2, typename Graph >
-            bool operator()(
-                const RankMap& rank_map,
-                const RankMap2& rank_map2,
-                const Graph& g)
-            {
-                if ( n-- == 0 )
-                {
-                    return true;
-                }
-                if (!tol)
-                    return false;
-
-                typedef typename property_traits< RankMap >::value_type rank_type;
-                rank_type sum_abs(0);
-                BGL_FORALL_VERTICES_T(v, g, Graph)
-                {
-                    rank_type difference = get(rank_map, v)-get(rank_map2, v);
-                    if(difference<0)
-                        difference = -difference;
-                    sum_abs += difference;
-                }
-                return sum_abs*num_vertices(g)<tol;
-            }
-
-            std::size_t get_remaining_iters() const
-            {
-                return n;
-            }
-
-            bool has_converged() const
-            {
-                return n || !tol;
-            }
-
-        private:
-            std::size_t n;
-            double tol;
+            auto u = source(e, g);
+            std::size_t denom;
+            denom = out_degree(u, g) ;
+            return 1.0 / denom;
         };
+        return make_function_property_map<Edge, double>(f);
+    }
 
-        namespace detail
+    template <typename Graph>
+    boost::function_property_map<
+        std::function<double(typename boost::graph_traits<Graph>::edge_descriptor)>,
+        typename boost::graph_traits<Graph>::edge_descriptor>
+    spectral_weights(const Graph& g)
+    {
+        using Edge = typename boost::graph_traits<Graph>::edge_descriptor;
+        using Func = std::function<double(Edge)>;
+        Func f = [&g](Edge e)
         {
-            template <
+            typedef typename boost::graph_traits<Graph>::traversal_category category;
+            auto u = source(e, g);
+            auto v = target(e, g);
+            std::size_t denom;
+            denom = out_degree(u, g) * personalized_page_rank_detail::in_or_out_degree(v, g, category());
+            return 1.0 / std::sqrt(denom);
+        };
+        return make_function_property_map<Edge, double>(f);
+    }
+
+    template <typename Graph>
+    boost::function_property_map<
+        std::function<double(typename boost::graph_traits<Graph>::edge_descriptor)>,
+        typename boost::graph_traits<Graph>::edge_descriptor>
+    renormalized_weights(const Graph& g)
+    {
+        using Edge = typename boost::graph_traits<Graph>::edge_descriptor;
+        using Func = std::function<double(Edge)>;
+        Func f = [&g](Edge e)
+        {
+            typedef typename boost::graph_traits<Graph>::traversal_category category;
+            auto u = source(e, g);
+            auto v = target(e, g);
+            std::size_t denom;
+            denom = (1+out_degree(u, g)) * (1+personalized_page_rank_detail::in_or_out_degree(v, g, category()));
+            return 1.0 / std::sqrt(denom);
+        };
+        return make_function_property_map<Edge, double>(f);
+    }
+
+    struct vertex_map_convergence
+    {
+        explicit vertex_map_convergence(std::size_t n, double tol=0) : n(n), tol(tol) {} // allowing tolerance for early stopping
+
+        template < typename RankMap, typename RankMap2, typename Graph >
+        bool operator()(
+            const RankMap& current,
+            const RankMap2& previous,
+            const Graph& g)
+        {
+            if ( n-- == 0 )
+            {
+                return true;
+            }
+            if (!tol)
+            {
+                return false;
+            }
+
+            typedef typename property_traits< RankMap >::value_type rank_type;
+            rank_type sum_abs(0);
+            for (auto v : boost::make_iterator_range(vertices(g)))
+            {
+                rank_type difference = get(current, v)-get(previous, v);
+                sum_abs += std::abs(difference);
+            }
+            return sum_abs*num_vertices(g)<tol;
+        }
+
+        std::size_t get_remaining_iters() const
+        {
+            return n;
+        }
+
+        bool has_converged() const 
+        {
+            return n || !tol;
+        }
+
+    private:
+        std::size_t n;
+        double tol;
+    };
+
+    namespace personalized_page_rank_detail
+    {
+        template <
             typename Graph,
             typename WeightMap,
             typename PersonalizationMap,
             typename RankMap,
             typename RankMap2 >
-            void personalized_page_rank_step(
-                const Graph& g,
-                WeightMap weight_map,
-                PersonalizationMap personalization_map,
-                RankMap from_rank,
-                RankMap2 to_rank,
-                typename property_traits< RankMap >::value_type damping,
-                incidence_graph_tag)
+        void personalized_page_rank_step(
+            const Graph& g,
+            WeightMap weight_map,
+            PersonalizationMap personalization_map,
+            RankMap from_rank,
+            RankMap2 to_rank,
+            typename property_traits< RankMap >::value_type damping,
+            incidence_graph_tag)
+        {
+            typedef typename property_traits< RankMap >::value_type rank_type;
+            rank_type l1_norm(0); // Computing the norm simultaneously avoids an extra summing iteration.
+
+            // Initialize the constant part of maps
+            for (auto v : boost::make_iterator_range(vertices(g))) 
             {
-                typedef typename property_traits< RankMap >::value_type rank_type;
-                rank_type l1_norm(0); // Computing the norm simultaneously avoids an extra summing iteration.
-
-                // Initialize the constant part of maps
-                BGL_FORALL_VERTICES_T(v, g, Graph) {
-                    auto v_constant = rank_type(1 - damping) * get(personalization_map, v);
-                    put(to_rank, v, v_constant);
-                    l1_norm += v_constant;
-                }
-
-                BGL_FORALL_VERTICES_T(u, g, Graph)
-                {
-                    rank_type u_rank_factor = damping * get(from_rank, u);
-                    rank_type l1_accumulated_norm(0); // TBD: Consider making l1_norm volatile to reduce accumulation errors.
-                    BGL_FORALL_OUTEDGES_T(u, e, g, Graph)
-                    {
-                        auto v = target(e, g);
-                        rank_type u_rank_out = get(weight_map, e)*u_rank_factor;
-                        put(to_rank, v, get(to_rank, v) + u_rank_out);
-                        l1_accumulated_norm += u_rank_out;
-                    }
-                    l1_norm += l1_accumulated_norm;
-                }
-                BGL_FORALL_VERTICES_T(v, g, Graph) put(to_rank, v, get(to_rank, v)/l1_norm);
+                auto v_constant = rank_type(1 - damping) * get(personalization_map, v);
+                put(to_rank, v, v_constant);
+                l1_norm += v_constant;
             }
 
-            template <
-            typename Graph,
-            typename WeightMap,
-            typename PersonalizationMap,
-            typename RankMap,
-            typename RankMap2 >
-            void page_rank_step(
-                const Graph& g,
-                WeightMap weight_map,
-                PersonalizationMap personalization_map,
-                RankMap from_rank,
-                RankMap2 to_rank,
-                typename property_traits< RankMap >::value_type damping,
-                bidirectional_graph_tag)
+            for (auto u : boost::make_iterator_range(vertices(g)))
             {
-                typedef typename property_traits< RankMap >::value_type damping_type;
-                damping_type l1_norm(0); // Computing the norm simultaneously avoids an extra summing iteration.
-                BGL_FORALL_VERTICES_T(v, g, Graph)
+                rank_type u_rank_factor = damping * get(from_rank, u);
+                rank_type l1_accumulated_norm(0); // TBD: Consider making l1_norm volatile to reduce accumulation errors.
+                for (auto e : boost::make_iterator_range(out_edges(u, g))) 
                 {
-                    typename property_traits< RankMap >::value_type rank(0);
-                    BGL_FORALL_INEDGES_T(v, e, g, Graph) rank += get(from_rank, source(e, g))*get(weight_map, e);//get(from_rank, source(e, g)) / out_degree(source(e, g), g);
-                    auto v_score = (damping_type(1) - damping) * get(personalization_map, v) + damping * rank;
-                    put(to_rank, v, v_score);
-                    l1_norm += v_score;
+                    auto v = target(e, g);
+                    rank_type u_rank_out = get(weight_map, e)*u_rank_factor;
+                    put(to_rank, v, get(to_rank, v) + u_rank_out);
+                    l1_accumulated_norm += u_rank_out;
                 }
-                BGL_FORALL_VERTICES_T(v, g, Graph) put(to_rank, v, get(to_rank, v)/l1_norm);
+                l1_norm += l1_accumulated_norm;
             }
-        } // end namespace detail
+            BGL_FORALL_VERTICES_T(v, g, Graph) put(to_rank, v, get(to_rank, v)/l1_norm);
+        }
 
         template <
+            typename Graph,
+            typename WeightMap,
+            typename PersonalizationMap,
+            typename RankMap,
+            typename RankMap2 >
+        void page_rank_step(
+            const Graph& g,
+            WeightMap weight_map,
+            PersonalizationMap personalization_map,
+            RankMap from_rank,
+            RankMap2 to_rank,
+            typename property_traits< RankMap >::value_type damping,
+            bidirectional_graph_tag)
+        {
+            typedef typename property_traits< RankMap >::value_type damping_type;
+            damping_type l1_norm(0); // Computing the norm simultaneously avoids an extra summing iteration.
+            BGL_FORALL_VERTICES_T(v, g, Graph)
+            {
+                typename property_traits< RankMap >::value_type rank(0);
+                BGL_FORALL_INEDGES_T(v, e, g, Graph) rank += get(from_rank, source(e, g))*get(weight_map, e);//get(from_rank, source(e, g)) / out_degree(source(e, g), g);
+                auto v_score = (damping_type(1) - damping) * get(personalization_map, v) + damping * rank;
+                put(to_rank, v, v_score);
+                l1_norm += v_score;
+            }
+            BGL_FORALL_VERTICES_T(v, g, Graph) put(to_rank, v, get(to_rank, v)/l1_norm);
+        }
+    } // end namespace detail
+
+    template <
         typename Graph,
         typename WeightMap,
         typename PersonalizationMap,
         typename RankMap,
         typename Done,
         typename RankMap2 >
-        void personalized_page_rank(
-            const Graph& g,
-            WeightMap weight_map,
-            PersonalizationMap personalization_map,
-            RankMap rank_map,
-            Done& done,
-            typename property_traits< RankMap >::value_type damping,
-            typename graph_traits< Graph >::vertices_size_type n,
-            RankMap2 rank_map2
-            BOOST_GRAPH_ENABLE_IF_MODELS_PARM(Graph, vertex_list_graph_tag))
+    Done personalized_page_rank(
+        const Graph& g,
+        WeightMap weight_map,
+        PersonalizationMap personalization_map,
+        RankMap rank_map,
+        Done done,
+        typename property_traits< RankMap >::value_type damping,
+        typename graph_traits< Graph >::vertices_size_type n,
+        RankMap2 rank_map2
+        BOOST_GRAPH_ENABLE_IF_MODELS_PARM(Graph, vertex_list_graph_tag))
+    {
+        typedef typename property_traits< PersonalizationMap >::value_type rank_type;
+
+        rank_type personalization_norm(0);
+        BGL_FORALL_VERTICES_T(v, g, Graph) personalization_norm += get(personalization_map, v);
+
+        // TBD: This implementation couples iterators when possible under reduced L1 cache invalidation assumptions,
+        // but this is not necessarily the case because we may be grabbing 2x memory lanes each time to write there.
+        // Should investigate which pattern is faster.
+        BGL_FORALL_VERTICES_T(v, g, Graph)
         {
-            typedef typename property_traits< PersonalizationMap >::value_type rank_type;
+            rank_type value = get(personalization_map, v)/personalization_norm;
+            put(personalization_map, v, value);
+            put(rank_map, v, value);
+        }
 
-            rank_type personalization_norm(0);
-            BGL_FORALL_VERTICES_T(v, g, Graph) personalization_norm += get(personalization_map, v);
-
-            // TBD: This implementation couples iterators when possible under reduced L1 cache invalidation assumptions,
-            // but this is not necessarily the case because we may be grabbing 2x memory lanes each time to write there.
-            // Should investigate which pattern is faster.
-            BGL_FORALL_VERTICES_T(v, g, Graph)
-            {
-                rank_type value = get(personalization_map, v)/personalization_norm;
-                put(personalization_map, v, value);
-                put(rank_map, v, value);
-            }
-
-            bool to_map_2 = true;
-            do
-            {
-                typedef typename graph_traits< Graph >::traversal_category category;
-                if (to_map_2)
-                    detail::personalized_page_rank_step(g, weight_map, personalization_map, rank_map, rank_map2, damping, category());
-                else
-                    detail::personalized_page_rank_step(g, weight_map, personalization_map, rank_map2, rank_map, damping, category());
-                to_map_2 = !to_map_2;
-            } while (!done(rank_map, rank_map2, g)); // Symmetric call signature that should be unaffected by mode.
-
-            // Now multiply the result with personalization_norm to restore the order of magnitude and store it in rank_map.
-            // Also restore the original personalization_map's magnitude for reuse (this is only a tiny bit lossy).'
-            if (!to_map_2)
-            {
-                BGL_FORALL_VERTICES_T(v, g, Graph)
-                {
-                    put(rank_map, v, get(rank_map2, v)*personalization_norm);
-                    put(personalization_map, v, get(personalization_map, v)*personalization_norm);
-                }
-            }
+        bool to_map_2 = true;
+        do
+        {
+            typedef typename graph_traits< Graph >::traversal_category category;
+            if (to_map_2)
+                personalized_page_rank_detail::personalized_page_rank_step(g, weight_map, personalization_map, rank_map, rank_map2, damping, category());
             else
+                personalized_page_rank_detail::personalized_page_rank_step(g, weight_map, personalization_map, rank_map2, rank_map, damping, category());
+            to_map_2 = !to_map_2;
+        } while ((to_map_2  && !done(rank_map,  rank_map2, g)) || (!to_map_2 && !done(rank_map2, rank_map,  g)));
+        
+        // Now multiply the result with personalization_norm to restore the order of magnitude and store it in rank_map.
+        // Also restore the original personalization_map's magnitude for reuse (this is lossy up to numerical tolerance but leaner).'
+        if (!to_map_2)
+        {
+            for (auto v : boost::make_iterator_range(vertices(g)))
             {
-                BGL_FORALL_VERTICES_T(v, g, Graph)
-                {
-                    put(rank_map, v, get(rank_map, v)*personalization_norm);
-                    put(personalization_map, v, get(personalization_map, v)*personalization_norm);
-                }
+                put(rank_map, v, get(rank_map2, v)*personalization_norm);
+                put(personalization_map, v, get(personalization_map, v)*personalization_norm);
             }
         }
-
-        template <
-        typename Graph,
-        typename WeightMap,
-        typename PersonalizationMap,
-        typename RankMap,
-        typename Done >
-        void personalized_page_rank(
-            const Graph& g,
-            WeightMap weight_map,
-            PersonalizationMap personalization_map,
-            RankMap rank_map,
-            Done& done,
-            typename property_traits< RankMap >::value_type damping,
-            typename graph_traits< Graph >::vertices_size_type n)
+        else
         {
-            typedef typename property_traits< RankMap >::value_type rank_type;
-
-            std::vector< rank_type > ranks2(num_vertices(g));
-            personalized_page_rank(g, weight_map, personalization_map, rank_map, done, damping, n,
-                                   make_iterator_property_map(ranks2.begin(), get(vertex_index, g)));
+            for (auto v : boost::make_iterator_range(vertices(g)))
+            {
+                put(rank_map, v, get(rank_map, v)*personalization_norm);
+                put(personalization_map, v, get(personalization_map, v)*personalization_norm);
+            }
         }
-
-        template <
-        typename Graph,
-        typename WeightMap,
-        typename PersonalizationMap,
-        typename RankMap,
-        typename Done >
-        inline void personalized_page_rank(
-            const Graph& g,
-            WeightMap weight_map,
-            PersonalizationMap personalization_map,
-            RankMap rank_map,
-            Done& done,
-            typename property_traits< RankMap >::value_type damping = 0.85)
-        {
-            personalized_page_rank(g, weight_map, personalization_map, rank_map, done, damping, num_vertices(g));
-        }
-
-        template <
-        typename Graph,
-        typename WeightMap,
-        typename PersonalizationMap,
-        typename RankMap >
-        inline void personalized_page_rank(
-            const Graph& g,
-            WeightMap weight_map,
-            PersonalizationMap personalization_map,
-            RankMap rank_map,
-            typename property_traits< RankMap >::value_type damping = 0.85)
-        {
-            std::size_t n_iters(1.0/(1-damping)+0.5); // accounts for "most" random walks
-            auto convergence = vertex_map_convergence(n_iters);
-            personalized_page_rank(g, weight_map, personalization_map, rank_map, convergence, damping, num_vertices(g));
-        }
-
-        template <
-        typename Graph,
-        typename PersonalizationMap,
-        typename RankMap >
-        inline void personalized_page_rank(
-            const Graph& g,
-            PersonalizationMap personalization_map,
-            RankMap rank_map,
-            typename property_traits< RankMap >::value_type damping = 0.85)
-        {
-            personalized_page_rank(g, asymmetric_normalization(g), personalization_map, rank_map);
-        }
-
+        return done;
     }
+
+    template <
+        typename Graph,
+        typename WeightMap,
+        typename PersonalizationMap,
+        typename RankMap,
+        typename Done >
+    Done personalized_page_rank(
+        const Graph& g,
+        WeightMap weight_map,
+        PersonalizationMap personalization_map,
+        RankMap rank_map,
+        Done done,
+        typename property_traits< RankMap >::value_type damping,
+        typename graph_traits< Graph >::vertices_size_type n)
+    {
+        typedef typename property_traits< RankMap >::value_type rank_type;
+
+        std::vector< rank_type > ranks2(num_vertices(g));
+        return personalized_page_rank(g, weight_map, personalization_map, rank_map, done, damping, n,
+            make_iterator_property_map(ranks2.begin(), get(vertex_index, g)));
+    }
+
+    template <
+        typename Graph,
+        typename WeightMap,
+        typename PersonalizationMap,
+        typename RankMap,
+        typename Done >
+    inline Done personalized_page_rank(
+        const Graph& g,
+        WeightMap weight_map,
+        PersonalizationMap personalization_map,
+        RankMap rank_map,
+        Done done,
+        typename property_traits< RankMap >::value_type damping = 0.85)
+    {
+        return personalized_page_rank(g, weight_map, personalization_map, rank_map, done, damping, num_vertices(g));
+    }
+
+    template <
+        typename Graph,
+        typename WeightMap,
+        typename PersonalizationMap,
+        typename RankMap >
+    inline vertex_map_convergence personalized_page_rank(
+        const Graph& g,
+        WeightMap weight_map,
+        PersonalizationMap personalization_map,
+        RankMap rank_map,
+        typename property_traits< RankMap >::value_type damping = 0.85)
+    {
+        std::size_t n_iters(1.0/(1-damping)+0.5); // accounts for "most" random walks
+        auto convergence = vertex_map_convergence(n_iters);
+        return personalized_page_rank(g, weight_map, personalization_map, rank_map, convergence, damping, num_vertices(g));
+    }
+
+    template <
+        typename Graph,
+        typename PersonalizationMap,
+        typename RankMap >
+    inline vertex_map_convergence personalized_page_rank(
+        const Graph& g,
+        PersonalizationMap personalization_map,
+        RankMap rank_map,
+        typename property_traits< RankMap >::value_type damping = 0.85)
+    {
+        return personalized_page_rank(g, asymmetric_normalization(g), personalization_map, rank_map);
+    }
+
+}
 } // end namespace boost::graph
 
 #endif // BOOST_GRAPH_PERSONALIZED_PAGE_RANK_HPP

--- a/include/boost/graph/personalized_page_rank.hpp
+++ b/include/boost/graph/personalized_page_rank.hpp
@@ -1,0 +1,300 @@
+// Copyright 2026 Emmanouil Krasanakis
+
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+//  Authors: Emmanouil Krasanakis
+
+#ifndef BOOST_GRAPH_PAGE_RANK_HPP
+#define BOOST_GRAPH_PAGE_RANK_HPP
+
+#include <boost/property_map/property_map.hpp>
+#include <boost/graph/graph_traits.hpp>
+#include <boost/graph/properties.hpp>
+#include <boost/graph/iteration_macros.hpp>
+#include <boost/graph/overloading.hpp>
+#include <boost/graph/detail/mpi_include.hpp>
+#include <boost/property_map/function_property_map.hpp>
+#include <boost/throw_exception.hpp>
+#include <vector>
+
+namespace boost
+{
+    namespace graph
+    {
+
+        template < typename Graph >
+        auto asymmetric_normalization_weights(const Graph& g) {
+            using Edge = typename boost::graph_traits<Graph>::edge_descriptor;
+            return make_function_property_map<Edge, double>(
+                [&g](Edge e) {
+                    auto u = source(e, g);
+                    return 1.0 / out_degree(u, g);
+                });
+        }
+
+        template < typename Graph >
+        auto symmetric_normalization_weights(const Graph& g) {
+            using Edge = typename boost::graph_traits<Graph>::edge_descriptor;
+            return make_function_property_map<Edge, double>(
+                [&g](Edge e) {
+                    auto u = source(e, g);
+                    auto v = target(e, g);
+                    return 1.0 / std::sqrt(out_degree(u, g) * out_degree(v, g));
+                });
+        }
+
+        class BOOST_SYMBOL_VISIBLE vertex_map_not_converged : public std::exception
+        {
+        };
+
+        struct vertex_map_convergence
+        {
+            explicit vertex_map_convergence(std::size_t n, double tol=0) : n(n), tol(tol) {} // allowing tolerance for early stopping
+
+            template < typename RankMap, typename RankMap2, typename Graph >
+            bool operator()(
+                const RankMap& rank_map,
+                const RankMap2& rank_map2,
+                const Graph& g)
+            {
+                if ( n-- == 0 )
+                {
+                    if(tol) boost::throw_exception(vertex_map_not_converged());
+                    return true;
+                }
+                if (!tol)
+                    return false;
+
+                typedef typename property_traits< RankMap >::value_type rank_type;
+                rank_type sum_abs(0);
+                BGL_FORALL_VERTICES_T(v, g, Graph)
+                {
+                    rank_type difference = get(rank_map, v)-get(rank_map2, v);
+                    if(difference<0)
+                        difference = -difference;
+                    sum_abs += difference;
+                }
+                return sum_abs<tol;
+            }
+
+            std::size_t get_remaining_iters() const
+            {
+                return n;
+            }
+
+        private:
+            std::size_t n;
+            double tol;
+        };
+
+        namespace detail
+        {
+            template <
+            typename Graph,
+            typename WeightMap,
+            typename PersonalizationMap,
+            typename RankMap,
+            typename RankMap2 >
+            void personalized_page_rank_step(
+                const Graph& g,
+                const WeightMap& weight_map,
+                PersonalizationMap personalization_map,
+                RankMap from_rank,
+                RankMap2 to_rank,
+                typename property_traits< RankMap >::value_type damping,
+                incidence_graph_tag)
+            {
+                typedef typename property_traits< RankMap >::value_type rank_type;
+                rank_type l1_norm(0); // Computing the norm simultaneously avoids an extra summing iteration.
+
+                // Initialize the constant part of maps
+                BGL_FORALL_VERTICES_T(v, g, Graph) {
+                    auto v_constant = rank_type(1 - damping) * get(personalization_map, v);
+                    put(to_rank, v, v_constant);
+                    l1_norm += v_constant;
+                }
+
+                BGL_FORALL_VERTICES_T(u, g, Graph)
+                {
+                    rank_type u_rank_factor = damping * get(from_rank, u);
+                    rank_type l1_accumulated_norm(0); // TBD: Consider making l1_norm volatile even, to reduce accumulation errors.
+                    BGL_FORALL_OUTEDGES_T(u, e, g, Graph)
+                    {
+                        auto v = target(e, g);
+                        rank_type u_rank_out = get(weight_map, e)*u_rank_factor;
+                        put(to_rank, v, get(to_rank, v) + u_rank_out);
+                        l1_accumulated_norm += u_rank_out;
+                    }
+                    l1_norm += l1_accumulated_norm;
+                }
+                BGL_FORALL_VERTICES_T(v, g, Graph) put(to_rank, v, get(to_rank, v)/l1_norm);
+            }
+
+            template <
+            typename Graph,
+            typename WeightMap,
+            typename PersonalizationMap,
+            typename RankMap,
+            typename RankMap2 >
+            void page_rank_step(
+                const Graph& g,
+                const WeightMap& weight_map,
+                PersonalizationMap personalization_map,
+                RankMap from_rank,
+                RankMap2 to_rank,
+                typename property_traits< RankMap >::value_type damping,
+                bidirectional_graph_tag)
+            {
+                typedef typename property_traits< RankMap >::value_type damping_type;
+                damping_type l1_norm(0); // Computing the norm simultaneously avoids an extra summing iteration.
+                BGL_FORALL_VERTICES_T(v, g, Graph)
+                {
+                    typename property_traits< RankMap >::value_type rank(0);
+                    BGL_FORALL_INEDGES_T(v, e, g, Graph) rank += get(from_rank, source(e, g))*get(weight_map, e);//get(from_rank, source(e, g)) / out_degree(source(e, g), g);
+                    auto v_score = (damping_type(1) - damping) * get(personalization_map, v) + damping * rank;
+                    put(to_rank, v, v_score);
+                    l1_norm += v_score;
+                }
+                BGL_FORALL_VERTICES_T(v, g, Graph) put(to_rank, v, get(to_rank, v)/l1_norm);
+            }
+        } // end namespace detail
+
+        template <
+        typename Graph,
+        typename WeightMap,
+        typename PersonalizationMap,
+        typename RankMap,
+        typename Done,
+        typename RankMap2 >
+        void personalized_page_rank(
+            const Graph& g,
+            const WeightMap& weight_map,
+            PersonalizationMap personalization_map,
+            RankMap rank_map,
+            Done& done,
+            typename property_traits< RankMap >::value_type damping,
+            typename graph_traits< Graph >::vertices_size_type n,
+            RankMap2 rank_map2
+            BOOST_GRAPH_ENABLE_IF_MODELS_PARM(Graph, vertex_list_graph_tag))
+        {
+            typedef typename property_traits< PersonalizationMap >::value_type rank_type;
+
+            rank_type personalization_norm(0);
+            BGL_FORALL_VERTICES_T(v, g, Graph) personalization_norm += get(personalization_map, v);
+            if(!personalization_norm) personalization_norm = 1; // TBD: perhaps throw error here
+
+            // TBD: This implementation couples iterators when possible under reduced L1 cache invalidation assumptions,
+            // but this is not ncessarily the case due to writes. Perhaps investigate which pattern is faster.
+            BGL_FORALL_VERTICES_T(v, g, Graph)
+            {
+                rank_type value = get(personalization_map, v)/personalization_norm;
+                put(personalization_map, v, value);
+                put(rank_map, v, value);
+            }
+
+            bool to_map_2 = true;
+            do
+            {
+                typedef typename graph_traits< Graph >::traversal_category category;
+                if (to_map_2)
+                    detail::personalized_page_rank_step(g, weight_map, personalization_map, rank_map, rank_map2, damping, category());
+                else
+                    detail::personalized_page_rank_step(g, weight_map, personalization_map, rank_map2, rank_map, damping, category());
+                to_map_2 = !to_map_2;
+            } while (!done(rank_map, rank_map2, g)); // Symmetric call signature that should be unaffected by mode.
+
+            if (!to_map_2)
+            {
+                BGL_FORALL_VERTICES_T(v, g, Graph)
+                {
+                    put(rank_map, v, get(rank_map2, v)*personalization_norm);
+                    put(personalization_map, v, get(personalization_map, v)*personalization_norm); // restore to near-exact original
+                }
+            }
+            else
+            {
+                BGL_FORALL_VERTICES_T(v, g, Graph)
+                {
+                    put(rank_map, v, get(rank_map, v)*personalization_norm);
+                    put(personalization_map, v, get(personalization_map, v)*personalization_norm); // restore to near-exact original
+                }
+            }
+        }
+
+        template <
+        typename Graph,
+        typename WeightMap,
+        typename PersonalizationMap,
+        typename RankMap,
+        typename Done >
+        void personalized_page_rank(
+            const Graph& g,
+            const WeightMap& weight_map,
+            PersonalizationMap personalization_map,
+            RankMap rank_map,
+            Done& done,
+            typename property_traits< RankMap >::value_type damping,
+            typename graph_traits< Graph >::vertices_size_type n)
+        {
+            typedef typename property_traits< RankMap >::value_type rank_type;
+
+            std::vector< rank_type > ranks2(num_vertices(g));
+            personalized_page_rank(g, weight_map, personalization_map, rank_map, done, damping, n,
+                                   make_iterator_property_map(ranks2.begin(), get(vertex_index, g)));
+        }
+
+        template <
+        typename Graph,
+        typename WeightMap,
+        typename PersonalizationMap,
+        typename RankMap,
+        typename Done >
+        inline void personalized_page_rank(
+            const Graph& g,
+            const WeightMap& weight_map,
+            PersonalizationMap personalization_map,
+            RankMap rank_map,
+            Done& done,
+            typename property_traits< RankMap >::value_type damping = 0.85)
+        {
+            personalized_page_rank(g, weight_map, personalization_map, rank_map, done, damping, num_vertices(g));
+        }
+
+        template <
+        typename Graph,
+        typename WeightMap,
+        typename PersonalizationMap,
+        typename RankMap >
+        inline void personalized_page_rank(
+            const Graph& g,
+            const WeightMap& weight_map,
+            PersonalizationMap personalization_map,
+            RankMap rank_map,
+            typename property_traits< RankMap >::value_type damping = 0.85)
+        {
+            std::size_t n_iters(1.0/(1-damping)+0.5); // accounts for "most" random walks
+            auto convergence = vertex_map_convergence(n_iters);
+            personalized_page_rank(g, weight_map, personalization_map, rank_map, convergence, damping, num_vertices(g));
+        }
+
+        template <
+        typename Graph,
+        typename PersonalizationMap,
+        typename RankMap >
+        inline void personalized_page_rank(
+            const Graph& g,
+            PersonalizationMap personalization_map,
+            RankMap rank_map,
+            typename property_traits< RankMap >::value_type damping = 0.85)
+        {
+            personalized_page_rank(g, asymmetric_normalization(g), personalization_map, rank_map);
+        }
+
+    }
+} // end namespace boost::graph
+
+#include BOOST_GRAPH_MPI_INCLUDE(<boost/graph/distributed/personalized_page_rank.hpp>)
+
+#endif // BOOST_GRAPH_PAGE_RANK_HPP

--- a/include/boost/graph/personalized_page_rank.hpp
+++ b/include/boost/graph/personalized_page_rank.hpp
@@ -6,8 +6,8 @@
 
 //  Authors: Emmanouil Krasanakis
 
-#ifndef BOOST_GRAPH_PAGE_RANK_HPP
-#define BOOST_GRAPH_PAGE_RANK_HPP
+#ifndef BOOST_GRAPH_PERSONALIZED_PAGE_RANK_HPP
+#define BOOST_GRAPH_PERSONALIZED_PAGE_RANK_HPP
 
 #include <boost/property_map/property_map.hpp>
 #include <boost/graph/graph_traits.hpp>
@@ -16,325 +16,337 @@
 #include <boost/graph/overloading.hpp>
 #include <boost/graph/detail/mpi_include.hpp>
 #include <boost/property_map/function_property_map.hpp>
-#include <boost/throw_exception.hpp>
 #include <vector>
 
 namespace boost
 {
-namespace graph
-{
-
-    template < typename Graph >
-    auto markovian_weights(const Graph& g)
+    namespace graph
     {
-        using Edge = typename boost::graph_traits<Graph>::edge_descriptor;
-        return make_function_property_map<Edge, double>(
-            [&g](Edge e)
-                {
-                    auto u = source(e, g);
-                    auto denom = out_degree(u, g);;
-                    if(!denom) return denom;
-                    return 1.0 / denom;
-                }
-        );
-    }
-
-    template < typename Graph >
-    auto spectral_weights(const Graph& g)
-    {
-        using Edge = typename boost::graph_traits<Graph>::edge_descriptor;
-        return make_function_property_map<Edge, double>(
-            [&g](Edge e)
-                {
-                    auto u = source(e, g);
-                    auto v = target(e, g);
-                    std::size_t denom;
-                    if constexpr (boost::is_bidirectional_graph<Graph>::value)
-                        denom = out_degree(u, g) * in_degree(v, g);
-                    else
-                        denom = out_degree(u, g) * out_degree(v, g);
-                    return 1.0 / std::sqrt(denom);
-                }
-        );
-    }
-
-    template < typename Graph >
-    auto renormalized_weights(const Graph& g)
-    {
-        using Edge = typename boost::graph_traits<Graph>::edge_descriptor;
-        return make_function_property_map<Edge, double>(
-            [&g](Edge e)
-                {
-                    auto u = source(e, g);
-                    auto v = target(e, g);
-                    std::size_t denom;
-                    if constexpr (boost::is_bidirectional_graph<Graph>::value)
-                        denom = (1+out_degree(u, g)) * (1+in_degree(v, g));
-                    else
-                        denom = (1+out_degree(u, g)) * (1+out_degree(v, g));
-                    return 1.0 / std::sqrt(denom);
-                }
-        );
-    }
-
-    class BOOST_SYMBOL_VISIBLE vertex_map_not_converged : public std::exception
-    {
-    };
-    class BOOST_SYMBOL_VISIBLE zero_personalization : public std::exception
-    {
-    };
-
-    struct vertex_map_convergence
-    {
-        explicit vertex_map_convergence(std::size_t n, double tol=0) : n(n), tol(tol) {} // allowing tolerance for early stopping
-
-        template < typename RankMap, typename RankMap2, typename Graph >
-        bool operator()(
-            const RankMap& rank_map,
-            const RankMap2& rank_map2,
-            const Graph& g)
-        {
-            if ( n-- == 0 )
+        namespace detail {
+            template < typename Graph>
+            std::size_t proxy_in_degree(
+                typename boost::graph_traits<Graph>::vertex_descriptor v,
+                const Graph& g
+                BOOST_GRAPH_ENABLE_IF_MODELS_PARM(Graph, vertex_list_graph_tag))
             {
-                if(tol)
-                    boost::throw_exception(vertex_map_not_converged());
-                return true;
+                return out_degree(v, g);
             }
-            if (!tol)
-                return false;
-
-            typedef typename property_traits< RankMap >::value_type rank_type;
-            rank_type sum_abs(0);
-            BGL_FORALL_VERTICES_T(v, g, Graph)
+            template < typename Graph>
+            std::size_t proxy_in_degree(
+                typename boost::graph_traits<Graph>::vertex_descriptor v,
+                const Graph& g
+                BOOST_GRAPH_ENABLE_IF_MODELS_PARM(Graph, bidirectional_graph_tag))
             {
-                rank_type difference = get(rank_map, v)-get(rank_map2, v);
-                if(difference<0)
-                    difference = -difference;
-                sum_abs += difference;
+                return in_degree(v, g);
             }
-            return sum_abs*num_vertices(g)<tol;
         }
 
-        std::size_t get_remaining_iters() const
+        template <typename Graph>
+        boost::function_property_map<
+        std::function<double(typename boost::graph_traits<Graph>::edge_descriptor)>,
+        typename boost::graph_traits<Graph>::edge_descriptor>
+        markovian_weights(const Graph& g)
         {
-            return n;
+            using Edge = typename boost::graph_traits<Graph>::edge_descriptor;
+            using Func = std::function<double(Edge)>;
+            Func f = [&g](Edge e)
+            {
+                auto u = source(e, g);
+                std::size_t denom;
+                denom = out_degree(u, g) ;
+                return 1.0 / std::sqrt(denom);
+            };
+            return make_function_property_map<Edge, double>(f);
         }
 
-    private:
-        std::size_t n;
-        double tol;
-    };
+        template <typename Graph>
+        boost::function_property_map<
+        std::function<double(typename boost::graph_traits<Graph>::edge_descriptor)>,
+        typename boost::graph_traits<Graph>::edge_descriptor>
+        spectral_weights(const Graph& g)
+        {
+            using Edge = typename boost::graph_traits<Graph>::edge_descriptor;
+            using Func = std::function<double(Edge)>;
+            Func f = [&g](Edge e)
+            {
+                auto u = source(e, g);
+                auto v = target(e, g);
+                std::size_t denom;
+                denom = out_degree(u, g) * detail::proxy_in_degree(v, g);
+                return 1.0 / std::sqrt(denom);
+            };
+            return make_function_property_map<Edge, double>(f);
+        }
 
-    namespace detail
-    {
-        template <
+        template <typename Graph>
+        boost::function_property_map<
+        std::function<double(typename boost::graph_traits<Graph>::edge_descriptor)>,
+        typename boost::graph_traits<Graph>::edge_descriptor>
+        renormalized_weights(const Graph& g)
+        {
+            using Edge = typename boost::graph_traits<Graph>::edge_descriptor;
+            using Func = std::function<double(Edge)>;
+            Func f = [&g](Edge e)
+            {
+                auto u = source(e, g);
+                auto v = target(e, g);
+                std::size_t denom;
+                denom = (1+out_degree(u, g)) * (1+detail::proxy_in_degree(v, g));
+                return 1.0 / std::sqrt(denom);
+            };
+            return make_function_property_map<Edge, double>(f);
+        }
+
+        struct vertex_map_convergence
+        {
+            explicit vertex_map_convergence(std::size_t n, double tol=0) : n(n), tol(tol) {} // allowing tolerance for early stopping
+
+            template < typename RankMap, typename RankMap2, typename Graph >
+            bool operator()(
+                const RankMap& rank_map,
+                const RankMap2& rank_map2,
+                const Graph& g)
+            {
+                if ( n-- == 0 )
+                {
+                    return true;
+                }
+                if (!tol)
+                    return false;
+
+                typedef typename property_traits< RankMap >::value_type rank_type;
+                rank_type sum_abs(0);
+                BGL_FORALL_VERTICES_T(v, g, Graph)
+                {
+                    rank_type difference = get(rank_map, v)-get(rank_map2, v);
+                    if(difference<0)
+                        difference = -difference;
+                    sum_abs += difference;
+                }
+                return sum_abs*num_vertices(g)<tol;
+            }
+
+            std::size_t get_remaining_iters() const
+            {
+                return n;
+            }
+
+            bool has_converged() const
+            {
+                return n || !tol;
+            }
+
+        private:
+            std::size_t n;
+            double tol;
+        };
+
+        namespace detail
+        {
+            template <
             typename Graph,
             typename WeightMap,
             typename PersonalizationMap,
             typename RankMap,
             typename RankMap2 >
-        void personalized_page_rank_step(
-            const Graph& g,
-            const WeightMap& weight_map,
-            PersonalizationMap personalization_map,
-            RankMap from_rank,
-            RankMap2 to_rank,
-            typename property_traits< RankMap >::value_type damping,
-            incidence_graph_tag)
-        {
-            typedef typename property_traits< RankMap >::value_type rank_type;
-            rank_type l1_norm(0); // Computing the norm simultaneously avoids an extra summing iteration.
-
-            // Initialize the constant part of maps
-            BGL_FORALL_VERTICES_T(v, g, Graph) {
-                auto v_constant = rank_type(1 - damping) * get(personalization_map, v);
-                put(to_rank, v, v_constant);
-                l1_norm += v_constant;
-            }
-
-            BGL_FORALL_VERTICES_T(u, g, Graph)
+            void personalized_page_rank_step(
+                const Graph& g,
+                WeightMap weight_map,
+                PersonalizationMap personalization_map,
+                RankMap from_rank,
+                RankMap2 to_rank,
+                typename property_traits< RankMap >::value_type damping,
+                incidence_graph_tag)
             {
-                rank_type u_rank_factor = damping * get(from_rank, u);
-                rank_type l1_accumulated_norm(0); // TBD: Consider making l1_norm volatile to reduce accumulation errors.
-                BGL_FORALL_OUTEDGES_T(u, e, g, Graph)
-                {
-                    auto v = target(e, g);
-                    rank_type u_rank_out = get(weight_map, e)*u_rank_factor;
-                    put(to_rank, v, get(to_rank, v) + u_rank_out);
-                    l1_accumulated_norm += u_rank_out;
-                }
-                l1_norm += l1_accumulated_norm;
-            }
-            BGL_FORALL_VERTICES_T(v, g, Graph) put(to_rank, v, get(to_rank, v)/l1_norm);
-        }
+                typedef typename property_traits< RankMap >::value_type rank_type;
+                rank_type l1_norm(0); // Computing the norm simultaneously avoids an extra summing iteration.
 
-        template <
+                // Initialize the constant part of maps
+                BGL_FORALL_VERTICES_T(v, g, Graph) {
+                    auto v_constant = rank_type(1 - damping) * get(personalization_map, v);
+                    put(to_rank, v, v_constant);
+                    l1_norm += v_constant;
+                }
+
+                BGL_FORALL_VERTICES_T(u, g, Graph)
+                {
+                    rank_type u_rank_factor = damping * get(from_rank, u);
+                    rank_type l1_accumulated_norm(0); // TBD: Consider making l1_norm volatile to reduce accumulation errors.
+                    BGL_FORALL_OUTEDGES_T(u, e, g, Graph)
+                    {
+                        auto v = target(e, g);
+                        rank_type u_rank_out = get(weight_map, e)*u_rank_factor;
+                        put(to_rank, v, get(to_rank, v) + u_rank_out);
+                        l1_accumulated_norm += u_rank_out;
+                    }
+                    l1_norm += l1_accumulated_norm;
+                }
+                BGL_FORALL_VERTICES_T(v, g, Graph) put(to_rank, v, get(to_rank, v)/l1_norm);
+            }
+
+            template <
             typename Graph,
             typename WeightMap,
             typename PersonalizationMap,
             typename RankMap,
             typename RankMap2 >
-        void page_rank_step(
-            const Graph& g,
-            const WeightMap& weight_map,
-            PersonalizationMap personalization_map,
-            RankMap from_rank,
-            RankMap2 to_rank,
-            typename property_traits< RankMap >::value_type damping,
-            bidirectional_graph_tag)
-        {
-            typedef typename property_traits< RankMap >::value_type damping_type;
-            damping_type l1_norm(0); // Computing the norm simultaneously avoids an extra summing iteration.
-            BGL_FORALL_VERTICES_T(v, g, Graph)
+            void page_rank_step(
+                const Graph& g,
+                WeightMap weight_map,
+                PersonalizationMap personalization_map,
+                RankMap from_rank,
+                RankMap2 to_rank,
+                typename property_traits< RankMap >::value_type damping,
+                bidirectional_graph_tag)
             {
-                typename property_traits< RankMap >::value_type rank(0);
-                BGL_FORALL_INEDGES_T(v, e, g, Graph) rank += get(from_rank, source(e, g))*get(weight_map, e);//get(from_rank, source(e, g)) / out_degree(source(e, g), g);
-                auto v_score = (damping_type(1) - damping) * get(personalization_map, v) + damping * rank;
-                put(to_rank, v, v_score);
-                l1_norm += v_score;
+                typedef typename property_traits< RankMap >::value_type damping_type;
+                damping_type l1_norm(0); // Computing the norm simultaneously avoids an extra summing iteration.
+                BGL_FORALL_VERTICES_T(v, g, Graph)
+                {
+                    typename property_traits< RankMap >::value_type rank(0);
+                    BGL_FORALL_INEDGES_T(v, e, g, Graph) rank += get(from_rank, source(e, g))*get(weight_map, e);//get(from_rank, source(e, g)) / out_degree(source(e, g), g);
+                    auto v_score = (damping_type(1) - damping) * get(personalization_map, v) + damping * rank;
+                    put(to_rank, v, v_score);
+                    l1_norm += v_score;
+                }
+                BGL_FORALL_VERTICES_T(v, g, Graph) put(to_rank, v, get(to_rank, v)/l1_norm);
             }
-            BGL_FORALL_VERTICES_T(v, g, Graph) put(to_rank, v, get(to_rank, v)/l1_norm);
-        }
-    } // end namespace detail
+        } // end namespace detail
 
-    template <
+        template <
         typename Graph,
         typename WeightMap,
         typename PersonalizationMap,
         typename RankMap,
         typename Done,
         typename RankMap2 >
-    void personalized_page_rank(
-        const Graph& g,
-        const WeightMap& weight_map,
-        PersonalizationMap personalization_map,
-        RankMap rank_map,
-        Done& done,
-        typename property_traits< RankMap >::value_type damping,
-        typename graph_traits< Graph >::vertices_size_type n,
-        RankMap2 rank_map2
-        BOOST_GRAPH_ENABLE_IF_MODELS_PARM(Graph, vertex_list_graph_tag))
-    {
-        typedef typename property_traits< PersonalizationMap >::value_type rank_type;
-
-        rank_type personalization_norm(0);
-        BGL_FORALL_VERTICES_T(v, g, Graph) personalization_norm += get(personalization_map, v);
-        if(!personalization_norm)
-            boost::throw_exception(zero_personalization());
-
-        // TBD: This implementation couples iterators when possible under reduced L1 cache invalidation assumptions,
-        // but this is not necessarily the case because we may be grabbing twice memory lanes each time to write there.
-        // Should investigate which pattern is faster.
-        BGL_FORALL_VERTICES_T(v, g, Graph)
+        void personalized_page_rank(
+            const Graph& g,
+            WeightMap weight_map,
+            PersonalizationMap personalization_map,
+            RankMap rank_map,
+            Done& done,
+            typename property_traits< RankMap >::value_type damping,
+            typename graph_traits< Graph >::vertices_size_type n,
+            RankMap2 rank_map2
+            BOOST_GRAPH_ENABLE_IF_MODELS_PARM(Graph, vertex_list_graph_tag))
         {
-            rank_type value = get(personalization_map, v)/personalization_norm;
-            put(personalization_map, v, value);
-            put(rank_map, v, value);
-        }
+            typedef typename property_traits< PersonalizationMap >::value_type rank_type;
 
-        bool to_map_2 = true;
-        do
-        {
-            typedef typename graph_traits< Graph >::traversal_category category;
-            if (to_map_2)
-                detail::personalized_page_rank_step(g, weight_map, personalization_map, rank_map, rank_map2, damping, category());
+            rank_type personalization_norm(0);
+            BGL_FORALL_VERTICES_T(v, g, Graph) personalization_norm += get(personalization_map, v);
+
+            // TBD: This implementation couples iterators when possible under reduced L1 cache invalidation assumptions,
+            // but this is not necessarily the case because we may be grabbing 2x memory lanes each time to write there.
+            // Should investigate which pattern is faster.
+            BGL_FORALL_VERTICES_T(v, g, Graph)
+            {
+                rank_type value = get(personalization_map, v)/personalization_norm;
+                put(personalization_map, v, value);
+                put(rank_map, v, value);
+            }
+
+            bool to_map_2 = true;
+            do
+            {
+                typedef typename graph_traits< Graph >::traversal_category category;
+                if (to_map_2)
+                    detail::personalized_page_rank_step(g, weight_map, personalization_map, rank_map, rank_map2, damping, category());
+                else
+                    detail::personalized_page_rank_step(g, weight_map, personalization_map, rank_map2, rank_map, damping, category());
+                to_map_2 = !to_map_2;
+            } while (!done(rank_map, rank_map2, g)); // Symmetric call signature that should be unaffected by mode.
+
+            // Now multiply the result with personalization_norm to restore the order of magnitude and store it in rank_map.
+            // Also restore the original personalization_map's magnitude for reuse (this is only a tiny bit lossy).'
+            if (!to_map_2)
+            {
+                BGL_FORALL_VERTICES_T(v, g, Graph)
+                {
+                    put(rank_map, v, get(rank_map2, v)*personalization_norm);
+                    put(personalization_map, v, get(personalization_map, v)*personalization_norm);
+                }
+            }
             else
-                detail::personalized_page_rank_step(g, weight_map, personalization_map, rank_map2, rank_map, damping, category());
-            to_map_2 = !to_map_2;
-        } while (!done(rank_map, rank_map2, g)); // Symmetric call signature that should be unaffected by mode.
-
-        // Now multiply the result with personalization_norm to restore the order of magnitude and store it in rank_map.
-        // Also restore the original personalization_map's magnitude for reuse (this is only a tiny bit lossy).'
-        if (!to_map_2)
-        {
-            BGL_FORALL_VERTICES_T(v, g, Graph)
             {
-                put(rank_map, v, get(rank_map2, v)*personalization_norm);
-                put(personalization_map, v, get(personalization_map, v)*personalization_norm);
+                BGL_FORALL_VERTICES_T(v, g, Graph)
+                {
+                    put(rank_map, v, get(rank_map, v)*personalization_norm);
+                    put(personalization_map, v, get(personalization_map, v)*personalization_norm);
+                }
             }
         }
-        else
-        {
-            BGL_FORALL_VERTICES_T(v, g, Graph)
-            {
-                put(rank_map, v, get(rank_map, v)*personalization_norm);
-                put(personalization_map, v, get(personalization_map, v)*personalization_norm);
-            }
-        }
-    }
 
-    template <
+        template <
         typename Graph,
         typename WeightMap,
         typename PersonalizationMap,
         typename RankMap,
         typename Done >
-    void personalized_page_rank(
-        const Graph& g,
-        const WeightMap& weight_map,
-        PersonalizationMap personalization_map,
-        RankMap rank_map,
-        Done& done,
-        typename property_traits< RankMap >::value_type damping,
-        typename graph_traits< Graph >::vertices_size_type n)
-    {
-        typedef typename property_traits< RankMap >::value_type rank_type;
+        void personalized_page_rank(
+            const Graph& g,
+            WeightMap weight_map,
+            PersonalizationMap personalization_map,
+            RankMap rank_map,
+            Done& done,
+            typename property_traits< RankMap >::value_type damping,
+            typename graph_traits< Graph >::vertices_size_type n)
+        {
+            typedef typename property_traits< RankMap >::value_type rank_type;
 
-        std::vector< rank_type > ranks2(num_vertices(g));
-        personalized_page_rank(g, weight_map, personalization_map, rank_map, done, damping, n,
-            make_iterator_property_map(ranks2.begin(), get(vertex_index, g)));
-    }
+            std::vector< rank_type > ranks2(num_vertices(g));
+            personalized_page_rank(g, weight_map, personalization_map, rank_map, done, damping, n,
+                                   make_iterator_property_map(ranks2.begin(), get(vertex_index, g)));
+        }
 
-    template <
+        template <
         typename Graph,
         typename WeightMap,
         typename PersonalizationMap,
         typename RankMap,
         typename Done >
-    inline void personalized_page_rank(
-        const Graph& g,
-        const WeightMap& weight_map,
-        PersonalizationMap personalization_map,
-        RankMap rank_map,
-        Done& done,
-        typename property_traits< RankMap >::value_type damping = 0.85)
-    {
-        personalized_page_rank(g, weight_map, personalization_map, rank_map, done, damping, num_vertices(g));
-    }
+        inline void personalized_page_rank(
+            const Graph& g,
+            WeightMap weight_map,
+            PersonalizationMap personalization_map,
+            RankMap rank_map,
+            Done& done,
+            typename property_traits< RankMap >::value_type damping = 0.85)
+        {
+            personalized_page_rank(g, weight_map, personalization_map, rank_map, done, damping, num_vertices(g));
+        }
 
-    template <
+        template <
         typename Graph,
         typename WeightMap,
         typename PersonalizationMap,
         typename RankMap >
-    inline void personalized_page_rank(
-        const Graph& g,
-        const WeightMap& weight_map,
-        PersonalizationMap personalization_map,
-        RankMap rank_map,
-        typename property_traits< RankMap >::value_type damping = 0.85)
-    {
-        std::size_t n_iters(1.0/(1-damping)+0.5); // accounts for "most" random walks
-        auto convergence = vertex_map_convergence(n_iters);
-        personalized_page_rank(g, weight_map, personalization_map, rank_map, convergence, damping, num_vertices(g));
-    }
+        inline void personalized_page_rank(
+            const Graph& g,
+            WeightMap weight_map,
+            PersonalizationMap personalization_map,
+            RankMap rank_map,
+            typename property_traits< RankMap >::value_type damping = 0.85)
+        {
+            std::size_t n_iters(1.0/(1-damping)+0.5); // accounts for "most" random walks
+            auto convergence = vertex_map_convergence(n_iters);
+            personalized_page_rank(g, weight_map, personalization_map, rank_map, convergence, damping, num_vertices(g));
+        }
 
-    template <
+        template <
         typename Graph,
         typename PersonalizationMap,
         typename RankMap >
-    inline void personalized_page_rank(
-        const Graph& g,
-        PersonalizationMap personalization_map,
-        RankMap rank_map,
-        typename property_traits< RankMap >::value_type damping = 0.85)
-    {
-        personalized_page_rank(g, asymmetric_normalization(g), personalization_map, rank_map);
-    }
+        inline void personalized_page_rank(
+            const Graph& g,
+            PersonalizationMap personalization_map,
+            RankMap rank_map,
+            typename property_traits< RankMap >::value_type damping = 0.85)
+        {
+            personalized_page_rank(g, asymmetric_normalization(g), personalization_map, rank_map);
+        }
 
-}
+    }
 } // end namespace boost::graph
 
-#include BOOST_GRAPH_MPI_INCLUDE(<boost/graph/distributed/personalized_page_rank.hpp>)
-
-#endif // BOOST_GRAPH_PAGE_RANK_HPP
+#endif // BOOST_GRAPH_PERSONALIZED_PAGE_RANK_HPP

--- a/include/boost/graph/personalized_page_rank.hpp
+++ b/include/boost/graph/personalized_page_rank.hpp
@@ -21,278 +21,318 @@
 
 namespace boost
 {
-    namespace graph
+namespace graph
+{
+
+    template < typename Graph >
+    auto markovian_weights(const Graph& g)
     {
-
-        template < typename Graph >
-        auto asymmetric_normalization_weights(const Graph& g) {
-            using Edge = typename boost::graph_traits<Graph>::edge_descriptor;
-            return make_function_property_map<Edge, double>(
-                [&g](Edge e) {
+        using Edge = typename boost::graph_traits<Graph>::edge_descriptor;
+        return make_function_property_map<Edge, double>(
+            [&g](Edge e)
+                {
                     auto u = source(e, g);
-                    return 1.0 / out_degree(u, g);
-                });
-        }
+                    auto denom = out_degree(u, g);;
+                    if(!denom) return denom;
+                    return 1.0 / denom;
+                }
+        );
+    }
 
-        template < typename Graph >
-        auto symmetric_normalization_weights(const Graph& g) {
-            using Edge = typename boost::graph_traits<Graph>::edge_descriptor;
-            return make_function_property_map<Edge, double>(
-                [&g](Edge e) {
+    template < typename Graph >
+    auto spectral_weights(const Graph& g)
+    {
+        using Edge = typename boost::graph_traits<Graph>::edge_descriptor;
+        return make_function_property_map<Edge, double>(
+            [&g](Edge e)
+                {
                     auto u = source(e, g);
                     auto v = target(e, g);
-                    return 1.0 / std::sqrt(out_degree(u, g) * out_degree(v, g));
-                });
+                    std::size_t denom;
+                    if constexpr (boost::is_bidirectional_graph<Graph>::value)
+                        denom = out_degree(u, g) * in_degree(v, g);
+                    else
+                        denom = out_degree(u, g) * out_degree(v, g);
+                    return 1.0 / std::sqrt(denom);
+                }
+        );
+    }
+
+    template < typename Graph >
+    auto renormalized_weights(const Graph& g)
+    {
+        using Edge = typename boost::graph_traits<Graph>::edge_descriptor;
+        return make_function_property_map<Edge, double>(
+            [&g](Edge e)
+                {
+                    auto u = source(e, g);
+                    auto v = target(e, g);
+                    std::size_t denom;
+                    if constexpr (boost::is_bidirectional_graph<Graph>::value)
+                        denom = (1+out_degree(u, g)) * (1+in_degree(v, g));
+                    else
+                        denom = (1+out_degree(u, g)) * (1+out_degree(v, g));
+                    return 1.0 / std::sqrt(denom);
+                }
+        );
+    }
+
+    class BOOST_SYMBOL_VISIBLE vertex_map_not_converged : public std::exception
+    {
+    };
+    class BOOST_SYMBOL_VISIBLE zero_personalization : public std::exception
+    {
+    };
+
+    struct vertex_map_convergence
+    {
+        explicit vertex_map_convergence(std::size_t n, double tol=0) : n(n), tol(tol) {} // allowing tolerance for early stopping
+
+        template < typename RankMap, typename RankMap2, typename Graph >
+        bool operator()(
+            const RankMap& rank_map,
+            const RankMap2& rank_map2,
+            const Graph& g)
+        {
+            if ( n-- == 0 )
+            {
+                if(tol)
+                    boost::throw_exception(vertex_map_not_converged());
+                return true;
+            }
+            if (!tol)
+                return false;
+
+            typedef typename property_traits< RankMap >::value_type rank_type;
+            rank_type sum_abs(0);
+            BGL_FORALL_VERTICES_T(v, g, Graph)
+            {
+                rank_type difference = get(rank_map, v)-get(rank_map2, v);
+                if(difference<0)
+                    difference = -difference;
+                sum_abs += difference;
+            }
+            return sum_abs*num_vertices(g)<tol;
         }
 
-        class BOOST_SYMBOL_VISIBLE vertex_map_not_converged : public std::exception
+        std::size_t get_remaining_iters() const
         {
-        };
+            return n;
+        }
 
-        struct vertex_map_convergence
-        {
-            explicit vertex_map_convergence(std::size_t n, double tol=0) : n(n), tol(tol) {} // allowing tolerance for early stopping
+    private:
+        std::size_t n;
+        double tol;
+    };
 
-            template < typename RankMap, typename RankMap2, typename Graph >
-            bool operator()(
-                const RankMap& rank_map,
-                const RankMap2& rank_map2,
-                const Graph& g)
-            {
-                if ( n-- == 0 )
-                {
-                    if(tol) boost::throw_exception(vertex_map_not_converged());
-                    return true;
-                }
-                if (!tol)
-                    return false;
-
-                typedef typename property_traits< RankMap >::value_type rank_type;
-                rank_type sum_abs(0);
-                BGL_FORALL_VERTICES_T(v, g, Graph)
-                {
-                    rank_type difference = get(rank_map, v)-get(rank_map2, v);
-                    if(difference<0)
-                        difference = -difference;
-                    sum_abs += difference;
-                }
-                return sum_abs<tol;
-            }
-
-            std::size_t get_remaining_iters() const
-            {
-                return n;
-            }
-
-        private:
-            std::size_t n;
-            double tol;
-        };
-
-        namespace detail
-        {
-            template <
+    namespace detail
+    {
+        template <
             typename Graph,
             typename WeightMap,
             typename PersonalizationMap,
             typename RankMap,
             typename RankMap2 >
-            void personalized_page_rank_step(
-                const Graph& g,
-                const WeightMap& weight_map,
-                PersonalizationMap personalization_map,
-                RankMap from_rank,
-                RankMap2 to_rank,
-                typename property_traits< RankMap >::value_type damping,
-                incidence_graph_tag)
-            {
-                typedef typename property_traits< RankMap >::value_type rank_type;
-                rank_type l1_norm(0); // Computing the norm simultaneously avoids an extra summing iteration.
+        void personalized_page_rank_step(
+            const Graph& g,
+            const WeightMap& weight_map,
+            PersonalizationMap personalization_map,
+            RankMap from_rank,
+            RankMap2 to_rank,
+            typename property_traits< RankMap >::value_type damping,
+            incidence_graph_tag)
+        {
+            typedef typename property_traits< RankMap >::value_type rank_type;
+            rank_type l1_norm(0); // Computing the norm simultaneously avoids an extra summing iteration.
 
-                // Initialize the constant part of maps
-                BGL_FORALL_VERTICES_T(v, g, Graph) {
-                    auto v_constant = rank_type(1 - damping) * get(personalization_map, v);
-                    put(to_rank, v, v_constant);
-                    l1_norm += v_constant;
-                }
-
-                BGL_FORALL_VERTICES_T(u, g, Graph)
-                {
-                    rank_type u_rank_factor = damping * get(from_rank, u);
-                    rank_type l1_accumulated_norm(0); // TBD: Consider making l1_norm volatile even, to reduce accumulation errors.
-                    BGL_FORALL_OUTEDGES_T(u, e, g, Graph)
-                    {
-                        auto v = target(e, g);
-                        rank_type u_rank_out = get(weight_map, e)*u_rank_factor;
-                        put(to_rank, v, get(to_rank, v) + u_rank_out);
-                        l1_accumulated_norm += u_rank_out;
-                    }
-                    l1_norm += l1_accumulated_norm;
-                }
-                BGL_FORALL_VERTICES_T(v, g, Graph) put(to_rank, v, get(to_rank, v)/l1_norm);
+            // Initialize the constant part of maps
+            BGL_FORALL_VERTICES_T(v, g, Graph) {
+                auto v_constant = rank_type(1 - damping) * get(personalization_map, v);
+                put(to_rank, v, v_constant);
+                l1_norm += v_constant;
             }
 
-            template <
-            typename Graph,
-            typename WeightMap,
-            typename PersonalizationMap,
-            typename RankMap,
-            typename RankMap2 >
-            void page_rank_step(
-                const Graph& g,
-                const WeightMap& weight_map,
-                PersonalizationMap personalization_map,
-                RankMap from_rank,
-                RankMap2 to_rank,
-                typename property_traits< RankMap >::value_type damping,
-                bidirectional_graph_tag)
+            BGL_FORALL_VERTICES_T(u, g, Graph)
             {
-                typedef typename property_traits< RankMap >::value_type damping_type;
-                damping_type l1_norm(0); // Computing the norm simultaneously avoids an extra summing iteration.
-                BGL_FORALL_VERTICES_T(v, g, Graph)
+                rank_type u_rank_factor = damping * get(from_rank, u);
+                rank_type l1_accumulated_norm(0); // TBD: Consider making l1_norm volatile to reduce accumulation errors.
+                BGL_FORALL_OUTEDGES_T(u, e, g, Graph)
                 {
-                    typename property_traits< RankMap >::value_type rank(0);
-                    BGL_FORALL_INEDGES_T(v, e, g, Graph) rank += get(from_rank, source(e, g))*get(weight_map, e);//get(from_rank, source(e, g)) / out_degree(source(e, g), g);
-                    auto v_score = (damping_type(1) - damping) * get(personalization_map, v) + damping * rank;
-                    put(to_rank, v, v_score);
-                    l1_norm += v_score;
+                    auto v = target(e, g);
+                    rank_type u_rank_out = get(weight_map, e)*u_rank_factor;
+                    put(to_rank, v, get(to_rank, v) + u_rank_out);
+                    l1_accumulated_norm += u_rank_out;
                 }
-                BGL_FORALL_VERTICES_T(v, g, Graph) put(to_rank, v, get(to_rank, v)/l1_norm);
+                l1_norm += l1_accumulated_norm;
             }
-        } // end namespace detail
+            BGL_FORALL_VERTICES_T(v, g, Graph) put(to_rank, v, get(to_rank, v)/l1_norm);
+        }
 
         template <
+            typename Graph,
+            typename WeightMap,
+            typename PersonalizationMap,
+            typename RankMap,
+            typename RankMap2 >
+        void page_rank_step(
+            const Graph& g,
+            const WeightMap& weight_map,
+            PersonalizationMap personalization_map,
+            RankMap from_rank,
+            RankMap2 to_rank,
+            typename property_traits< RankMap >::value_type damping,
+            bidirectional_graph_tag)
+        {
+            typedef typename property_traits< RankMap >::value_type damping_type;
+            damping_type l1_norm(0); // Computing the norm simultaneously avoids an extra summing iteration.
+            BGL_FORALL_VERTICES_T(v, g, Graph)
+            {
+                typename property_traits< RankMap >::value_type rank(0);
+                BGL_FORALL_INEDGES_T(v, e, g, Graph) rank += get(from_rank, source(e, g))*get(weight_map, e);//get(from_rank, source(e, g)) / out_degree(source(e, g), g);
+                auto v_score = (damping_type(1) - damping) * get(personalization_map, v) + damping * rank;
+                put(to_rank, v, v_score);
+                l1_norm += v_score;
+            }
+            BGL_FORALL_VERTICES_T(v, g, Graph) put(to_rank, v, get(to_rank, v)/l1_norm);
+        }
+    } // end namespace detail
+
+    template <
         typename Graph,
         typename WeightMap,
         typename PersonalizationMap,
         typename RankMap,
         typename Done,
         typename RankMap2 >
-        void personalized_page_rank(
-            const Graph& g,
-            const WeightMap& weight_map,
-            PersonalizationMap personalization_map,
-            RankMap rank_map,
-            Done& done,
-            typename property_traits< RankMap >::value_type damping,
-            typename graph_traits< Graph >::vertices_size_type n,
-            RankMap2 rank_map2
-            BOOST_GRAPH_ENABLE_IF_MODELS_PARM(Graph, vertex_list_graph_tag))
+    void personalized_page_rank(
+        const Graph& g,
+        const WeightMap& weight_map,
+        PersonalizationMap personalization_map,
+        RankMap rank_map,
+        Done& done,
+        typename property_traits< RankMap >::value_type damping,
+        typename graph_traits< Graph >::vertices_size_type n,
+        RankMap2 rank_map2
+        BOOST_GRAPH_ENABLE_IF_MODELS_PARM(Graph, vertex_list_graph_tag))
+    {
+        typedef typename property_traits< PersonalizationMap >::value_type rank_type;
+
+        rank_type personalization_norm(0);
+        BGL_FORALL_VERTICES_T(v, g, Graph) personalization_norm += get(personalization_map, v);
+        if(!personalization_norm)
+            boost::throw_exception(zero_personalization());
+
+        // TBD: This implementation couples iterators when possible under reduced L1 cache invalidation assumptions,
+        // but this is not necessarily the case because we may be grabbing twice memory lanes each time to write there.
+        // Should investigate which pattern is faster.
+        BGL_FORALL_VERTICES_T(v, g, Graph)
         {
-            typedef typename property_traits< PersonalizationMap >::value_type rank_type;
+            rank_type value = get(personalization_map, v)/personalization_norm;
+            put(personalization_map, v, value);
+            put(rank_map, v, value);
+        }
 
-            rank_type personalization_norm(0);
-            BGL_FORALL_VERTICES_T(v, g, Graph) personalization_norm += get(personalization_map, v);
-            if(!personalization_norm) personalization_norm = 1; // TBD: perhaps throw error here
+        bool to_map_2 = true;
+        do
+        {
+            typedef typename graph_traits< Graph >::traversal_category category;
+            if (to_map_2)
+                detail::personalized_page_rank_step(g, weight_map, personalization_map, rank_map, rank_map2, damping, category());
+            else
+                detail::personalized_page_rank_step(g, weight_map, personalization_map, rank_map2, rank_map, damping, category());
+            to_map_2 = !to_map_2;
+        } while (!done(rank_map, rank_map2, g)); // Symmetric call signature that should be unaffected by mode.
 
-            // TBD: This implementation couples iterators when possible under reduced L1 cache invalidation assumptions,
-            // but this is not ncessarily the case due to writes. Perhaps investigate which pattern is faster.
+        // Now multiply the result with personalization_norm to restore the order of magnitude and store it in rank_map.
+        // Also restore the original personalization_map's magnitude for reuse (this is only a tiny bit lossy).'
+        if (!to_map_2)
+        {
             BGL_FORALL_VERTICES_T(v, g, Graph)
             {
-                rank_type value = get(personalization_map, v)/personalization_norm;
-                put(personalization_map, v, value);
-                put(rank_map, v, value);
-            }
-
-            bool to_map_2 = true;
-            do
-            {
-                typedef typename graph_traits< Graph >::traversal_category category;
-                if (to_map_2)
-                    detail::personalized_page_rank_step(g, weight_map, personalization_map, rank_map, rank_map2, damping, category());
-                else
-                    detail::personalized_page_rank_step(g, weight_map, personalization_map, rank_map2, rank_map, damping, category());
-                to_map_2 = !to_map_2;
-            } while (!done(rank_map, rank_map2, g)); // Symmetric call signature that should be unaffected by mode.
-
-            if (!to_map_2)
-            {
-                BGL_FORALL_VERTICES_T(v, g, Graph)
-                {
-                    put(rank_map, v, get(rank_map2, v)*personalization_norm);
-                    put(personalization_map, v, get(personalization_map, v)*personalization_norm); // restore to near-exact original
-                }
-            }
-            else
-            {
-                BGL_FORALL_VERTICES_T(v, g, Graph)
-                {
-                    put(rank_map, v, get(rank_map, v)*personalization_norm);
-                    put(personalization_map, v, get(personalization_map, v)*personalization_norm); // restore to near-exact original
-                }
+                put(rank_map, v, get(rank_map2, v)*personalization_norm);
+                put(personalization_map, v, get(personalization_map, v)*personalization_norm);
             }
         }
-
-        template <
-        typename Graph,
-        typename WeightMap,
-        typename PersonalizationMap,
-        typename RankMap,
-        typename Done >
-        void personalized_page_rank(
-            const Graph& g,
-            const WeightMap& weight_map,
-            PersonalizationMap personalization_map,
-            RankMap rank_map,
-            Done& done,
-            typename property_traits< RankMap >::value_type damping,
-            typename graph_traits< Graph >::vertices_size_type n)
+        else
         {
-            typedef typename property_traits< RankMap >::value_type rank_type;
-
-            std::vector< rank_type > ranks2(num_vertices(g));
-            personalized_page_rank(g, weight_map, personalization_map, rank_map, done, damping, n,
-                                   make_iterator_property_map(ranks2.begin(), get(vertex_index, g)));
+            BGL_FORALL_VERTICES_T(v, g, Graph)
+            {
+                put(rank_map, v, get(rank_map, v)*personalization_norm);
+                put(personalization_map, v, get(personalization_map, v)*personalization_norm);
+            }
         }
-
-        template <
-        typename Graph,
-        typename WeightMap,
-        typename PersonalizationMap,
-        typename RankMap,
-        typename Done >
-        inline void personalized_page_rank(
-            const Graph& g,
-            const WeightMap& weight_map,
-            PersonalizationMap personalization_map,
-            RankMap rank_map,
-            Done& done,
-            typename property_traits< RankMap >::value_type damping = 0.85)
-        {
-            personalized_page_rank(g, weight_map, personalization_map, rank_map, done, damping, num_vertices(g));
-        }
-
-        template <
-        typename Graph,
-        typename WeightMap,
-        typename PersonalizationMap,
-        typename RankMap >
-        inline void personalized_page_rank(
-            const Graph& g,
-            const WeightMap& weight_map,
-            PersonalizationMap personalization_map,
-            RankMap rank_map,
-            typename property_traits< RankMap >::value_type damping = 0.85)
-        {
-            std::size_t n_iters(1.0/(1-damping)+0.5); // accounts for "most" random walks
-            auto convergence = vertex_map_convergence(n_iters);
-            personalized_page_rank(g, weight_map, personalization_map, rank_map, convergence, damping, num_vertices(g));
-        }
-
-        template <
-        typename Graph,
-        typename PersonalizationMap,
-        typename RankMap >
-        inline void personalized_page_rank(
-            const Graph& g,
-            PersonalizationMap personalization_map,
-            RankMap rank_map,
-            typename property_traits< RankMap >::value_type damping = 0.85)
-        {
-            personalized_page_rank(g, asymmetric_normalization(g), personalization_map, rank_map);
-        }
-
     }
+
+    template <
+        typename Graph,
+        typename WeightMap,
+        typename PersonalizationMap,
+        typename RankMap,
+        typename Done >
+    void personalized_page_rank(
+        const Graph& g,
+        const WeightMap& weight_map,
+        PersonalizationMap personalization_map,
+        RankMap rank_map,
+        Done& done,
+        typename property_traits< RankMap >::value_type damping,
+        typename graph_traits< Graph >::vertices_size_type n)
+    {
+        typedef typename property_traits< RankMap >::value_type rank_type;
+
+        std::vector< rank_type > ranks2(num_vertices(g));
+        personalized_page_rank(g, weight_map, personalization_map, rank_map, done, damping, n,
+            make_iterator_property_map(ranks2.begin(), get(vertex_index, g)));
+    }
+
+    template <
+        typename Graph,
+        typename WeightMap,
+        typename PersonalizationMap,
+        typename RankMap,
+        typename Done >
+    inline void personalized_page_rank(
+        const Graph& g,
+        const WeightMap& weight_map,
+        PersonalizationMap personalization_map,
+        RankMap rank_map,
+        Done& done,
+        typename property_traits< RankMap >::value_type damping = 0.85)
+    {
+        personalized_page_rank(g, weight_map, personalization_map, rank_map, done, damping, num_vertices(g));
+    }
+
+    template <
+        typename Graph,
+        typename WeightMap,
+        typename PersonalizationMap,
+        typename RankMap >
+    inline void personalized_page_rank(
+        const Graph& g,
+        const WeightMap& weight_map,
+        PersonalizationMap personalization_map,
+        RankMap rank_map,
+        typename property_traits< RankMap >::value_type damping = 0.85)
+    {
+        std::size_t n_iters(1.0/(1-damping)+0.5); // accounts for "most" random walks
+        auto convergence = vertex_map_convergence(n_iters);
+        personalized_page_rank(g, weight_map, personalization_map, rank_map, convergence, damping, num_vertices(g));
+    }
+
+    template <
+        typename Graph,
+        typename PersonalizationMap,
+        typename RankMap >
+    inline void personalized_page_rank(
+        const Graph& g,
+        PersonalizationMap personalization_map,
+        RankMap rank_map,
+        typename property_traits< RankMap >::value_type damping = 0.85)
+    {
+        personalized_page_rank(g, asymmetric_normalization(g), personalization_map, rank_map);
+    }
+
+}
 } // end namespace boost::graph
 
 #include BOOST_GRAPH_MPI_INCLUDE(<boost/graph/distributed/personalized_page_rank.hpp>)

--- a/include/boost/graph/personalized_page_rank.hpp
+++ b/include/boost/graph/personalized_page_rank.hpp
@@ -38,6 +38,7 @@ namespace graph
                 sum_abs += std::abs(get(current, v) - get(previous, v));
             return sum_abs*num_vertices(g)<tol;
         }
+    protected:
         std::size_t iters;
         double tol;
     };
@@ -140,6 +141,17 @@ namespace graph
         RankMap2 rank_map2
         BOOST_GRAPH_ENABLE_IF_MODELS_PARM(Graph, vertex_list_graph_tag))
     {
+        using Vertex = typename graph_traits<Graph>::vertex_descriptor;
+        using Edge = typename graph_traits<Graph>::edge_descriptor;
+        BOOST_CONCEPT_ASSERT(( boost::IncidenceGraphConcept<Graph> ));
+        BOOST_CONCEPT_ASSERT(( boost::VertexListGraphConcept<Graph> ));
+        BOOST_CONCEPT_ASSERT(( boost::ReadablePropertyMapConcept<WeightMap, Edge> ));
+        BOOST_CONCEPT_ASSERT(( boost::ReadablePropertyMapConcept<PersonalizationMap, Vertex>));
+        BOOST_CONCEPT_ASSERT(( boost::ReadWritePropertyMapConcept<RankMap,  Vertex> ));
+
+
+        assert (damping>=-1.0 && damping<1.0 && "Damping outside the closed-open range [-1.0,1.0) could induce numerical instability."); // non-inclussive upper limit is deliberate
+
         using rank_type = typename property_traits< PersonalizationMap >::value_type;
         rank_type personalization_norm(0);
         for (auto v : boost::make_iterator_range(vertices(g))) 

--- a/include/boost/graph/personalized_page_rank.hpp
+++ b/include/boost/graph/personalized_page_rank.hpp
@@ -12,10 +12,14 @@
 #include <boost/property_map/property_map.hpp>
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/properties.hpp>
-#include <boost/graph/iteration_macros.hpp>
-#include <boost/graph/overloading.hpp>
-#include <boost/graph/detail/mpi_include.hpp>
 #include <boost/property_map/function_property_map.hpp>
+#include <boost/range/iterator_range.hpp>
+#include <boost/concept/assert.hpp>
+#include <boost/graph/graph_concepts.hpp>
+#include <boost/assert.hpp>
+
+#include <cmath>
+#include <cstddef>
 #include <vector>
 
 namespace boost
@@ -138,19 +142,19 @@ namespace graph
         RankMap rank_map,
         Done done,
         typename property_traits< RankMap >::value_type damping,
-        RankMap2 rank_map2
-        BOOST_GRAPH_ENABLE_IF_MODELS_PARM(Graph, vertex_list_graph_tag))
+        RankMap2 rank_map2)
     {
         using Vertex = typename graph_traits<Graph>::vertex_descriptor;
         using Edge = typename graph_traits<Graph>::edge_descriptor;
         BOOST_CONCEPT_ASSERT(( boost::IncidenceGraphConcept<Graph> ));
         BOOST_CONCEPT_ASSERT(( boost::VertexListGraphConcept<Graph> ));
         BOOST_CONCEPT_ASSERT(( boost::ReadablePropertyMapConcept<WeightMap, Edge> ));
-        BOOST_CONCEPT_ASSERT(( boost::ReadablePropertyMapConcept<PersonalizationMap, Vertex>));
+        BOOST_CONCEPT_ASSERT(( boost::ReadWritePropertyMapConcept<PersonalizationMap, Vertex>));
         BOOST_CONCEPT_ASSERT(( boost::ReadWritePropertyMapConcept<RankMap,  Vertex> ));
+        BOOST_CONCEPT_ASSERT(( boost::ReadWritePropertyMapConcept<RankMap2,  Vertex> ));
 
 
-        assert (damping>=-1.0 && damping<1.0 && "Damping outside the closed-open range [-1.0,1.0) could induce numerical instability."); // non-inclussive upper limit is deliberate
+        BOOST_ASSERT_MSG (damping>=-1.0 && damping<1.0, "Damping outside the closed-open range [-1.0,1.0) could induce numerical instability."); // non-inclussive upper limit is deliberate
 
         using rank_type = typename property_traits< PersonalizationMap >::value_type;
         rank_type personalization_norm(0);
@@ -170,7 +174,7 @@ namespace graph
         bool to_map_2 = true;
         do
         {
-            typedef typename graph_traits< Graph >::traversal_category category;
+            using category = typename graph_traits< Graph >::traversal_category;
             if (to_map_2)
                 personalized_page_rank_detail::personalized_page_rank_step(g, weight_map, personalization_map, rank_map, rank_map2, damping, category());
             else

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -175,6 +175,7 @@ alias graph_test_regular :
     [ run delete_edge.cpp ]
     [ run johnson-test.cpp ]
     [ run lvalue_pmap.cpp ]
+    [ run personalized_pagerank_test.cpp ]
     ;
 
 alias graph_test_with_filesystem : :

--- a/test/personalized_pagerank_test.cpp
+++ b/test/personalized_pagerank_test.cpp
@@ -1,0 +1,68 @@
+
+#include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/personalized_page_rank.hpp>
+#include <boost/property_map/property_map.hpp>
+#include <iostream>
+#include <vector>
+#include <iomanip>
+
+int main(int, char*[]) {
+    using namespace boost;
+    // deliberately hard (slow-converging) graph
+    using Graph = adjacency_list<vecS, vecS, directedS>;
+    std::vector<std::pair<int,int>> edges = {
+        {0,1},{1,0},{1,2},{2,1},{2,3},{3,2},
+        {4,5},{5,4},{5,6},{6,5},{6,7},{7,6},{7,8},{8,7},{8,9},{9,8},{9,10},{10,9},
+        {0,3},{3,0},{1,3},{3,1},{1,4},{4,1},
+        {4,6},{6,4},{6,9},{9,6},{6,8},{8,6},{7,9},{9,7},{8,10},{10,8},
+        {11,10},{10,11},{10,12},{12,10}
+    };
+    Graph g(edges.begin(), edges.end(), 13);
+
+    std::vector<double> ranks(num_vertices(g));
+    auto rank_map = make_iterator_property_map(ranks.begin(), get(vertex_index, g));
+    std::vector<double> personalization(num_vertices(g));
+    auto personalization_map = make_iterator_property_map(personalization.begin(), get(vertex_index, g));
+    personalization[0] = 1;
+    personalization[1] = 1;
+    personalization[2] = 1;
+    personalization[3] = 1;
+
+    std::size_t max_iters(100); // Convergence is so bad in this graph that it needs such a high cap.
+    auto weight = spectral_weights(g);
+    auto convergence1 = graph::vertex_map_convergence(max_iters, 1.E-9);
+    convergence1 = graph::personalized_page_rank(g, weight, personalization_map, rank_map, convergence1);
+
+    std::cout << "ended after "<<max_iters-convergence1.get_remaining_iters() << " iterations\n";
+    std::cout << std::fixed << std::setprecision(4);
+    for (std::size_t v = 0; v < num_vertices(g); ++v) 
+    {
+        std::cout << "vertex " << v << "  rank=" << ranks[v] << "\n";
+    }
+    BOOST_ASSERT(ranks[0]==ranks[2]); // should be exactly equal due to symmetry, even when considering floating point coarseness
+    BOOST_ASSERT(ranks[0]<ranks[1]+0.1);
+    BOOST_ASSERT(ranks[8]==ranks[9]);
+    BOOST_ASSERT(ranks[11]==ranks[12]);
+    BOOST_ASSERT(ranks[11]>0);
+    BOOST_ASSERT(convergence1.has_converged());
+
+    // COMPUTING A HIGH-PASS VERSION BY PASSING NEGATIVE DAMPING (resulting values can be negative)
+    // This is not completely correct yet for computing graph gradients, because it needs to eskew normalization,
+    // so we need to be able to customize said normalization.
+    // Damping should generaly be in the range [-1,1].
+    auto renorm_weight = renormalized_weights(g);
+    auto convergence2 = graph::vertex_map_convergence(max_iters, 1.E-9);
+    convergence2 = graph::personalized_page_rank(g, renorm_weight, personalization_map, rank_map, convergence2, -0.8);
+    std::cout << "ended after "<<max_iters-convergence2.get_remaining_iters() << " iterations\n";
+    std::cout << std::fixed << std::setprecision(4);
+    for (std::size_t v = 0; v < num_vertices(g); ++v) 
+    {
+        std::cout << "vertex " << v << "  flow=" << ranks[v] << "\n";
+    }
+    BOOST_ASSERT(ranks[0]==ranks[2]); // should be exactly equal due to symmetry, even when considering floating point coarseness
+    BOOST_ASSERT(ranks[0]>ranks[1]+0.1);
+    BOOST_ASSERT(ranks[8]==ranks[9]);
+    BOOST_ASSERT(ranks[11]==ranks[12]);
+    BOOST_ASSERT(ranks[11]<0);
+    BOOST_ASSERT(convergence1.has_converged());
+}

--- a/test/personalized_pagerank_test.cpp
+++ b/test/personalized_pagerank_test.cpp
@@ -18,7 +18,7 @@ int main(int, char*[]) {
         {11,10},{10,11},{10,12},{12,10}
     };
     Graph g(edges.begin(), edges.end(), 13);
-
+    
     std::vector<double> ranks(num_vertices(g));
     auto rank_map = make_iterator_property_map(ranks.begin(), get(vertex_index, g));
     std::vector<double> personalization(num_vertices(g));
@@ -29,11 +29,13 @@ int main(int, char*[]) {
     personalization[3] = 1;
 
     std::size_t max_iters(100); // Convergence is so bad in this graph that it needs such a high cap.
-    auto weight = spectral_weights(g);
-    auto convergence1 = graph::vertex_map_convergence(max_iters, 1.E-9);
-    convergence1 = graph::personalized_page_rank(g, weight, personalization_map, rank_map, convergence1);
+    using Edge = graph_traits<Graph>::edge_descriptor;
+    auto weight = make_function_property_map<Edge, double>(
+        [&g](Edge e){ return 1.0 / std::sqrt(double(out_degree(source(e, g), g) * out_degree(target(e, g), g))); });
+    auto convergence1 = graph::rank_convergence(max_iters, 1.E-9);
+    convergence1 = graph::personalized_page_rank(g, weight, personalization_map, rank_map, convergence1, 0.9);
 
-    std::cout << "ended after "<<max_iters-convergence1.get_remaining_iters() << " iterations\n";
+    std::cout << "ended after "<<max_iters-convergence1.iters << " iterations\n";
     std::cout << std::fixed << std::setprecision(4);
     for (std::size_t v = 0; v < num_vertices(g); ++v) 
     {
@@ -44,16 +46,17 @@ int main(int, char*[]) {
     BOOST_ASSERT(ranks[8]==ranks[9]);
     BOOST_ASSERT(ranks[11]==ranks[12]);
     BOOST_ASSERT(ranks[11]>0);
-    BOOST_ASSERT(convergence1.has_converged());
+    BOOST_ASSERT(convergence1.iters<max_iters);
 
     // COMPUTING A HIGH-PASS VERSION BY PASSING NEGATIVE DAMPING (resulting values can be negative)
     // This is not completely correct yet for computing graph gradients, because it needs to eskew normalization,
     // so we need to be able to customize said normalization.
     // Damping should generaly be in the range [-1,1].
-    auto renorm_weight = renormalized_weights(g);
-    auto convergence2 = graph::vertex_map_convergence(max_iters, 1.E-9);
+    auto renorm_weight = make_function_property_map<Edge, double>(
+        [&g](Edge e){ return 1.0 / std::sqrt(double((1.0+out_degree(source(e, g), g)) * (1.0+out_degree(target(e, g), g)))); });
+    auto convergence2 = graph::rank_convergence(max_iters, 1.E-9);
     convergence2 = graph::personalized_page_rank(g, renorm_weight, personalization_map, rank_map, convergence2, -0.8);
-    std::cout << "ended after "<<max_iters-convergence2.get_remaining_iters() << " iterations\n";
+    std::cout << "ended after "<<max_iters-convergence2.iters << " iterations\n";
     std::cout << std::fixed << std::setprecision(4);
     for (std::size_t v = 0; v < num_vertices(g); ++v) 
     {
@@ -64,5 +67,5 @@ int main(int, char*[]) {
     BOOST_ASSERT(ranks[8]==ranks[9]);
     BOOST_ASSERT(ranks[11]==ranks[12]);
     BOOST_ASSERT(ranks[11]<0);
-    BOOST_ASSERT(convergence1.has_converged());
+    BOOST_ASSERT(convergence2.iters<max_iters);
 }

--- a/test/personalized_pagerank_test.cpp
+++ b/test/personalized_pagerank_test.cpp
@@ -6,66 +6,72 @@
 #include <vector>
 #include <iomanip>
 
-int main(int, char*[]) {
-    using namespace boost;
-    // deliberately hard (slow-converging) graph
-    using Graph = adjacency_list<vecS, vecS, directedS>;
-    std::vector<std::pair<int,int>> edges = {
-        {0,1},{1,0},{1,2},{2,1},{2,3},{3,2},
-        {4,5},{5,4},{5,6},{6,5},{6,7},{7,6},{7,8},{8,7},{8,9},{9,8},{9,10},{10,9},
-        {0,3},{3,0},{1,3},{3,1},{1,4},{4,1},
-        {4,6},{6,4},{6,9},{9,6},{6,8},{8,6},{7,9},{9,7},{8,10},{10,8},
-        {11,10},{10,11},{10,12},{12,10}
+using DirectedGraph = typename boost::adjacency_list<boost::vecS, boost::vecS, boost::directedS>;
+using DirectedVertex = typename boost::graph_traits<DirectedGraph>::vertex_descriptor;
+using DirectedEdge = typename boost::graph_traits<DirectedGraph>::edge_descriptor;
+
+struct custom_rank_convergence: public boost::graph::rank_convergence
+{
+    explicit custom_rank_convergence(std::size_t iters, double tol=0) : boost::graph::rank_convergence(iters,tol) {}
+    std::size_t get_remaining_iters() const { return iters; }
+};
+
+void directed_graph_tests(double damping, double renormalize)
+{
+    std::vector<std::pair<std::vector<std::pair<int,int>>, int>> graph_defs = {
+        // deliberately hard symmetric graph
+        {{
+            {0,1},{1,0},{1,2},{2,1},{2,3},{3,2},
+            {4,5},{5,4},{5,6},{6,5},{6,7},{7,6},{7,8},{8,7},{8,9},{9,8},{9,10},{10,9},
+            {0,3},{3,0},{1,3},{3,1},{1,4},{4,1},
+            {4,6},{6,4},{6,9},{9,6},{6,8},{8,6},{7,9},{9,7},{8,10},{10,8},
+            {11,10},{10,11},{10,12},{12,10}
+        }, 13},
+        // undirected circle with 0 and 2 being symmetric, and a non-symmetric directed one-way blocks 2 hops away from 0 ({7,6} blocked) and 2 ({4,5} blocked)
+        {{ {0,1},{1,0},{1,3},{3,1},{3,2},{2,3},{2,4},{4,2},{5,4},{5,6},{6,5},{6,7},{7,0},{0,7}}, 8},
+        // fully undirected graph
+        {{ {0,1}, {2,1}, {0,3}, {2,3}, {3,4}, {4,5}, {1,5}, {5,2}, {5,0}}, 6},
+        // same as above but missing incoming edges for 0 and 2 (whole graph is a sink, needs correct normalization that guards against zero to not yield nans)
+        {{ {0,1}, {2,1}, {0,3}, {2,3}, {3,4}, {4,5}, {1,5}}, 6}
     };
-    Graph g(edges.begin(), edges.end(), 13);
-    
-    std::vector<double> ranks(num_vertices(g));
-    auto rank_map = make_iterator_property_map(ranks.begin(), get(vertex_index, g));
-    std::vector<double> personalization(num_vertices(g));
-    auto personalization_map = make_iterator_property_map(personalization.begin(), get(vertex_index, g));
-    personalization[0] = 1;
-    personalization[1] = 1;
-    personalization[2] = 1;
-    personalization[3] = 1;
-
-    std::size_t max_iters(100); // Convergence is so bad in this graph that it needs such a high cap.
-    using Edge = graph_traits<Graph>::edge_descriptor;
-    auto weight = make_function_property_map<Edge, double>(
-        [&g](Edge e){ return 1.0 / std::sqrt(double(out_degree(source(e, g), g) * out_degree(target(e, g), g))); });
-    auto convergence1 = graph::rank_convergence(max_iters, 1.E-9);
-    convergence1 = graph::personalized_page_rank(g, weight, personalization_map, rank_map, convergence1, 0.9);
-
-    std::cout << "ended after "<<max_iters-convergence1.iters << " iterations\n";
-    std::cout << std::fixed << std::setprecision(4);
-    for (std::size_t v = 0; v < num_vertices(g); ++v) 
+    for(auto& graph_details : graph_defs)
     {
-        std::cout << "vertex " << v << "  rank=" << ranks[v] << "\n";
-    }
-    BOOST_ASSERT(ranks[0]==ranks[2]); // should be exactly equal due to symmetry, even when considering floating point coarseness
-    BOOST_ASSERT(ranks[0]<ranks[1]+0.1);
-    BOOST_ASSERT(ranks[8]==ranks[9]);
-    BOOST_ASSERT(ranks[11]==ranks[12]);
-    BOOST_ASSERT(ranks[11]>0);
-    BOOST_ASSERT(convergence1.iters<max_iters);
+        DirectedGraph g(graph_details.first.begin(), graph_details.first.end(), graph_details.second);
+        std::vector<double> ranks(num_vertices(g));
+        auto rank_map = boost::make_iterator_property_map(ranks.begin(), get(boost::vertex_index, g));
+        std::vector<double> personalization(num_vertices(g));
+        auto personalization_map = boost::make_iterator_property_map(personalization.begin(), get(boost::vertex_index, g));
+        personalization[0] = 1;
+        personalization[1] = 1;
+        personalization[2] = 1;
+        personalization[3] = 1;
 
-    // COMPUTING A HIGH-PASS VERSION BY PASSING NEGATIVE DAMPING (resulting values can be negative)
-    // This is not completely correct yet for computing graph gradients, because it needs to eskew normalization,
-    // so we need to be able to customize said normalization.
-    // Damping should generaly be in the range [-1,1].
-    auto renorm_weight = make_function_property_map<Edge, double>(
-        [&g](Edge e){ return 1.0 / std::sqrt(double((1.0+out_degree(source(e, g), g)) * (1.0+out_degree(target(e, g), g)))); });
-    auto convergence2 = graph::rank_convergence(max_iters, 1.E-9);
-    convergence2 = graph::personalized_page_rank(g, renorm_weight, personalization_map, rank_map, convergence2, -0.8);
-    std::cout << "ended after "<<max_iters-convergence2.iters << " iterations\n";
-    std::cout << std::fixed << std::setprecision(4);
-    for (std::size_t v = 0; v < num_vertices(g); ++v) 
-    {
-        std::cout << "vertex " << v << "  flow=" << ranks[v] << "\n";
+        std::size_t max_iters(300); // Convergence is just that bad in tested graphs; usually it's much lower.'
+        auto weight = boost::make_function_property_map<DirectedEdge, double>([&g,renormalize](DirectedEdge e){
+            auto denom = out_degree(source(e, g), g) * out_degree(target(e, g), g);
+            if(denom==0) return 0.0;
+            return 1.0 / std::sqrt(renormalize+double(denom));
+        });
+        auto convergence = custom_rank_convergence(max_iters, 1.E-9);
+        convergence = boost::graph::personalized_page_rank(g, weight, personalization_map, rank_map, convergence, damping);
+
+        // the following asserts hold for all tested graphs and personalization: 0,1,2,3 plus some other nodes is a mini-cluster with 0 and 2 being structurally symmetric
+        assert(convergence.get_remaining_iters()<max_iters);                                     // ran
+        assert(convergence.get_remaining_iters()>0 || (damping<0.0));                            // converged (derivatives may not converge)
+        assert((ranks[0]<ranks[1]+0.1) || (damping<0.0) || damping>1.0);                         // holds for all graphs given low-pass damping
+        assert((ranks[0]!=ranks[1]) == (damping!=0.0));                                          // but not the same normally, the same 1.0 personalization if damping is zero
+        assert(ranks[0]==ranks[2] || (damping<=-1.0));                                           // equal due to symmetry, even under non-convergence and floating coarseness
+        assert(std::abs(ranks[0]-ranks[2])<1.E-14);                                              // approximately equal in cases where even addition order matters
+        assert((ranks[0]<0.0)||(ranks[1]<0.0)||(ranks[num_vertices(g)-1]<=0.0)||(damping>0.0));  // ensure that negative flows are possible for negative damping
     }
-    BOOST_ASSERT(ranks[0]==ranks[2]); // should be exactly equal due to symmetry, even when considering floating point coarseness
-    BOOST_ASSERT(ranks[0]>ranks[1]+0.1);
-    BOOST_ASSERT(ranks[8]==ranks[9]);
-    BOOST_ASSERT(ranks[11]==ranks[12]);
-    BOOST_ASSERT(ranks[11]<0);
-    BOOST_ASSERT(convergence2.iters<max_iters);
+}
+
+int main(int, char*[])
+{
+    directed_graph_tests(0.9, 0);    // normal mode
+    directed_graph_tests(0.9, 1.0);  // with renormalization
+    directed_graph_tests(0.99, 0);   // huge damping (asymptotically exponentially slow convergence as we approach 1.0)
+    directed_graph_tests(0.0, 0);    // just yield the personalization again
+    directed_graph_tests(-0.8, 1.0); // negative flow = some kind of derivate
+    directed_graph_tests(-1.0, 1.0); // huge negative flow
 }

--- a/test/personalized_pagerank_test.cpp
+++ b/test/personalized_pagerank_test.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <vector>
 #include <iomanip>
+#include <boost/core/lightweight_test.hpp>
 
 using DirectedGraph = typename boost::adjacency_list<boost::vecS, boost::vecS, boost::directedS>;
 using DirectedVertex = typename boost::graph_traits<DirectedGraph>::vertex_descriptor;
@@ -56,13 +57,13 @@ void directed_graph_tests(double damping, double renormalize)
         convergence = boost::graph::personalized_page_rank(g, weight, personalization_map, rank_map, convergence, damping);
 
         // the following asserts hold for all tested graphs and personalization: 0,1,2,3 plus some other nodes is a mini-cluster with 0 and 2 being structurally symmetric
-        assert(convergence.get_remaining_iters()<max_iters);                                     // ran
-        assert(convergence.get_remaining_iters()>0 || (damping<0.0));                            // converged (derivatives may not converge)
-        assert((ranks[0]<ranks[1]+0.1) || (damping<0.0) || damping>1.0);                         // holds for all graphs given low-pass damping
-        assert((ranks[0]!=ranks[1]) == (damping!=0.0));                                          // but not the same normally, the same 1.0 personalization if damping is zero
-        assert(ranks[0]==ranks[2] || (damping<=-1.0));                                           // equal due to symmetry, even under non-convergence and floating coarseness
-        assert(std::abs(ranks[0]-ranks[2])<1.E-14);                                              // approximately equal in cases where even addition order matters
-        assert((ranks[0]<0.0)||(ranks[1]<0.0)||(ranks[num_vertices(g)-1]<=0.0)||(damping>0.0));  // ensure that negative flows are possible for negative damping
+        BOOST_TEST(convergence.get_remaining_iters()<max_iters);                                     // ran
+        BOOST_TEST(convergence.get_remaining_iters()>0 || (damping<0.0));                            // converged (derivatives may not converge)
+        BOOST_TEST((ranks[0]<ranks[1]+0.1) || (damping<0.0) || damping>1.0);                         // holds for all graphs given low-pass damping
+        BOOST_TEST((ranks[0]!=ranks[1]) == (damping!=0.0));                                          // but not the same normally, the same 1.0 personalization if damping is zero
+        BOOST_TEST(ranks[0]==ranks[2] || (damping<=-1.0));                                           // equal due to symmetry, even under non-convergence and floating coarseness
+        BOOST_TEST(std::abs(ranks[0]-ranks[2])<1.E-14);                                              // approximately equal in cases where even addition order matters
+        BOOST_TEST((ranks[0]<0.0)||(ranks[1]<0.0)||(ranks[num_vertices(g)-1]<=0.0)||(damping>0.0));  // ensure that negative flows are possible for negative damping
     }
 }
 
@@ -74,4 +75,5 @@ int main(int, char*[])
     directed_graph_tests(0.0, 0);    // just yield the personalization again
     directed_graph_tests(-0.8, 1.0); // negative flow = some kind of derivate
     directed_graph_tests(-1.0, 1.0); // huge negative flow
+    return boost::report_errors();
 }

--- a/test/personalized_pagerank_test.cpp
+++ b/test/personalized_pagerank_test.cpp
@@ -1,15 +1,23 @@
-
 #include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/page_rank.hpp>
 #include <boost/graph/personalized_page_rank.hpp>
+#include <boost/graph/random.hpp>
+#include <boost/random/mersenne_twister.hpp>
 #include <boost/property_map/property_map.hpp>
+#include <boost/property_map/function_property_map.hpp>
+#include <boost/core/lightweight_test.hpp>
+#include <random>
 #include <iostream>
 #include <vector>
 #include <iomanip>
-#include <boost/core/lightweight_test.hpp>
 
 using DirectedGraph = typename boost::adjacency_list<boost::vecS, boost::vecS, boost::directedS>;
 using DirectedVertex = typename boost::graph_traits<DirectedGraph>::vertex_descriptor;
 using DirectedEdge = typename boost::graph_traits<DirectedGraph>::edge_descriptor;
+
+using BidirectionalGraph = boost::adjacency_list<boost::vecS, boost::vecS, boost::bidirectionalS>;
+using BidirectionalVertex = typename boost::graph_traits<BidirectionalGraph>::vertex_descriptor;
+using BidirectionalEdge = typename boost::graph_traits<BidirectionalGraph>::edge_descriptor;
 
 struct custom_rank_convergence: public boost::graph::rank_convergence
 {
@@ -67,6 +75,91 @@ void directed_graph_tests(double damping, double renormalize)
     }
 }
 
+void compliance_comparison_tests(double damping, int repetitions)
+{
+    // compares personalized pagerank with the non-personalized pagerank algorithm implementation
+    const unsigned damping_id = static_cast<unsigned>(std::lround(damping * 100.0));
+    std::mt19937 rng(damping_id);
+    for (int repetition=0; repetition<repetitions; ++repetition)
+    {
+        // random graph of 5 to 55 vertices
+        std::size_t n = 5 + (rng() % 50);
+        std::size_t max_edges = n*(n-1)/2;
+        BidirectionalGraph g;
+        boost::generate_random_graph(g, n, rng() % (max_edges+1), rng, false, false);
+
+        // run pagerank
+        std::vector<double> pagerank_ranks(n);
+        auto pagerank_map = boost::make_iterator_property_map(
+            pagerank_ranks.begin(), 
+            get(boost::vertex_index, g)
+        );
+        boost::graph::page_rank(g, pagerank_map, boost::graph::n_iterations(10000), damping);
+
+        // run personalized pagerank
+        std::vector<double> personalized_pagerank_ranks(n);
+        auto personalized_result_map = boost::make_iterator_property_map(
+            personalized_pagerank_ranks.begin(), 
+            get(boost::vertex_index, g)
+        );
+        std::vector<double> personalization(n);
+        for(int i=0;i<n;++i)
+            personalization[i] = 1.0;
+        auto personalization_map = boost::make_iterator_property_map(
+            personalization.begin(), 
+            get(boost::vertex_index, g)
+        );
+        auto edge_weight = boost::make_function_property_map<BidirectionalEdge, double>([&g](BidirectionalEdge e){
+            const auto degree = out_degree(source(e, g), g);
+            return 1.0 / degree;
+        });
+        boost::graph::personalized_page_rank(g, edge_weight, personalization_map, personalized_result_map, custom_rank_convergence(10000), damping);
+
+        // compare
+        std::size_t differences = 0;
+        double expected_l1_norm = 0;
+        double actual_l1_norm = 0;
+        for (std::size_t v=0;v<n;++v)
+        {
+            const double expected = pagerank_map[v];
+            const double actual   = personalized_result_map[v];
+            BOOST_TEST(std::isfinite(expected));
+            BOOST_TEST(std::isfinite(actual));
+            if(std::abs(expected - actual) > 1.E-9) 
+                ++differences;
+            expected_l1_norm += expected;
+            actual_l1_norm += actual;
+        }
+        
+        // EXPALAINING DIFFERENCES IN personalized_page_rank VS page_rank
+        // The way page_rank has been implemented, it does NOT preserve the
+        // input L1 norm when there are dangling nodes. Those nodes are, however,
+        // assigned a known score `1-damping`. Rescaling the final result is not
+        // enough because this fixed dangling node treatment "poisons" the
+        // value of other nodes.
+        //
+        // On the other hand, personalized_page_rank strives to maintain largely 
+        // the same invariants with the added constraint that the input L1 norm
+        // is ALWAYS preserved. This means that dangling node values are scaled
+        // into an unknown (though fixed)
+        //
+        // Applying `boost::graph::remove_dangling_links` on the graph
+        // before ranking its nots is how this discrepancy is mitigated. 
+        // However, this is not done in this testm in order to prepare for 
+        // future extensions where the personalized_page_rank normalization 
+        // schema can be controlled externally.
+        // 
+        // Currently, commenting out `put(to_rank, v, get(to_rank, v)/l1_norm);`,
+        // which is what should be controlled, lets the test pass without skipping
+        // anything.
+        if(std::abs(expected_l1_norm-n)>1.E-9) 
+            continue;
+        // the following should guarantee equivalence
+        BOOST_TEST(std::abs(expected_l1_norm-actual_l1_norm)<1.E-9); // easier to investigate if not held true
+        BOOST_TEST(!differences); // stronger condition that all ranks should be similar
+    }
+}
+
 int main(int, char*[])
 {
     directed_graph_tests(0.9, 0);    // normal mode
@@ -75,5 +168,8 @@ int main(int, char*[])
     directed_graph_tests(0.0, 0);    // just yield the personalization again
     directed_graph_tests(-0.8, 1.0); // negative flow = some kind of derivate
     directed_graph_tests(-1.0, 1.0); // huge negative flow
+
+    for(int i=0;i<=99;++i)
+        compliance_comparison_tests(0.01*i, 20);
     return boost::report_errors();
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [ ] Bug fix
- [x] New feature or API addition
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

<!-- A short summary of the change. -->

Provides an implementation of personalized PageRank following the motivating issue's outline for the provided interface.

### Motivation

<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->

Refs #493 

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->

`personalized_pagerank_test.cpp` was added to tests. This runs two node scoring scenarios on a graph with well-understood structure, where assertions are added for equality between isomorphic nodes and certain interesting numerical comparisons checked to hold. The build command for local testing was `g++ -std=c++14 -I./boost -o test test.cpp -O2`.

### Checklist

- [x] Existing tests pass (`b2` in the `test/` directory).
- [x] New behavior is covered by a test, or this is a docs / build / refactor change.
- [ ] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.

Documentation change not applicable, but likely new documentation should be added to reflect the introduced algorithm.