### PR TITLE
fix: silence -Wunused-local-typedef and -Wunused-variable in four examples

### DIFF
--- a/example/graph-assoc-types.cpp
+++ b/example/graph-assoc-types.cpp
@@ -7,6 +7,7 @@
 //=======================================================================
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/adjacency_list.hpp>
+#include <boost/core/ignore_unused.hpp>
 
 using namespace boost;
 
@@ -21,6 +22,7 @@ template < typename Graph > void generic_foo(Graph& g)
     // Access iterator types...
     // Access size types...
     // Now do something useful...
+    boost::ignore_unused< Vertex, Edge, Dir, Par >();
 }
 
 template < typename Graph > void generic_bar(Graph& g)

--- a/example/minimum_degree_ordering.cpp
+++ b/example/minimum_degree_ordering.cpp
@@ -42,7 +42,6 @@ struct harwell_boeing
 {
     harwell_boeing(char* filename)
     {
-        int Nrhs;
         char* Type;
         Type = new char[4];
         isComplex = false;

--- a/example/quick-tour.cpp
+++ b/example/quick-tour.cpp
@@ -31,7 +31,6 @@ template < typename Graph, typename VertexNameMap >
 void print_vertex_names(const Graph& g, VertexNameMap name_map)
 {
     std::cout << "vertices(g) = { ";
-    using iter_t = typename graph_traits< Graph >::vertex_iterator;
     for (auto p = vertices(g); p.first != p.second; ++p.first)
     {
         print_vertex_name(*p.first, name_map);

--- a/example/two_graphs_common_spanning_trees.cpp
+++ b/example/two_graphs_common_spanning_trees.cpp
@@ -57,6 +57,7 @@ int main(int argc, char** argv)
     for (auto const & vec : coll)
     {
         // Here you can play with the trees that the algorithm has found.
+        (void) vec;
     }
 
     return 0;


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

Refs #496 

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [x] Bug fix
- [ ] New feature or API addition
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

<!-- A short summary of the change. -->

Silence `-Wunused-local-typedef` and `-Wunused-variable` in four examples (clears 7 warnings/job on both clang and gcc, example-only, no behavioral change).
- `graph-assoc-types.cpp`: kept the illustrative associated-type typedefs but marked them with `boost::ignore_unused<>()` (portable across C++14, not `[[maybe_unused]]`).
- `quick-tour.cpp`: removed the dead `iter_t` typedef (the loop uses `auto`).
- `minimum_degree_ordering.cpp`: removed the unused `Nrhs` variable.
- `two_graphs_common_spanning_trees.cpp`: added `(void) vec;` in the placeholder loop body.

### Motivation

<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->

Refs #496 

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->

### Checklist

- [x] Existing tests pass (`b2` in the `test/` directory).
- [x] New behavior is covered by a test, or this is a docs / build / refactor change.
- [x] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.
