### PR TITLE
fix: restructure visitors pages to match old html style

### DIFF
--- a/doc/modules/ROOT/nav.adoc
+++ b/doc/modules/ROOT/nav.adoc
@@ -11,13 +11,14 @@
 ** xref:property_maps/pitfalls.adoc[Common Mistakes]
 * xref:visitors/overview.adoc[Visitors]
 ** Pre-built Event Visitors
-*** xref:visitors/predecessor_recorder.adoc[Predecessor Recorder]
+*** xref:visitors/predecessor_recorder.adoc[Vertex Predecessor Recorder]
+*** xref:visitors/edge_predecessor_recorder.adoc[Edge Predecessor Recorder]
 *** xref:visitors/distance_recorder.adoc[Distance Recorder]
-*** xref:visitors/time_stamper.adoc[Time Stamper]
 *** xref:visitors/property_put.adoc[Property Put]
 *** xref:visitors/property_writer.adoc[Property Writer]
-*** xref:visitors/edge_predecessor_recorder.adoc[Edge Predecessor Recorder]
+*** xref:visitors/time_stamper.adoc[Time Stamper]
 *** xref:visitors/null_visitor.adoc[Null Visitor]
+** Algorithm-specific visitors
 *** xref:visitors/tsp_tour_visitor.adoc[TSP Tour Visitor]
 *** xref:visitors/tsp_tour_len_visitor.adoc[TSP Tour Len Visitor]
 *** xref:visitors/astar_heuristic.adoc[A* Heuristic (Zero)]

--- a/doc/modules/ROOT/pages/visitors/distance_recorder.adoc
+++ b/doc/modules/ROOT/pages/visitors/distance_recorder.adoc
@@ -1,10 +1,83 @@
 = distance_recorder
 
-Records the hop distance of each vertex from the source during a graph search.
+Records the distance of each vertex from the source vertex into a property map.
+When applied to edge `e = (u, v)`, the distance of `v` is recorded as one more
+than the distance of `u`.
 
 *Defined in:* `<boost/graph/visitors.hpp>` +
-*Models:* EventVisitor +
-*Typical event:* `on_tree_edge` (edge events only)
+*Models:* xref:visitors/EventVisitor.adoc[EventVisitor] +
+*Typical event:* `on_tree_edge` or `on_relax_edge` (edge events only; cannot be
+used with vertex events)
+
+To use it, wrap it in an algorithm adaptor and optionally combine it with other
+event visitors; see the xref:visitors/overview.adoc[visitors overview].
+
+== Synopsis
+
+[source,cpp]
+----
+template <typename DistanceMap, typename EventTag>
+struct distance_recorder {
+  typedef EventTag event_filter;
+  distance_recorder(DistanceMap pa);
+
+  template <class Edge, class Graph>
+  void operator()(Edge e, const Graph& g);
+};
+
+template <typename DistanceMap, typename EventTag>
+distance_recorder<DistanceMap, EventTag>
+record_distances(DistanceMap pa, EventTag);
+----
+
+== Template Parameters
+
+[cols="1,3",options="header"]
+|===
+| Parameter | Description
+
+| `DistanceMap`
+| A WritablePropertyMap whose key type is the graph's vertex descriptor and whose
+  value type is the distance (a numeric type that supports adding one).
+
+| `EventTag`
+| The event at which to record. Must be an edge event (e.g. `on_tree_edge`,
+  `on_relax_edge`).
+|===
+
+== Associated Types
+
+[cols="1,3",options="header"]
+|===
+| Type | Description
+
+| `event_filter`
+| The event tag the visitor responds to. Same type as `EventTag`.
+|===
+
+== Member Functions
+
+[cols="1,3",options="header"]
+|===
+| Member | Description
+
+| `distance_recorder(DistanceMap pa)`
+| Constructs a recorder writing distances into the property map `pa`.
+
+| `void operator()(Edge e, const Graph& g)`
+| Given edge `e = (u, v)`, records the distance of `v` as one more than the
+  distance of `u`: `put(pa, v, get(pa, u) + 1)`.
+|===
+
+== Non-Member Functions
+
+[cols="1,3",options="header"]
+|===
+| Function | Description
+
+| `record_distances(DistanceMap pa, EventTag)`
+| Convenience factory that creates a `distance_recorder`.
+|===
 
 == Example
 
@@ -17,33 +90,3 @@ include::example$visitors/distance_recorder.cpp[]
 ----
 include::example$visitors/distance_recorder.txt[]
 ----
-
-== Synopsis
-
-[source,cpp]
-----
-template <typename DistanceMap, typename EventTag>
-struct distance_recorder;
-
-template <typename DistanceMap, typename EventTag>
-distance_recorder<DistanceMap, EventTag>
-record_distances(DistanceMap pa, EventTag);
-----
-
-== Parameters
-
-[cols="1,3",options="header"]
-|===
-| Parameter | Description
-
-| `DistanceMap`
-| WritablePropertyMap. Key type is vertex descriptor.
-
-| `EventTag`
-| Must be an edge event tag (e.g. `on_tree_edge`).
-|===
-
-== Behavior
-
-Given edge `e = (u, v)`, sets the distance of `v` to one plus the distance
-of `u`: `put(dist_map, v, get(dist_map, u) + 1)`.

--- a/doc/modules/ROOT/pages/visitors/edge_predecessor_recorder.adoc
+++ b/doc/modules/ROOT/pages/visitors/edge_predecessor_recorder.adoc
@@ -1,12 +1,90 @@
 = edge_predecessor_recorder
 
-Records the predecessor _edge_ (not vertex) for each vertex. Useful when a
-graph has parallel edges and you need to know which specific edge the search
-used to reach a vertex.
+Records the predecessor _edge_ of each vertex in a property map, an efficient way
+to encode the search tree traversed during a graph search. Use this instead of
+xref:visitors/predecessor_recorder.adoc[`predecessor_recorder`] (which records the
+predecessor vertex) when a graph has parallel edges and you need to know which
+specific edge the search used to reach a vertex.
 
 *Defined in:* `<boost/graph/visitors.hpp>` +
-*Models:* EventVisitor +
-*Typical event:* `on_tree_edge` or `on_relax_edge` (edge events only)
+*Models:* xref:visitors/EventVisitor.adoc[EventVisitor] +
+*Typical event:* `on_tree_edge` or `on_relax_edge` (edge events only; cannot be
+used with vertex events)
+
+To use it, wrap it in an algorithm adaptor and optionally combine it with other
+event visitors; see the xref:visitors/overview.adoc[visitors overview].
+
+== Synopsis
+
+[source,cpp]
+----
+template <typename PredEdgeMap, typename EventTag>
+struct edge_predecessor_recorder {
+  typedef EventTag event_filter;
+  edge_predecessor_recorder(PredEdgeMap pa);
+
+  template <class Edge, class Graph>
+  void operator()(Edge e, const Graph& g);
+};
+
+template <typename PredEdgeMap, typename EventTag>
+edge_predecessor_recorder<PredEdgeMap, EventTag>
+record_edge_predecessors(PredEdgeMap pa, EventTag);
+----
+
+== Template Parameters
+
+[cols="1,3",options="header"]
+|===
+| Parameter | Description
+
+| `PredEdgeMap`
+| A WritablePropertyMap whose key type is the graph's vertex descriptor and whose
+  value type is the graph's edge descriptor.
+
+| `EventTag`
+| The event at which to record. Must be an edge event (e.g. `on_tree_edge`,
+  `on_relax_edge`).
+|===
+
+== Associated Types
+
+[cols="1,3",options="header"]
+|===
+| Type | Description
+
+| `event_filter`
+| The event tag the visitor responds to. Same type as `EventTag`.
+|===
+
+== Member Functions
+
+[cols="1,3",options="header"]
+|===
+| Member | Description
+
+| `edge_predecessor_recorder(PredEdgeMap pa)`
+| Constructs a recorder writing predecessor edges into the property map `pa`.
+
+| `void operator()(Edge e, const Graph& g)`
+| Given edge `e = (u, v)`, records `e` as the predecessor edge of `v`:
+  `put(pa, v, e)`.
+|===
+
+== Non-Member Functions
+
+[cols="1,3",options="header"]
+|===
+| Function | Description
+
+| `record_edge_predecessors(PredEdgeMap pa, EventTag)`
+| Convenience factory that creates an `edge_predecessor_recorder`.
+|===
+
+TIP: The source vertex (the root of the search tree) is not assigned a predecessor
+edge. Initialize it to a sentinel value before running the algorithm to identify
+the root. For DFS (which builds a forest), do the same for every vertex so all
+roots can be distinguished.
 
 == Example
 
@@ -19,39 +97,3 @@ include::example$visitors/edge_predecessor_recorder.cpp[]
 ----
 include::example$visitors/edge_predecessor_recorder.txt[]
 ----
-
-== Synopsis
-
-[source,cpp]
-----
-template <typename PredEdgeMap, typename EventTag>
-struct edge_predecessor_recorder;
-
-template <typename PredEdgeMap, typename EventTag>
-edge_predecessor_recorder<PredEdgeMap, EventTag>
-record_edge_predecessors(PredEdgeMap pa, EventTag);
-----
-
-== Parameters
-
-[cols="1,3",options="header"]
-|===
-| Parameter | Description
-
-| `PredEdgeMap`
-| WritablePropertyMap. Key type is vertex descriptor, value type is edge
-  descriptor.
-
-| `EventTag`
-| Must be an edge event tag (e.g. `on_tree_edge`, `on_relax_edge`).
-|===
-
-== Behavior
-
-Given edge `e = (u, v)`, records `e` as the predecessor edge of `v`:
-`put(pred_edge_map, v, e)`.
-
-TIP: The source vertex (root of the search tree) will not have a predecessor
-edge assigned. Initialize it to a sentinel value before running the algorithm.
-For DFS (which creates a forest), do the same for every vertex so that all
-roots can be identified.

--- a/doc/modules/ROOT/pages/visitors/null_visitor.adoc
+++ b/doc/modules/ROOT/pages/visitors/null_visitor.adoc
@@ -1,19 +1,40 @@
 = null_visitor
 
-A no-op event visitor that does nothing. Used as a placeholder or default when
-combining event visitors and one slot is not needed.
+A no-op event visitor that does nothing. Useful as a placeholder or default when
+an algorithm requires a visitor but no action is needed, or to fill an unused slot
+when combining event visitors.
 
 *Defined in:* `<boost/graph/visitors.hpp>` +
-*Models:* EventVisitor
+*Models:* xref:visitors/EventVisitor.adoc[EventVisitor]
 
 == Synopsis
 
 [source,cpp]
 ----
 struct null_visitor {
-    using event_filter = void;
+  typedef on_no_event event_filter;
 
-    template <typename X, typename Graph>
-    void operator()(X, const Graph&) {}
+  template <class T, class Graph>
+  void operator()(T x, Graph& g);
 };
 ----
+
+== Associated Types
+
+[cols="1,3",options="header"]
+|===
+| Type | Description
+
+| `event_filter`
+| `on_no_event`. The visitor is not associated with any algorithm event.
+|===
+
+== Member Functions
+
+[cols="1,3",options="header"]
+|===
+| Member | Description
+
+| `void operator()(T x, Graph& g)`
+| Does nothing.
+|===

--- a/doc/modules/ROOT/pages/visitors/predecessor_recorder.adoc
+++ b/doc/modules/ROOT/pages/visitors/predecessor_recorder.adoc
@@ -1,10 +1,86 @@
 = predecessor_recorder
 
-Records the predecessor (parent) vertex for each vertex in a property map.
+Records the predecessor (parent) vertex of each vertex in a property map. This is
+an efficient way to encode the search tree traversed during a graph search.
 
 *Defined in:* `<boost/graph/visitors.hpp>` +
-*Models:* EventVisitor +
-*Typical event:* `on_tree_edge` or `on_relax_edge` (edge events only)
+*Models:* xref:visitors/EventVisitor.adoc[EventVisitor] +
+*Typical event:* `on_tree_edge` or `on_relax_edge` (edge events only; cannot be
+used with vertex events)
+
+To use it, wrap it in an algorithm adaptor and optionally combine it with other
+event visitors; see the xref:visitors/overview.adoc[visitors overview].
+
+== Synopsis
+
+[source,cpp]
+----
+template <typename PredecessorMap, typename EventTag>
+struct predecessor_recorder {
+  typedef EventTag event_filter;
+  predecessor_recorder(PredecessorMap pa);
+
+  template <class Edge, class Graph>
+  void operator()(Edge e, const Graph& g);
+};
+
+template <typename PredecessorMap, typename EventTag>
+predecessor_recorder<PredecessorMap, EventTag>
+record_predecessors(PredecessorMap pa, EventTag);
+----
+
+== Template Parameters
+
+[cols="1,3",options="header"]
+|===
+| Parameter | Description
+
+| `PredecessorMap`
+| A WritablePropertyMap whose key and value types are both the graph's vertex
+  descriptor.
+
+| `EventTag`
+| The event at which to record. Must be an edge event (e.g. `on_tree_edge`,
+  `on_relax_edge`).
+|===
+
+== Associated Types
+
+[cols="1,3",options="header"]
+|===
+| Type | Description
+
+| `event_filter`
+| The event tag the visitor responds to. Same type as `EventTag`.
+|===
+
+== Member Functions
+
+[cols="1,3",options="header"]
+|===
+| Member | Description
+
+| `predecessor_recorder(PredecessorMap pa)`
+| Constructs a recorder writing predecessors into the property map `pa`.
+
+| `void operator()(Edge e, const Graph& g)`
+| Given edge `e = (u, v)`, records `u` as the predecessor of `v`: `put(pa, v, u)`.
+|===
+
+== Non-Member Functions
+
+[cols="1,3",options="header"]
+|===
+| Function | Description
+
+| `record_predecessors(PredecessorMap pa, EventTag)`
+| Convenience factory that creates a `predecessor_recorder`.
+|===
+
+TIP: Algorithms such as Dijkstra and BFS do not assign a predecessor to the source
+vertex (the root of the search tree). Initialize the source's predecessor to itself
+to mark it as the only vertex that is its own parent. For DFS (which builds a
+forest), initialize every vertex to itself so all roots can be distinguished.
 
 == Example
 
@@ -17,38 +93,3 @@ include::example$visitors/predecessor_recorder.cpp[]
 ----
 include::example$visitors/predecessor_recorder.txt[]
 ----
-
-TIP: Initialize the source vertex's predecessor to itself before running the
-algorithm. This marks the root of the search tree as the only vertex that is
-its own parent. For DFS (which creates a forest), initialize every vertex to
-itself.
-
-== Synopsis
-
-[source,cpp]
-----
-template <typename PredecessorMap, typename EventTag>
-struct predecessor_recorder;
-
-template <typename PredecessorMap, typename EventTag>
-predecessor_recorder<PredecessorMap, EventTag>
-record_predecessors(PredecessorMap pa, EventTag);
-----
-
-== Parameters
-
-[cols="1,3",options="header"]
-|===
-| Parameter | Description
-
-| `PredecessorMap`
-| WritablePropertyMap. Key type and value type are both the vertex descriptor.
-
-| `EventTag`
-| Must be an edge event tag (e.g. `on_tree_edge`, `on_relax_edge`).
-|===
-
-== Behavior
-
-Given edge `e = (u, v)`, records `u` as the predecessor of `v`:
-`put(predecessor_map, v, u)`.

--- a/doc/modules/ROOT/pages/visitors/property_put.adoc
+++ b/doc/modules/ROOT/pages/visitors/property_put.adoc
@@ -1,11 +1,85 @@
 = property_put
 
-Assigns a fixed constant value to a property map entry when an event occurs.
-Useful for initialization or for marking specific edges (e.g. back edges).
+Writes a fixed value to a property map when a vertex or edge is visited at an
+event point. Useful as an alternative to an explicit loop for initializing a
+property map, or to mark a subset of vertices or edges (for example, only back
+edges) during a search.
 
 *Defined in:* `<boost/graph/visitors.hpp>` +
-*Models:* EventVisitor +
-*Typical event:* any
+*Models:* xref:visitors/EventVisitor.adoc[EventVisitor] +
+*Typical event:* any (vertex or edge)
+
+To use it, wrap it in an algorithm adaptor and optionally combine it with other
+event visitors; see the xref:visitors/overview.adoc[visitors overview].
+
+== Synopsis
+
+[source,cpp]
+----
+template <typename PropertyMap, typename EventTag>
+struct property_put {
+  typedef EventTag event_filter;
+  property_put(PropertyMap pa,
+               typename property_traits<PropertyMap>::value_type value);
+
+  template <class VertexOrEdge, class Graph>
+  void operator()(VertexOrEdge x, const Graph& g);
+};
+
+template <typename PropertyMap, typename EventTag>
+property_put<PropertyMap, EventTag>
+put_property(PropertyMap pa,
+             typename property_traits<PropertyMap>::value_type value,
+             EventTag);
+----
+
+== Template Parameters
+
+[cols="1,3",options="header"]
+|===
+| Parameter | Description
+
+| `PropertyMap`
+| A WritablePropertyMap whose key type is the graph's vertex or edge descriptor
+  (depending on the event tag).
+
+| `EventTag`
+| The event at which to write. May be any event, vertex or edge.
+|===
+
+== Associated Types
+
+[cols="1,3",options="header"]
+|===
+| Type | Description
+
+| `event_filter`
+| The event tag the visitor responds to. Same type as `EventTag`.
+|===
+
+== Member Functions
+
+[cols="1,3",options="header"]
+|===
+| Member | Description
+
+| `property_put(PropertyMap pa, value_type value)`
+| Constructs a visitor that writes the fixed `value` into the property map `pa`.
+
+| `void operator()(VertexOrEdge x, const Graph& g)`
+| Writes the fixed value into the property map for `x` (a vertex or edge):
+  `put(pa, x, value)`.
+|===
+
+== Non-Member Functions
+
+[cols="1,3",options="header"]
+|===
+| Function | Description
+
+| `put_property(PropertyMap pa, value_type value, EventTag)`
+| Convenience factory that creates a `property_put`.
+|===
 
 == Example
 
@@ -18,34 +92,3 @@ include::example$visitors/property_put.cpp[]
 ----
 include::example$visitors/property_put.txt[]
 ----
-
-== Synopsis
-
-[source,cpp]
-----
-template <typename PropertyMap, typename EventTag>
-struct property_put;
-
-template <typename PropertyMap, typename EventTag>
-property_put<PropertyMap, EventTag>
-put_property(PropertyMap pa,
-             typename property_traits<PropertyMap>::value_type val,
-             EventTag);
-----
-
-== Parameters
-
-[cols="1,3",options="header"]
-|===
-| Parameter | Description
-
-| `PropertyMap`
-| WritablePropertyMap. Key type is vertex or edge descriptor.
-
-| `EventTag`
-| Any event tag (vertex or edge).
-|===
-
-== Behavior
-
-Writes the fixed value to the property map: `put(pa, x, val)`.

--- a/doc/modules/ROOT/pages/visitors/property_writer.adoc
+++ b/doc/modules/ROOT/pages/visitors/property_writer.adoc
@@ -1,11 +1,85 @@
 = property_writer
 
-Writes the property value of a vertex or edge to an output iterator when an
-event occurs. Useful for debugging or logging during graph traversal.
+Writes the property value of a vertex or edge to an output iterator when an event
+occurs. Useful for debugging or logging during a graph traversal.
 
 *Defined in:* `<boost/graph/visitors.hpp>` +
-*Models:* EventVisitor +
-*Typical event:* `on_discover_vertex`, `on_examine_edge`
+*Models:* xref:visitors/EventVisitor.adoc[EventVisitor] +
+*Typical event:* any (vertex or edge), e.g. `on_discover_vertex`,
+`on_examine_edge`
+
+To use it, wrap it in an algorithm adaptor and optionally combine it with other
+event visitors; see the xref:visitors/overview.adoc[visitors overview].
+
+== Synopsis
+
+[source,cpp]
+----
+template <typename PropertyMap, typename OutputIterator, typename EventTag>
+struct property_writer {
+  typedef EventTag event_filter;
+  property_writer(PropertyMap pa, OutputIterator out);
+
+  template <class T, class Graph>
+  void operator()(T x, Graph& g);
+};
+
+template <typename PropertyMap, typename OutputIterator, typename EventTag>
+property_writer<PropertyMap, OutputIterator, EventTag>
+write_property(PropertyMap pa, OutputIterator out, EventTag);
+----
+
+== Template Parameters
+
+[cols="1,3",options="header"]
+|===
+| Parameter | Description
+
+| `PropertyMap`
+| A ReadablePropertyMap whose key type is the graph's vertex or edge descriptor
+  (depending on the event tag), and whose value type is writable to the output
+  iterator.
+
+| `OutputIterator`
+| The output iterator the property values are written to.
+
+| `EventTag`
+| The event at which to write. May be any event, vertex or edge.
+|===
+
+== Associated Types
+
+[cols="1,3",options="header"]
+|===
+| Type | Description
+
+| `event_filter`
+| The event tag the visitor responds to. Same type as `EventTag`.
+|===
+
+== Member Functions
+
+[cols="1,3",options="header"]
+|===
+| Member | Description
+
+| `property_writer(PropertyMap pa, OutputIterator out)`
+| Constructs a writer reading from the property map `pa` and writing to `out`.
+
+| `void operator()(T x, Graph& g)`
+| Reads the property of `x` (a vertex or edge) and writes it to the output
+  iterator: `*out++ = get(pa, x)`.
+|===
+
+== Non-Member Functions
+
+[cols="1,3",options="header"]
+|===
+| Function | Description
+
+| `write_property(PropertyMap pa, OutputIterator out, EventTag)`
+| Convenience factory that creates a `property_writer`.
+|===
 
 == Example
 
@@ -18,35 +92,3 @@ include::example$visitors/property_writer.cpp[]
 ----
 include::example$visitors/property_writer.txt[]
 ----
-
-== Synopsis
-
-[source,cpp]
-----
-template <typename PropertyMap, typename OutputIterator, typename EventTag>
-struct property_writer;
-
-template <typename PropertyMap, typename OutputIterator, typename EventTag>
-property_writer<PropertyMap, OutputIterator, EventTag>
-write_property(PropertyMap pa, OutputIterator out, EventTag);
-----
-
-== Parameters
-
-[cols="1,3",options="header"]
-|===
-| Parameter | Description
-
-| `PropertyMap`
-| ReadablePropertyMap. Key type is vertex or edge descriptor.
-
-| `OutputIterator`
-| Output iterator. The property's value type must be writable to it.
-
-| `EventTag`
-| Any event tag (vertex or edge).
-|===
-
-== Behavior
-
-Writes the property value to the output iterator: `*out++ = get(pa, x)`.

--- a/doc/modules/ROOT/pages/visitors/time_stamper.adoc
+++ b/doc/modules/ROOT/pages/visitors/time_stamper.adoc
@@ -1,11 +1,87 @@
 = time_stamper
 
-Stamps a monotonically increasing time value when an event occurs. Commonly
-used to record discover and finish times during DFS.
+Stamps a monotonically increasing time value onto a vertex or edge when an event
+occurs. Commonly used to record the discover and finish times of vertices during
+a graph search.
 
 *Defined in:* `<boost/graph/visitors.hpp>` +
-*Models:* EventVisitor +
-*Typical event:* `on_discover_vertex`, `on_finish_vertex`
+*Models:* xref:visitors/EventVisitor.adoc[EventVisitor] +
+*Typical event:* any (vertex or edge), e.g. `on_discover_vertex`,
+`on_finish_vertex`
+
+To use it, wrap it in an algorithm adaptor and optionally combine it with other
+event visitors; see the xref:visitors/overview.adoc[visitors overview].
+
+== Synopsis
+
+[source,cpp]
+----
+template <typename TimeMap, typename TimeT, typename EventTag>
+struct time_stamper {
+  typedef EventTag event_filter;
+  time_stamper(TimeMap pa, TimeT& t);
+
+  template <class X, class Graph>
+  void operator()(X x, const Graph& g);
+};
+
+template <typename TimeMap, typename TimeT, typename EventTag>
+time_stamper<TimeMap, TimeT, EventTag>
+stamp_times(TimeMap pa, TimeT& t, EventTag);
+----
+
+== Template Parameters
+
+[cols="1,3",options="header"]
+|===
+| Parameter | Description
+
+| `TimeMap`
+| A WritablePropertyMap whose key type is the graph's vertex or edge descriptor
+  (depending on the event tag), and whose value type accepts the time counter.
+
+| `TimeT`
+| The time-counter type. Passed by reference and incremented on each event, so a
+  single counter can be shared across several `time_stamper` objects.
+
+| `EventTag`
+| The event at which to stamp the time. May be any event, vertex or edge.
+|===
+
+== Associated Types
+
+[cols="1,3",options="header"]
+|===
+| Type | Description
+
+| `event_filter`
+| The event tag the visitor responds to. Same type as `EventTag`.
+|===
+
+== Member Functions
+
+[cols="1,3",options="header"]
+|===
+| Member | Description
+
+| `time_stamper(TimeMap pa, TimeT& t)`
+| Constructs a time stamper writing into the property map `pa` and using the
+  shared counter `t`.
+
+| `void operator()(X x, const Graph& g)`
+| Increments the counter and stamps the new value onto `x` (a vertex or edge):
+  `put(pa, x, ++t)`.
+|===
+
+== Non-Member Functions
+
+[cols="1,3",options="header"]
+|===
+| Function | Description
+
+| `stamp_times(TimeMap pa, TimeT& t, EventTag)`
+| Convenience factory that creates a `time_stamper`.
+|===
 
 == Example
 
@@ -18,35 +94,3 @@ include::example$visitors/time_stamper.cpp[]
 ----
 include::example$visitors/time_stamper.txt[]
 ----
-
-== Synopsis
-
-[source,cpp]
-----
-template <typename TimeMap, typename TimeT, typename EventTag>
-struct time_stamper;
-
-template <typename TimeMap, typename TimeT, typename EventTag>
-time_stamper<TimeMap, TimeT, EventTag>
-stamp_times(TimeMap pa, TimeT& t, EventTag);
-----
-
-== Parameters
-
-[cols="1,3",options="header"]
-|===
-| Parameter | Description
-
-| `TimeMap`
-| WritablePropertyMap. Key type is the vertex or edge descriptor.
-
-| `TimeT`
-| The time counter type. Passed by reference; incremented on each event.
-
-| `EventTag`
-| Any event tag (vertex or edge).
-|===
-
-== Behavior
-
-Increments the counter and stamps the time: `put(time_map, x, ++t)`.


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [ ] Bug fix
- [ ] New feature or API addition
- [ ] Refactor (no behavior change)
- [x] Documentation
- [ ] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

<!-- A short summary of the change. -->

Revisit modern documentation of visitors to match the old style html.

### Motivation

<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->

There were some deviations from old style during migration (e.g. tables removed) that made it harder to navigate. This PR intends to remediate it.

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->

### Checklist

- [x] Existing tests pass (`b2` in the `test/` directory).
- [x] New behavior is covered by a test, or this is a docs / build / refactor change.
- [x] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.
