### PR TITLE
Fix unused dead code in `louvain_clustering.hpp`

### DIFF
--- a/include/boost/graph/louvain_clustering.hpp
+++ b/include/boost/graph/louvain_clustering.hpp
@@ -55,7 +55,6 @@ auto aggregate(
     const IndexMap& index_map
 ){
     using vertex_descriptor = typename graph_traits<Graph>::vertex_descriptor;
-    using edge_descriptor = typename graph_traits<Graph>::edge_descriptor;
     using vertex_iterator = typename graph_traits<Graph>::vertex_iterator;
     using edge_iterator = typename graph_traits<Graph>::edge_iterator;
     using community_type = typename property_traits<CommunityMap>::value_type;
@@ -223,7 +222,6 @@ local_optimization_impl(
     
     // Use vertex_index map to support both integral (vecS) and non-integral (listS) vertex descriptors
     auto idx_map = get(vertex_index, g);
-    using index_map_t = decltype(idx_map);
     
     // Storage vectors backing property maps: enables both vertex_descriptor and integer access
     std::vector<weight_type> k_vec(n, weight_type(0));
@@ -240,7 +238,6 @@ local_optimization_impl(
     weight_type Q = f.quality(g, communities, w, k, in, tot, m);
     weight_type Q_new = Q;
     std::size_t num_moves = 0;
-    std::size_t pass_number = 0;
     bool has_rolled_back = false;
     
     // Randomize vertex order once
@@ -262,7 +259,6 @@ local_optimization_impl(
     {
         Q = Q_new;
         num_moves = 0;        
-        pass_number++;
         
         // Lazy save: only save state if we've previously needed to rollback
         if (has_rolled_back) {
@@ -400,7 +396,6 @@ local_optimization_impl(
     weight_type Q = f.quality(g, communities, w);
     weight_type Q_new = Q;
     std::size_t num_moves = 0;
-    std::size_t pass_number = 0;
     bool has_rolled_back = false;
 
     // Pre-allocate rollback buffer
@@ -410,7 +405,6 @@ local_optimization_impl(
     {
         Q = Q_new;
         num_moves = 0;
-        pass_number++;
 
         // Lazy save: only save state if we've previously needed to rollback
         if (has_rolled_back) {
@@ -526,7 +520,6 @@ louvain_clustering(
         "louvain_clustering requires an undirected graph"
     );
 
-    using vertex_descriptor = typename graph_traits<Graph>::vertex_descriptor;
     using weight_type = typename property_traits<WeightMap>::value_type;
     using vertex_iterator = typename graph_traits<Graph>::vertex_iterator;
     
@@ -555,10 +548,7 @@ louvain_clustering(
     auto coarse = louvain_detail::aggregate(g0, partition_idx_map, w0, idx);
     
     std::size_t prev_n_vertices = n;
-    std::size_t iteration = 0;
-
     while (true) {
-        iteration++;
         // Check convergence: graph didn't get smaller (no communities merged)
         std::size_t n_communities = num_vertices(coarse.graph);
         


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

Refs #496 

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [x] Bug fix
- [ ] New feature or API addition
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

<!-- A short summary of the change. -->

Remove dead code in Louvain algorithm that was triggering warnings in CI.

### Motivation

<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->

#496 

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->

Same CI, less warnings

### Checklist

- [x] Existing tests pass (`b2` in the `test/` directory).
- [x] New behavior is covered by a test, or this is a docs / build / refactor change.
- [x] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.