### PR TITLE
Replace the deprecated `std::random_shuffle` with `std::shuffle`

### DIFF
--- a/example/fibonacci_heap.cpp
+++ b/example/fibonacci_heap.cpp
@@ -43,11 +43,7 @@ int main()
 
             for (int c = 0; c < w.size(); ++c)
                 w[c] = c;
-#ifndef BOOST_NO_CXX98_RANDOM_SHUFFLE
-            std::random_shuffle(w.begin(), w.end());
-#else
             std::shuffle(w.begin(), w.end(), gen);
-#endif
 
             for (i = 0; i < N; ++i)
                 Q.push(i);

--- a/test/isomorphism.cpp
+++ b/test/isomorphism.cpp
@@ -77,19 +77,11 @@ randomly_permute_graph(const Graph1& g1, Graph2& g2)
 
     random_generator_type gen;
 
-#ifndef BOOST_NO_CXX98_RANDOM_SHUFFLE
-    random_functor< random_generator_type > rand_fun(gen);
-#endif
-
     // Decide new order
     std::vector< vertex1 > orig_vertices;
     std::copy(vertices(g1).first, vertices(g1).second,
         std::back_inserter(orig_vertices));
-#ifndef BOOST_NO_CXX98_RANDOM_SHUFFLE
-    std::random_shuffle(orig_vertices.begin(), orig_vertices.end(), rand_fun);
-#else
     std::shuffle(orig_vertices.begin(), orig_vertices.end(), gen);
-#endif
     std::map< vertex1, vertex2 > vertex_map;
 
     for (std::size_t i = 0; i < num_vertices(g1); ++i)
@@ -303,12 +295,7 @@ void test_colored_isomorphism(int n, double edge_probability)
 
     random_generator_type gen;
 
-#ifndef BOOST_NO_CXX98_RANDOM_SHUFFLE
-    random_functor< random_generator_type > rand_fun(gen);
-    std::random_shuffle(colors.begin(), colors.end(), rand_fun);
-#else
     std::shuffle(colors.begin(), colors.end(), gen);
-#endif
 
     int v_idx = 0;
     for (graph1::vertex_iterator v = vertices(g1).first;

--- a/test/vf2_sub_graph_iso_test.cpp
+++ b/test/vf2_sub_graph_iso_test.cpp
@@ -68,19 +68,12 @@ void randomly_permute_graph(Graph1& g1, const Graph2& g2)
     typedef typename graph_traits< Graph2 >::edge_iterator edge_iterator;
 
     random_generator_type gen;
-#ifndef BOOST_NO_CXX98_RANDOM_SHUFFLE
-    random_functor< random_generator_type > rand_fun(gen);
-#endif
 
     // Decide new order
     std::vector< vertex2 > orig_vertices;
     std::copy(vertices(g2).first, vertices(g2).second,
         std::back_inserter(orig_vertices));
-#ifndef BOOST_NO_CXX98_RANDOM_SHUFFLE
-    std::random_shuffle(orig_vertices.begin(), orig_vertices.end(), rand_fun);
-#else
     std::shuffle(orig_vertices.begin(), orig_vertices.end(), gen);
-#endif
     std::map< vertex2, vertex1 > vertex_map;
 
     std::size_t i = 0;


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

clears `-Wdeprecated-declarations` on both clang and gcc : refer #496 

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [x] Bug fix
- [ ] New feature or API addition
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

<!-- A short summary of the change. -->

Replace the deprecated `std::random_shuffle` (removed in C++17) with `std::shuffle` (avaiable in C++14)
- `isomorphism.cpp` and `vf2_sub_graph_iso_test.cpp`: dropped the `BOOST_NO_CXX98_RANDOM_SHUFFLE` guard, now always `std::shuffle(..., gen)`, and removed the now-unused `rand_fun`.
- `fibonacci_heap.cpp`: same guard collapse to `std::shuffle(..., gen)`.

### Motivation

<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->

Refs #496 

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->

### Checklist

- [x] Existing tests pass (`b2` in the `test/` directory).
- [x] New behavior is covered by a test, or this is a docs / build / refactor change.
- [x] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.