### PR TITLE
add missing const values; use some using instead of typedef

### DIFF
--- a/include/boost/graph/successive_shortest_path_nonnegative_weights.hpp
+++ b/include/boost/graph/successive_shortest_path_nonnegative_weights.hpp
@@ -22,6 +22,7 @@
 #include <boost/graph/properties.hpp>
 #include <boost/graph/iteration_macros.hpp>
 #include <boost/graph/detail/augment.hpp>
+#include <boost/concept/assert.hpp>
 
 namespace boost
 {
@@ -34,6 +35,13 @@ namespace detail
     : public put_get_helper< typename property_traits< Weight >::value_type,
           MapReducedWeight< Graph, Weight, Distance, Reversed > >
     {
+        
+        using edge_descriptor = typename graph_traits< Graph >::edge_descriptor;
+        using vertex_descriptor = typename graph_traits< Graph >::vertex_descriptor;
+
+        BOOST_CONCEPT_ASSERT(( ReadablePropertyMapConcept<Weight, edge_descriptor> ));
+        BOOST_CONCEPT_ASSERT(( ReadablePropertyMapConcept<Distance, vertex_descriptor> ));
+        
         using g_traits = graph_traits< Graph >;
 
     public:
@@ -55,9 +63,9 @@ namespace detail
 
     private:
         const Graph& g_;
-        const Weight weight_;
-        const Distance distance_;
-        const Reversed rev_;
+        Weight weight_;
+        Distance distance_;
+        Reversed rev_;
     };
 
     template < class Graph, class Weight, class Distance, class Reversed >
@@ -79,9 +87,11 @@ void successive_shortest_path_nonnegative_weights(const Graph& g,
     ResidualCapacity residual_capacity, Weight weight, Reversed rev,
     VertexIndex index, Pred pred, Distance distance, Distance2 distance_prev)
 {
+
+    using edge_descriptor = typename graph_traits< Graph >::edge_descriptor;
+    
     filtered_graph< const Graph, is_residual_edge< ResidualCapacity > > gres
         = detail::residual_graph(g, residual_capacity);
-    typedef typename graph_traits< Graph >::edge_descriptor edge_descriptor;
 
     BGL_FORALL_EDGES_T(e, g, Graph)
     {

--- a/include/boost/graph/successive_shortest_path_nonnegative_weights.hpp
+++ b/include/boost/graph/successive_shortest_path_nonnegative_weights.hpp
@@ -14,8 +14,6 @@
 #ifndef BOOST_GRAPH_SUCCESSIVE_SHORTEST_PATH_HPP
 #define BOOST_GRAPH_SUCCESSIVE_SHORTEST_PATH_HPP
 
-#include <numeric>
-
 #include <boost/property_map/property_map.hpp>
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/graph_concepts.hpp>
@@ -36,13 +34,14 @@ namespace detail
     : public put_get_helper< typename property_traits< Weight >::value_type,
           MapReducedWeight< Graph, Weight, Distance, Reversed > >
     {
-        typedef graph_traits< Graph > gtraits;
+        using g_traits = graph_traits< Graph >;
 
     public:
-        typedef boost::readable_property_map_tag category;
-        typedef typename property_traits< Weight >::value_type value_type;
-        typedef value_type reference;
-        typedef typename gtraits::edge_descriptor key_type;
+        using category = boost::readable_property_map_tag;
+        using value_type = typename property_traits< Weight >::value_type;
+        using reference = value_type;
+        using key_type = typename g_traits::edge_descriptor;
+        
         MapReducedWeight(const Graph& g, Weight w, Distance d, Reversed r)
         : g_(g), weight_(w), distance_(d), rev_(r)
         {
@@ -56,9 +55,9 @@ namespace detail
 
     private:
         const Graph& g_;
-        Weight weight_;
-        Distance distance_;
-        Reversed rev_;
+        const Weight weight_;
+        const Distance distance_;
+        const Reversed rev_;
     };
 
     template < class Graph, class Weight, class Distance, class Reversed >
@@ -137,13 +136,13 @@ namespace detail
     template < class Graph, class Capacity, class ResidualCapacity,
         class Weight, class Reversed, class Pred, class Distance,
         class VertexIndex >
-    void successive_shortest_path_nonnegative_weights_dispatch3(Graph& g,
+    void successive_shortest_path_nonnegative_weights_dispatch3(const Graph& g,
         typename graph_traits< Graph >::vertex_descriptor s,
         typename graph_traits< Graph >::vertex_descriptor t, Capacity capacity,
         ResidualCapacity residual_capacity, Weight weight, Reversed rev,
         VertexIndex index, Pred pred, Distance dist, param_not_found)
     {
-        typedef typename property_traits< Weight >::value_type D;
+        using D = typename property_traits< Weight >::value_type;
 
         std::vector< D > d_map(num_vertices(g));
 
@@ -155,7 +154,7 @@ namespace detail
     template < class Graph, class P, class T, class R, class Capacity,
         class ResidualCapacity, class Weight, class Reversed, class Pred,
         class Distance, class VertexIndex >
-    void successive_shortest_path_nonnegative_weights_dispatch2(Graph& g,
+    void successive_shortest_path_nonnegative_weights_dispatch2(const Graph& g,
         typename graph_traits< Graph >::vertex_descriptor s,
         typename graph_traits< Graph >::vertex_descriptor t, Capacity capacity,
         ResidualCapacity residual_capacity, Weight weight, Reversed rev,
@@ -171,14 +170,14 @@ namespace detail
     template < class Graph, class P, class T, class R, class Capacity,
         class ResidualCapacity, class Weight, class Reversed, class Pred,
         class VertexIndex >
-    void successive_shortest_path_nonnegative_weights_dispatch2(Graph& g,
+    void successive_shortest_path_nonnegative_weights_dispatch2(const Graph& g,
         typename graph_traits< Graph >::vertex_descriptor s,
         typename graph_traits< Graph >::vertex_descriptor t, Capacity capacity,
         ResidualCapacity residual_capacity, Weight weight, Reversed rev,
         VertexIndex index, Pred pred, param_not_found,
         const bgl_named_params< P, T, R >& params)
     {
-        typedef typename property_traits< Weight >::value_type D;
+        using D = typename property_traits< Weight >::value_type;
 
         std::vector< D > d_map(num_vertices(g));
 
@@ -191,7 +190,7 @@ namespace detail
     template < class Graph, class P, class T, class R, class Capacity,
         class ResidualCapacity, class Weight, class Reversed, class Pred,
         class VertexIndex >
-    void successive_shortest_path_nonnegative_weights_dispatch1(Graph& g,
+    void successive_shortest_path_nonnegative_weights_dispatch1(const Graph& g,
         typename graph_traits< Graph >::vertex_descriptor s,
         typename graph_traits< Graph >::vertex_descriptor t, Capacity capacity,
         ResidualCapacity residual_capacity, Weight weight, Reversed rev,
@@ -206,14 +205,14 @@ namespace detail
     template < class Graph, class P, class T, class R, class Capacity,
         class ResidualCapacity, class Weight, class Reversed,
         class VertexIndex >
-    void successive_shortest_path_nonnegative_weights_dispatch1(Graph& g,
+    void successive_shortest_path_nonnegative_weights_dispatch1(const Graph& g,
         typename graph_traits< Graph >::vertex_descriptor s,
         typename graph_traits< Graph >::vertex_descriptor t, Capacity capacity,
         ResidualCapacity residual_capacity, Weight weight, Reversed rev,
         VertexIndex index, param_not_found,
         const bgl_named_params< P, T, R >& params)
     {
-        typedef typename graph_traits< Graph >::edge_descriptor edge_descriptor;
+        using edge_descriptor = typename graph_traits< Graph >::edge_descriptor;
         std::vector< edge_descriptor > pred_vec(num_vertices(g));
 
         successive_shortest_path_nonnegative_weights_dispatch2(g, s, t,
@@ -247,7 +246,7 @@ void successive_shortest_path_nonnegative_weights(Graph& g,
     typename graph_traits< Graph >::vertex_descriptor s,
     typename graph_traits< Graph >::vertex_descriptor t)
 {
-    bgl_named_params< int, buffer_param_t > params(0);
+    const bgl_named_params< int, buffer_param_t > params(0);
     successive_shortest_path_nonnegative_weights(g, s, t, params);
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

### Before submitting

- [x] This PR targets the `develop` branch.
- [X] I searched for an existing PR or issue covering the same change. (actually this PR superseeds https://github.com/boostorg/graph/pull/160)
- [X] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [x] Bug fix
- [ ] New feature or API addition
- [x] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

It superseeds https://github.com/boostorg/graph/pull/160


### Motivation

Some `const` qualifiers are missing. Not a big deal, but it make it clearer to have them in place. Notice that the named parameter interface cannot be changed without introducing a breaking change: the reason is that it defaults to use graph internal property map as output, thus the graph must be modifiable to extract that map.

Incidentally I change some `typedef` to `using`.

### Testing

Existing tests should be fine

### Checklist

- [x] Existing tests pass (`b2` in the `test/` directory).
- [x] New behavior is covered by a test, or this is a docs / build / refactor change.
- [x] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.
