### PR TITLE
fix: lambda capture 'this' is not used

### DIFF
--- a/include/boost/graph/howard_cycle_ratio.hpp
+++ b/include/boost/graph/howard_cycle_ratio.hpp
@@ -357,7 +357,7 @@ namespace detail
             boost::tie(uv_itr, vie) = vertices(m_g);
             float_t mcr = m_bound;
             while ((uv_itr = std::find_if(uv_itr, vie,
-                        [this, &vcm_](const auto& uv)
+                        [&](const auto& uv)
                         {
                             return std::equal_to< my_color_type >()(
                                 my_white, vcm_[uv]);


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

Refs #496 

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [x] Bug fix
- [ ] New feature or API addition
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

<!-- A short summary of the change. -->

Reduce warning for "this" captured but not used.

### Motivation

<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->

### Checklist

- [x] Existing tests pass (`b2` in the `test/` directory).
- [x] New behavior is covered by a test, or this is a docs / build / refactor change.
- [x] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.
