### PR TITLE
fix: remove 6 stale or deprecated dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,16 +25,13 @@ target_link_libraries(boost_graph
     Boost::concept_check
     Boost::config
     Boost::container_hash
-    Boost::conversion
     Boost::core
     Boost::detail
-    Boost::foreach
     Boost::function
     Boost::integer
     Boost::iterator
     Boost::lexical_cast
     Boost::math
-    Boost::move
     Boost::mpl
     Boost::multi_index
     Boost::multiprecision
@@ -52,7 +49,6 @@ target_link_libraries(boost_graph
     Boost::tti
     Boost::tuple
     Boost::type_traits
-    Boost::typeof
     Boost::unordered
     Boost::utility
     Boost::xpressive

--- a/build.jam
+++ b/build.jam
@@ -15,7 +15,6 @@ constant boost_dependencies :
     /boost/concept_check//boost_concept_check
     /boost/config//boost_config
     /boost/container_hash//boost_container_hash
-    /boost/conversion//boost_conversion
     /boost/core//boost_core
     /boost/detail//boost_detail
     /boost/foreach//boost_foreach

--- a/build.jam
+++ b/build.jam
@@ -40,7 +40,6 @@ constant boost_dependencies :
     /boost/tti//boost_tti
     /boost/tuple//boost_tuple
     /boost/type_traits//boost_type_traits
-    /boost/typeof//boost_typeof
     /boost/unordered//boost_unordered
     /boost/utility//boost_utility
     /boost/xpressive//boost_xpressive ;

--- a/build.jam
+++ b/build.jam
@@ -16,7 +16,6 @@ constant boost_dependencies :
     /boost/container_hash//boost_container_hash
     /boost/core//boost_core
     /boost/detail//boost_detail
-    /boost/foreach//boost_foreach
     /boost/function//boost_function
     /boost/integer//boost_integer
     /boost/iterator//boost_iterator

--- a/build.jam
+++ b/build.jam
@@ -11,7 +11,6 @@ constant boost_dependencies :
     /boost/array//boost_array
     /boost/assert//boost_assert
     /boost/bimap//boost_bimap
-    /boost/bind//boost_bind
     /boost/concept_check//boost_concept_check
     /boost/config//boost_config
     /boost/container_hash//boost_container_hash

--- a/build.jam
+++ b/build.jam
@@ -22,7 +22,6 @@ constant boost_dependencies :
     /boost/iterator//boost_iterator
     /boost/lexical_cast//boost_lexical_cast
     /boost/math//boost_math_tr1
-    /boost/move//boost_move
     /boost/mpl//boost_mpl
     /boost/multi_index//boost_multi_index
     /boost/multiprecision//boost_multiprecision

--- a/include/boost/graph/buffer_concepts.hpp
+++ b/include/boost/graph/buffer_concepts.hpp
@@ -7,7 +7,6 @@
 #define BOOST_GRAPH_BUFFER_CONCEPTS_HPP 1
 #include <boost/concept_check.hpp>
 #include <boost/property_map/property_map.hpp>
-#include <boost/typeof/typeof.hpp>
 #include <boost/type_traits/add_const.hpp>
 #include <boost/type_traits/add_reference.hpp>
 #include <boost/type_traits/remove_reference.hpp>

--- a/include/boost/graph/depth_first_search.hpp
+++ b/include/boost/graph/depth_first_search.hpp
@@ -21,7 +21,6 @@
 #include <boost/graph/named_function_params.hpp>
 #include <boost/graph/detail/mpi_include.hpp>
 #include <boost/ref.hpp>
-#include <boost/implicit_cast.hpp>
 #include <boost/optional.hpp>
 #include <boost/parameter.hpp>
 #include <boost/concept/assert.hpp>
@@ -275,7 +274,7 @@ void depth_first_search(const VertexListGraph& g, DFSVisitor vis,
     typename graph_traits< VertexListGraph >::vertex_iterator ui, ui_end;
     for (boost::tie(ui, ui_end) = vertices(g); ui != ui_end; ++ui)
     {
-        Vertex u = implicit_cast< Vertex >(*ui);
+        Vertex u = *ui;
         put(color, u, Color::white());
         vis.initialize_vertex(u, g);
     }
@@ -289,7 +288,7 @@ void depth_first_search(const VertexListGraph& g, DFSVisitor vis,
 
     for (boost::tie(ui, ui_end) = vertices(g); ui != ui_end; ++ui)
     {
-        Vertex u = implicit_cast< Vertex >(*ui);
+        Vertex u = *ui;
         ColorValue u_color = get(color, u);
         if (u_color == Color::white())
         {

--- a/include/boost/graph/graphviz.hpp
+++ b/include/boost/graph/graphviz.hpp
@@ -34,7 +34,6 @@
 #include <boost/static_assert.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/xpressive/xpressive_static.hpp>
-#include <boost/foreach.hpp>
 
 namespace boost
 {
@@ -843,13 +842,13 @@ namespace detail
                     edge_permutation_from_sorting[temp[e]] = e;
                 }
                 typedef boost::tuple< id_t, bgl_vertex_t, id_t > v_prop;
-                BOOST_FOREACH (const v_prop& t, vertex_props)
+                for (const v_prop& t : vertex_props)
                 {
                     put(boost::get< 0 >(t), dp_, boost::get< 1 >(t),
                         boost::get< 2 >(t));
                 }
                 typedef boost::tuple< id_t, bgl_edge_t, id_t > e_prop;
-                BOOST_FOREACH (const e_prop& t, edge_props)
+                for (const e_prop& t : edge_props)
                 {
                     put(boost::get< 0 >(t), dp_,
                         edge_permutation_from_sorting[boost::get< 1 >(t)],

--- a/include/boost/graph/hawick_circuits.hpp
+++ b/include/boost/graph/hawick_circuits.hpp
@@ -9,7 +9,6 @@
 
 #include <algorithm>
 #include <boost/assert.hpp>
-#include <boost/foreach.hpp>
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/one_bit_color_map.hpp>
 #include <boost/graph/properties.hpp>
@@ -17,6 +16,7 @@
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
 #include <boost/range/iterator.hpp>
+#include <boost/range/iterator_range.hpp>
 #include <boost/tuple/tuple.hpp> // for boost::tie
 #include <boost/type_traits/remove_reference.hpp>
 #include <boost/utility/result_of.hpp>
@@ -133,7 +133,7 @@ namespace hawick_circuits_detail
         // documented above.
         bool blocked_map_starts_all_unblocked() const
         {
-            BOOST_FOREACH (Vertex v, vertices(graph_))
+            for (Vertex v : boost::make_iterator_range(vertices(graph_)))
                 if (is_blocked(v))
                     return false;
             return true;
@@ -143,7 +143,7 @@ namespace hawick_circuits_detail
         // sharing data structures between iterations does not break the code.
         bool all_closed_rows_are_empty() const
         {
-            BOOST_FOREACH (typename ClosedMatrix::reference row, closed_)
+            for (typename ClosedMatrix::reference row : closed_)
                 if (!row.empty())
                     return false;
             return true;

--- a/include/boost/graph/hawick_circuits.hpp
+++ b/include/boost/graph/hawick_circuits.hpp
@@ -13,7 +13,6 @@
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/one_bit_color_map.hpp>
 #include <boost/graph/properties.hpp>
-#include <boost/move/utility.hpp>
 #include <boost/property_map/property_map.hpp>
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
@@ -48,11 +47,11 @@ namespace hawick_circuits_detail
 
         template < typename Vertex, typename Graph >
         typename result< get_all_adjacent_vertices(
-            BOOST_FWD_REF(Vertex), BOOST_FWD_REF(Graph)) >::type
-        operator()(BOOST_FWD_REF(Vertex) v, BOOST_FWD_REF(Graph) g) const
+            Vertex&&, Graph&&) >::type
+        operator()(Vertex&& v, Graph&& g) const
         {
             return adjacent_vertices(
-                boost::forward< Vertex >(v), boost::forward< Graph >(g));
+                std::forward< Vertex >(v), std::forward< Graph >(g));
         }
     };
 
@@ -347,34 +346,34 @@ namespace hawick_circuits_detail
 
     template < typename GetAdjacentVertices, typename Graph, typename Visitor >
     void call_hawick_circuits(
-        Graph const& graph, BOOST_FWD_REF(Visitor) visitor,
+        Graph const& graph, Visitor&& visitor,
         unsigned int max_length)
     {
         call_hawick_circuits< GetAdjacentVertices >(graph,
-            boost::forward< Visitor >(visitor), get(vertex_index, graph),
+            std::forward< Visitor >(visitor), get(vertex_index, graph),
             max_length);
     }
 } // end namespace hawick_circuits_detail
 
 //! Enumerate all the elementary circuits in a directed multigraph.
 template < typename Graph, typename Visitor, typename VertexIndexMap >
-void hawick_circuits(BOOST_FWD_REF(Graph) graph, BOOST_FWD_REF(Visitor) visitor,
-    BOOST_FWD_REF(VertexIndexMap) vertex_index_map,
+void hawick_circuits(Graph&& graph, Visitor&& visitor,
+    VertexIndexMap&& vertex_index_map,
     unsigned int max_length = 0)
 {
     hawick_circuits_detail::call_hawick_circuits<
         hawick_circuits_detail::get_all_adjacent_vertices >(
-        boost::forward< Graph >(graph), boost::forward< Visitor >(visitor),
-        boost::forward< VertexIndexMap >(vertex_index_map), max_length);
+        std::forward< Graph >(graph), std::forward< Visitor >(visitor),
+        std::forward< VertexIndexMap >(vertex_index_map), max_length);
 }
 
 template < typename Graph, typename Visitor >
-void hawick_circuits(BOOST_FWD_REF(Graph) graph, BOOST_FWD_REF(Visitor) visitor,
+void hawick_circuits(Graph&& graph, Visitor&& visitor,
     unsigned int max_length = 0)
 {
     hawick_circuits_detail::call_hawick_circuits<
         hawick_circuits_detail::get_all_adjacent_vertices >(
-        boost::forward< Graph >(graph), boost::forward< Visitor >(visitor),
+        std::forward< Graph >(graph), std::forward< Visitor >(visitor),
         max_length);
 }
 
@@ -383,25 +382,25 @@ void hawick_circuits(BOOST_FWD_REF(Graph) graph, BOOST_FWD_REF(Visitor) visitor,
  * edges will not be considered. Each circuit will be considered only once.
  */
 template < typename Graph, typename Visitor, typename VertexIndexMap >
-void hawick_unique_circuits(BOOST_FWD_REF(Graph) graph,
-    BOOST_FWD_REF(Visitor) visitor,
-    BOOST_FWD_REF(VertexIndexMap) vertex_index_map,
+void hawick_unique_circuits(Graph&& graph,
+    Visitor&& visitor,
+    VertexIndexMap&& vertex_index_map,
     unsigned int max_length = 0)
 {
     hawick_circuits_detail::call_hawick_circuits<
         hawick_circuits_detail::get_unique_adjacent_vertices >(
-        boost::forward< Graph >(graph), boost::forward< Visitor >(visitor),
-        boost::forward< VertexIndexMap >(vertex_index_map), max_length);
+        std::forward< Graph >(graph), std::forward< Visitor >(visitor),
+        std::forward< VertexIndexMap >(vertex_index_map), max_length);
 }
 
 template < typename Graph, typename Visitor >
 void hawick_unique_circuits(
-    BOOST_FWD_REF(Graph) graph, BOOST_FWD_REF(Visitor) visitor,
+    Graph&& graph, Visitor&& visitor,
     unsigned int max_length = 0)
 {
     hawick_circuits_detail::call_hawick_circuits<
         hawick_circuits_detail::get_unique_adjacent_vertices >(
-        boost::forward< Graph >(graph), boost::forward< Visitor >(visitor),
+        std::forward< Graph >(graph), std::forward< Visitor >(visitor),
         max_length);
 }
 } // end namespace boost

--- a/include/boost/graph/is_straight_line_drawing.hpp
+++ b/include/boost/graph/is_straight_line_drawing.hpp
@@ -16,7 +16,6 @@
 #include <boost/graph/properties.hpp>
 #include <boost/graph/planar_detail/bucket_sort.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
-#include <boost/numeric/conversion/cast.hpp>
 
 #include <algorithm>
 #include <vector>

--- a/src/graphml.cpp
+++ b/src/graphml.cpp
@@ -11,7 +11,6 @@
 //           Tiago de Paula Peixoto
 
 #define BOOST_GRAPH_SOURCE
-#include <boost/foreach.hpp>
 #include <boost/optional.hpp>
 #include <boost/throw_exception.hpp>
 #include <boost/graph/graphml.hpp>
@@ -44,7 +43,7 @@ public:
         using boost::property_tree::ptree;
         size_t current_idx = 0;
         bool is_first = is_root;
-        BOOST_FOREACH (const ptree::value_type& n, top)
+        for (const ptree::value_type& n : top)
         {
             if (n.first == "graph")
             {
@@ -54,7 +53,7 @@ public:
                     if (is_first)
                     {
                         is_first = false;
-                        BOOST_FOREACH (const ptree::value_type& attr, n.second)
+                        for (const ptree::value_type& attr : n.second)
                         {
                             if (attr.first != "data")
                                 continue;
@@ -83,7 +82,7 @@ public:
                 | boost::property_tree::xml_parser::trim_whitespace);
         ptree gml = pt.get_child(path("graphml"));
         // Search for attributes
-        BOOST_FOREACH (const ptree::value_type& child, gml)
+        for (const ptree::value_type& child : gml)
         {
             if (child.first != "key")
                 continue;
@@ -127,17 +126,17 @@ public:
         std::vector< const ptree* > graphs;
         handle_graph();
         get_graphs(gml, desired_idx, true, graphs);
-        BOOST_FOREACH (const ptree* gr, graphs)
+        for (const ptree* gr : graphs)
         {
             // Search for nodes
-            BOOST_FOREACH (const ptree::value_type& node, *gr)
+            for (const ptree::value_type& node : *gr)
             {
                 if (node.first != "node")
                     continue;
                 std::string id
                     = node.second.get< std::string >(path("<xmlattr>/id"));
                 handle_vertex(id);
-                BOOST_FOREACH (const ptree::value_type& attr, node.second)
+                for (const ptree::value_type& attr : node.second)
                 {
                     if (attr.first != "data")
                         continue;
@@ -148,13 +147,13 @@ public:
                 }
             }
         }
-        BOOST_FOREACH (const ptree* gr, graphs)
+        for (const ptree* gr : graphs)
         {
             bool default_directed
                 = gr->get< std::string >(path("<xmlattr>/edgedefault"))
                 == "directed";
             // Search for edges
-            BOOST_FOREACH (const ptree::value_type& edge, *gr)
+            for (const ptree::value_type& edge : *gr)
             {
                 if (edge.first != "edge")
                     continue;
@@ -180,7 +179,7 @@ public:
                 }
                 size_t old_edges_size = m_edge.size();
                 handle_edge(source, target);
-                BOOST_FOREACH (const ptree::value_type& attr, edge.second)
+                for (const ptree::value_type& attr : edge.second)
                 {
                     if (attr.first != "data")
                         continue;


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

Reducing boost dependencies with C++ modernization. It's pure hygiene, not user-facing, breaks no API.

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [ ] Bug fix
- [ ] New feature or API addition
- [x] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

<!-- A short summary of the change. -->

A few commits of hygiene:

1. Remove Boost.Conversion. It was used only in DFS for `implicit_cast`, when copy-initialization `(Vertex u = expr;)` requires an implicit conversion exercising the exact same constraint `boost::implicit_cast` enforces.
2. Remove stale boost.bind dependency (not use anywhere)
3. Remove stale boost.typeof dependency (included but not used)
4. Remove boost.move dependency
5. Remove boost.foreach dependency
6. Remove boost.numeric_conversion dependency

### Motivation

<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->

Users complained they need to drag the entire Boost ecosystem to use Boost.Graph. Meanwhile, many dependencies were pulled in older C++ versions for utilities that C++14 now provides.

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->

### Checklist

- [x] Existing tests pass (`b2` in the `test/` directory).
- [x] New behavior is covered by a test, or this is a docs / build / refactor change.
- [x] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.
