### PR TITLE
doc: opt out of aggregated boostlook to solve toc issues

### DIFF
--- a/doc/playbook.yml
+++ b/doc/playbook.yml
@@ -23,5 +23,5 @@ asciidoc:
 
 ui:
   bundle:
-    url: https://github.com/boostorg/unordered-ui-bundle/raw/c80db72a7ba804256beb36e3a46d9c7df265d8d7/ui-bundle.zip
+    url: https://github.com/boostorg/graph-ui-bundle/raw/c80db72a7ba804256beb36e3a46d9c7df265d8d7/ui-bundle.zip
     snapshot: true


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [x] Bug fix
- [ ] New feature or API addition
- [ ] Refactor (no behavior change)
- [x] Documentation
- [x] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

<!-- A short summary of the change. -->

So the boostlook aggregated framework does not collapse table of contents. It makes navigation particularly hard.
Here we imitate exactly what Boost.Unordered is doing.
We have full control over https://github.com/boostorg/graph-ui-bundle
It means we can control the ToC rendering and reinstate the warning banner saying the documentation is being rewritten.
### Motivation

<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->

By leaving boostlook I believe we lose access to PR previews (they were not truthfull to final rendering anyway)
So just merge and see how it renders on develop and/or master 😢 

### Checklist

- [x] Existing tests pass (`b2` in the `test/` directory).
- [x] New behavior is covered by a test, or this is a docs / build / refactor change.
- [x] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.
