### PR TITLE
fix: initialize `edge_property_type` value in `adjacency_list.hpp`

### DIFF
--- a/include/boost/graph/detail/adjacency_list.hpp
+++ b/include/boost/graph/detail/adjacency_list.hpp
@@ -742,7 +742,7 @@ inline std::pair< typename Config::edge_descriptor, bool > add_edge(
     typename Config::vertex_descriptor u, typename Config::vertex_descriptor v,
     directed_graph_helper< Config >& g_)
 {
-    typename Config::edge_property_type p;
+    typename Config::edge_property_type p {};
     return add_edge(u, v, p, g_);
 }
 //=========================================================================
@@ -1094,7 +1094,7 @@ inline std::pair< typename Config::edge_descriptor, bool > add_edge(
     typename Config::vertex_descriptor u, typename Config::vertex_descriptor v,
     undirected_graph_helper< Config >& g_)
 {
-    typename Config::edge_property_type p;
+    typename Config::edge_property_type p {};
     return add_edge(u, v, p, g_);
 }
 
@@ -1518,7 +1518,7 @@ inline std::pair< typename Config::edge_descriptor, bool > add_edge(
     typename Config::vertex_descriptor u, typename Config::vertex_descriptor v,
     bidirectional_graph_helper_with_property< Config >& g_)
 {
-    typename Config::edge_property_type p;
+    typename Config::edge_property_type p {};
     return add_edge(u, v, p, g_);
 }
 // O(1)
@@ -2272,7 +2272,7 @@ inline std::pair< typename Config::edge_descriptor, bool > add_edge(
     typename Config::vertex_descriptor u, typename Config::vertex_descriptor v,
     vec_adj_list_impl< Graph, Config, Base >& g_)
 {
-    typename Config::edge_property_type p;
+    typename Config::edge_property_type p {};
     return add_edge(u, v, p, g_);
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

Refs #496

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [x] Bug fix
- [ ] New feature or API addition
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

<!-- A short summary of the change. -->

### Motivation

<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->

Fix #496 

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->

Same CI, less warnings

### Checklist

- [x] Existing tests pass (`b2` in the `test/` directory).
- [x] New behavior is covered by a test, or this is a docs / build / refactor change.
- [x] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.