### PR TITLE
fix bot warning count to match head.sha against base repo open PR list

### DIFF
--- a/.github/workflows/warning-count-comment.yml
+++ b/.github/workflows/warning-count-comment.yml
@@ -44,7 +44,14 @@ jobs:
 
       - name: Resolve PR number
         id: pr
-        run: echo "num=$(gh api "repos/$REPO/commits/$HEAD_SHA/pulls" --jq '.[0].number')" >> "$GITHUB_OUTPUT"
+        run: |
+          num=$(gh api "repos/$REPO/pulls?state=open&per_page=100" \
+                  --jq "map(select(.head.sha==\"$HEAD_SHA\"))[0].number")
+          if [ -z "$num" ]; then
+            echo "no open PR found with head $HEAD_SHA" >&2
+            exit 1
+          fi
+          echo "num=$num" >> "$GITHUB_OUTPUT"
 
       - name: Post or update sticky comment
         uses: marocchino/sticky-pull-request-comment@v2


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

Refs #496  

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [x] Bug fix
- [ ] New feature or API addition
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

<!-- A short summary of the change. -->

Fix the warning count bot to match head.sha against base repo open PR list

### Motivation

Currently fails.

<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->

### Checklist

- [x] Existing tests pass (`b2` in the `test/` directory).
- [x] New behavior is covered by a test, or this is a docs / build / refactor change.
- [x] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.
