### PR TITLE
fix: remove dead test variables

### DIFF
--- a/test/csr_graph_test.cpp
+++ b/test/csr_graph_test.cpp
@@ -321,18 +321,6 @@ template < typename OrigGraph > void graph_test(const OrigGraph& g)
         {
             BOOST_TEST(source(*oei, g2) == *vi);
         }
-
-        // Find a vertex for testing
-        CSRGraphT::vertex_descriptor test_vertex
-            = vertex(num_vertices(g2) / 2, g2);
-        int edge_count = 0;
-        CSRGraphT::out_edge_iterator oei2, oei2_end;
-        for (boost::tie(oei2, oei_end) = out_edges(*vi, g2); oei2 != oei_end;
-             ++oei2)
-        {
-            if (target(*oei2, g2) == test_vertex)
-                ++edge_count;
-        }
     }
 
     // Run brandes_betweenness_centrality, which touches on a whole lot

--- a/test/graph.cpp
+++ b/test/graph.cpp
@@ -156,7 +156,7 @@ template < class Graph > std::size_t count_edges(Graph& g)
 int main(int, char*[])
 {
     int ret = 0;
-    std::size_t N = 5, E = 0;
+    std::size_t N = 5;
     std::size_t old_N;
 
     typedef ::Graph Graph;
@@ -218,7 +218,6 @@ int main(int, char*[])
                 ret = -1;
                 break;
             }
-            ++E;
         }
 
         // remove_edge(u, v, g)
@@ -235,7 +234,6 @@ int main(int, char*[])
 
             Edge e = random_edge(g, gen);
             boost::tie(a, b) = boost::incident(e, g);
-            --E;
 #if VERBOSE
             cerr << "remove_edge(" << vertex_id_map[a] << ","
                  << vertex_id_map[b] << ")" << endl;
@@ -278,7 +276,6 @@ int main(int, char*[])
             Vertex a, b;
             Edge e = random_edge(g, gen);
             boost::tie(a, b) = boost::incident(e, g);
-            --E;
 #if VERBOSE
             cerr << "remove_edge(" << vertex_id_map[a] << ","
                  << vertex_id_map[b] << ")" << endl;

--- a/test/property_iter.cpp
+++ b/test/property_iter.cpp
@@ -60,7 +60,7 @@ using std::find;
 int main(int, char*[])
 {
     int ret = 0;
-    std::size_t N = 5, E = 0;
+    std::size_t N = 5;
 
     typedef ::Graph Graph;
     Graph g;
@@ -114,7 +114,6 @@ int main(int, char*[])
             std::cout << "finished printing" << std::endl;
 #endif
         }
-        ++E;
     }
 
     typedef boost::graph_property_iter_range< Graph, vertex_id_t >::iterator


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

Refs #496 

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [x] Bug fix
- [ ] New feature or API addition
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

<!-- A short summary of the change. -->

Remove dead `-Wunused-but-set-variable` test variables

Clears ~19 clang `-Wunused-but-set-variable` warnings per CI job. All changes are
test-only with no behavioral effect: each removed variable was written but never read.

- **`test/graph.cpp` (`E`)**: An edge counter (`++E` on add, `--E` on remove) introduced with the original graph test file (Jeremy Siek, 2000) that was never read in the entire history of the file. The actual edge-count invariant is already verified via `count_edges(g)`, so `E` was redundant scaffolding from day one. Removed the declaration and its three writes.

- **`test/property_iter.cpp` (`E`)**: The same write-only edge-counter idiom, never read. This test exercises property iterators, so the counter was never relevant. Removed the declaration and its single increment.

- **`test/csr_graph_test.cpp` (`edge_count` block)**: Originally (Douglas Gregor, 2005) this counted a vertex's out-edges to verify the CSR `edge()` and `edge_range()` functions. Those functions were deliberately removed in 2009 (Jeremiah Willcock) as unsupportable under the CSR model, along with the assertions that used the count, but the counting loop was left behind. Removed the whole orphaned block (also clearing a latent unused `oei2_end` and avoiding cascading `-Wunused-variable`/`-Wempty-body` warnings that deleting only the variable would cause).

These can't be repurposed into assertions: the `E` counters have no readable invariant (the real edge-count check already lives in `count_edges(g)`, and `num_edges == E` would be wrong for multigraph configs), and `edge_count` only ever backed assertions that were deliberately removed in 2009 with the `edge()`/`edge_range()` functions.

### Motivation

<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->

See #496

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->

### Checklist

- [x] Existing tests pass (`b2` in the `test/` directory).
- [x] New behavior is covered by a test, or this is a docs / build / refactor change.
- [x] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.
