### PR TITLE
clears gcc -Wsign-compare

### DIFF
--- a/example/fibonacci_heap.cpp
+++ b/example/fibonacci_heap.cpp
@@ -41,7 +41,7 @@ int main()
             ICmp cmp(&w[0], std::less< float >());
             fibonacci_heap< int, ICmp > Q(N, cmp);
 
-            for (int c = 0; c < w.size(); ++c)
+            for (std::size_t c = 0; c < w.size(); ++c)
                 w[c] = c;
 #ifndef BOOST_NO_CXX98_RANDOM_SHUFFLE
             std::random_shuffle(w.begin(), w.end());

--- a/include/boost/pending/detail/disjoint_sets.hpp
+++ b/include/boost/pending/detail/disjoint_sets.hpp
@@ -55,8 +55,8 @@ namespace detail
     template < class ParentPA, class RankPA, class Vertex>
     inline void link_sets(ParentPA p, RankPA rank, Vertex i, Vertex j)
     {
-        assert(i == get(p, i));
-        assert(j == get(p, j));
+        assert(i == static_cast< Vertex >(get(p, i)));
+        assert(j == static_cast< Vertex >(get(p, j)));
         if (i == j)
             return;
         if (get(rank, i) > get(rank, j))

--- a/test/min_degree_empty.cpp
+++ b/test/min_degree_empty.cpp
@@ -37,7 +37,7 @@ int main(int argc, char** argv)
 
     for (size_t k = 0; k < n; ++k)
     {
-        BOOST_TEST(o[io[k]] == k);
+        BOOST_TEST(o[io[k]] == static_cast< int >(k));
     }
 
     return boost::report_errors();


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

Refs #496 

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [x] Bug fix
- [ ] New feature or API addition
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

<!-- A short summary of the change. -->

Fix `-Wsign-compare` (signed/unsigned comparison) warnings on gcc.
- `include/boost/pending/detail/disjoint_sets.hpp`: cast the property-map lookups to `Vertex` in the two `link_sets` asserts so they compare same-signedness (debug-only, stripped under `NDEBUG`).
- `example/fibonacci_heap.cpp`: changed the loop counter from `int` to `std::size_t` since it is compared against `w.size()`.
- `test/min_degree_empty.cpp`: cast the loop index `k` to `int` in the `BOOST_TEST` comparison against the `int`-valued ordering.

### Motivation

<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->

Refs #496

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->

### Checklist

- [x] Existing tests pass (`b2` in the `test/` directory).
- [x] New behavior is covered by a test, or this is a docs / build / refactor change.
- [x] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.
