### PR TITLE
refactor: removing many dependencies to Boost.MPL

### DIFF
--- a/include/boost/graph/adjacency_list.hpp
+++ b/include/boost/graph/adjacency_list.hpp
@@ -25,9 +25,6 @@
 #include <boost/graph/graph_mutability_traits.hpp>
 #include <boost/graph/graph_selectors.hpp>
 #include <boost/property_map/property_map.hpp>
-#include <boost/mpl/if.hpp>
-#include <boost/mpl/and.hpp>
-#include <boost/mpl/not.hpp>
 #include <boost/graph/detail/edge.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <type_traits>
@@ -220,8 +217,8 @@ struct adjacency_list_traits
     typedef typename DirectedS::is_bidir_t is_bidir;
     typedef typename DirectedS::is_directed_t is_directed;
 
-    typedef typename mpl::if_< is_bidir, bidirectional_tag,
-        typename mpl::if_< is_directed, directed_tag,
+    typedef typename std::conditional< is_bidir::value, bidirectional_tag,
+        typename std::conditional< is_directed::value, directed_tag,
             undirected_tag >::type >::type directed_category;
 
     typedef typename parallel_edge_traits< OutEdgeListS >::type
@@ -229,7 +226,7 @@ struct adjacency_list_traits
 
     typedef std::size_t vertices_size_type;
     typedef void* vertex_ptr;
-    typedef typename mpl::if_< is_rand_access, vertices_size_type,
+    typedef typename std::conditional< is_rand_access::value, vertices_size_type,
         vertex_ptr >::type vertex_descriptor;
     typedef detail::edge_desc_impl< directed_category, vertex_descriptor >
         edge_descriptor;
@@ -242,11 +239,12 @@ private:
     typedef typename container_gen< EdgeListS, dummy >::type EdgeContainer;
     typedef typename DirectedS::is_bidir_t BidirectionalT;
     typedef typename DirectedS::is_directed_t DirectedT;
-    typedef typename mpl::and_< DirectedT,
-        typename mpl::not_< BidirectionalT >::type >::type on_edge_storage;
+    typedef std::integral_constant< bool,
+        DirectedT::value && !BidirectionalT::value >
+        on_edge_storage;
 
 public:
-    typedef typename mpl::if_< on_edge_storage, std::size_t,
+    typedef typename std::conditional< on_edge_storage::value, std::size_t,
         typename EdgeContainer::size_type >::type edges_size_type;
 };
 

--- a/include/boost/graph/adjacency_matrix.hpp
+++ b/include/boost/graph/adjacency_matrix.hpp
@@ -20,8 +20,7 @@
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/graph_mutability_traits.hpp>
 #include <boost/graph/graph_selectors.hpp>
-#include <boost/mpl/if.hpp>
-#include <boost/mpl/bool.hpp>
+#include <type_traits>
 #include <boost/graph/adjacency_iterator.hpp>
 #include <boost/graph/detail/edge.hpp>
 #include <boost/iterator/iterator_adaptor.hpp>
@@ -413,7 +412,7 @@ public:
     // in_degree, etc.).
     BOOST_STATIC_ASSERT(!(is_same< Directed, bidirectionalS >::value));
 
-    typedef typename mpl::if_< is_directed, bidirectional_tag,
+    typedef typename std::conditional< is_directed::value, bidirectional_tag,
         undirected_tag >::type directed_category;
 
     typedef disallow_parallel_edge_tag edge_parallel_category;
@@ -470,7 +469,7 @@ public:
 
 public: // should be private
     typedef
-        typename mpl::if_< typename has_property< edge_property_type >::type,
+        typename std::conditional< has_property< edge_property_type >::type::value,
             std::pair< bool, edge_property_type >, char >::type StoredEdge;
 #if defined(BOOST_NO_STD_ALLOCATOR)
     typedef std::vector< StoredEdge > Matrix;
@@ -510,7 +509,7 @@ public:
         MatrixIter, size_type, edge_descriptor >
         UnDirOutEdgeIter;
 
-    typedef typename mpl::if_< typename Directed::is_directed_t, DirOutEdgeIter,
+    typedef typename std::conditional< Directed::is_directed_t::value, DirOutEdgeIter,
         UnDirOutEdgeIter >::type unfiltered_out_edge_iter;
 
     typedef detail::dir_adj_matrix_in_edge_iter< vertex_descriptor, MatrixIter,
@@ -521,7 +520,7 @@ public:
         MatrixIter, size_type, edge_descriptor >
         UnDirInEdgeIter;
 
-    typedef typename mpl::if_< typename Directed::is_directed_t, DirInEdgeIter,
+    typedef typename std::conditional< Directed::is_directed_t::value, DirInEdgeIter,
         UnDirInEdgeIter >::type unfiltered_in_edge_iter;
 
     typedef detail::adj_matrix_edge_iter< Directed, MatrixIter, size_type,
@@ -1103,7 +1102,7 @@ struct adj_mat_pm_helper< D, VP, EP, GP, A, Tag, edge_property_tag >
     {
         Tag tag;
         lookup_property_from_edge(Tag tag) : tag(tag) {}
-        typedef typename boost::mpl::if_< IsConst, const EP, EP >::type
+        typedef typename std::conditional< IsConst::value, const EP, EP >::type
             ep_type_nonref;
         typedef ep_type_nonref& ep_type;
         typedef typename lookup_one_property< ep_type_nonref, Tag >::type&
@@ -1116,20 +1115,20 @@ struct adj_mat_pm_helper< D, VP, EP, GP, A, Tag, edge_property_tag >
     };
 
     typedef function_property_map<
-        lookup_property_from_edge< boost::mpl::false_ >,
+        lookup_property_from_edge< std::false_type >,
         typename graph_traits<
             adjacency_matrix< D, VP, EP, GP, A > >::edge_descriptor >
         type;
     typedef function_property_map<
-        lookup_property_from_edge< boost::mpl::true_ >,
+        lookup_property_from_edge< std::true_type >,
         typename graph_traits<
             adjacency_matrix< D, VP, EP, GP, A > >::edge_descriptor >
         const_type;
     typedef edge_descriptor arg_type;
     typedef
-        typename lookup_property_from_edge< boost::mpl::false_ >::result_type
+        typename lookup_property_from_edge< std::false_type >::result_type
             single_nonconst_type;
-    typedef typename lookup_property_from_edge< boost::mpl::true_ >::result_type
+    typedef typename lookup_property_from_edge< std::true_type >::result_type
         single_const_type;
 
     static type get_nonconst(adjacency_matrix< D, VP, EP, GP, A >& g, Tag tag)

--- a/include/boost/graph/betweenness_centrality.hpp
+++ b/include/boost/graph/betweenness_centrality.hpp
@@ -19,7 +19,7 @@
 #include <boost/tuple/tuple.hpp>
 #include <boost/type_traits/is_convertible.hpp>
 #include <boost/type_traits/is_same.hpp>
-#include <boost/mpl/if.hpp>
+#include <type_traits>
 #include <boost/property_map/property_map.hpp>
 #include <boost/graph/named_function_params.hpp>
 #include <algorithm>
@@ -451,7 +451,7 @@ namespace detail
                 degree_size_type;
             typedef
                 typename graph_traits< Graph >::edge_descriptor edge_descriptor;
-            typedef typename mpl::if_c<
+            typedef typename std::conditional<
                 (is_same< CentralityMap, dummy_property_map >::value),
                 EdgeCentralityMap, CentralityMap >::type a_centrality_map;
             typedef typename property_traits< a_centrality_map >::value_type
@@ -483,7 +483,7 @@ namespace detail
                 degree_size_type;
             typedef
                 typename graph_traits< Graph >::edge_descriptor edge_descriptor;
-            typedef typename mpl::if_c<
+            typedef typename std::conditional<
                 (is_same< CentralityMap, dummy_property_map >::value),
                 EdgeCentralityMap, CentralityMap >::type a_centrality_map;
             typedef typename property_traits< a_centrality_map >::value_type

--- a/include/boost/graph/compressed_sparse_row_graph.hpp
+++ b/include/boost/graph/compressed_sparse_row_graph.hpp
@@ -36,7 +36,6 @@
 #include <boost/property_map/property_map.hpp>
 #include <boost/integer.hpp>
 #include <boost/iterator/iterator_facade.hpp>
-#include <boost/mpl/if.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/graph/graph_selectors.hpp>
 #include <boost/graph/detail/is_distributed_selector.hpp>
@@ -45,7 +44,6 @@
 #include <boost/functional/hash.hpp>
 #include <boost/next_prior.hpp>
 #include <boost/property_map/transform_value_property_map.hpp>
-#include <boost/mpl/print.hpp>
 
 namespace boost
 {

--- a/include/boost/graph/detail/adjacency_list.hpp
+++ b/include/boost/graph/detail/adjacency_list.hpp
@@ -27,9 +27,7 @@
 
 #include <boost/iterator/iterator_adaptor.hpp>
 
-#include <boost/mpl/if.hpp>
-#include <boost/mpl/not.hpp>
-#include <boost/mpl/and.hpp>
+#include <type_traits>
 #include <boost/graph/graph_concepts.hpp>
 #include <boost/pending/container_traits.hpp>
 #include <boost/graph/detail/adj_list_edge_iterator.hpp>
@@ -2343,8 +2341,8 @@ namespace detail
             typedef typename container_gen< VertexListS, vertex_ptr >::type
                 SeqVertexList;
             typedef boost::integer_range< vertex_descriptor > RandVertexList;
-            typedef typename mpl::if_< is_rand_access, RandVertexList,
-                SeqVertexList >::type VertexList;
+            typedef typename std::conditional< is_rand_access::value,
+                RandVertexList, SeqVertexList >::type VertexList;
 
             typedef typename VertexList::iterator vertex_iterator;
 
@@ -2354,21 +2352,22 @@ namespace detail
                 list_edge< vertex_descriptor, EdgeProperty > >::type
                 EdgeContainer;
 
-            typedef typename mpl::and_< DirectedT,
-                typename mpl::not_< BidirectionalT >::type >::type
+            typedef std::integral_constant< bool,
+                DirectedT::value && !BidirectionalT::value >
                 on_edge_storage;
 
-            typedef typename mpl::if_< on_edge_storage, std::size_t,
-                typename EdgeContainer::size_type >::type edges_size_type;
+            typedef typename std::conditional< on_edge_storage::value,
+                std::size_t, typename EdgeContainer::size_type >::type
+                edges_size_type;
 
             typedef typename EdgeContainer::iterator EdgeIter;
 
             typedef
                 typename detail::is_random_access< EdgeListS >::type is_edge_ra;
 
-            typedef typename mpl::if_< on_edge_storage,
+            typedef typename std::conditional< on_edge_storage::value,
                 stored_edge_property< vertex_descriptor, EdgeProperty >,
-                typename mpl::if_< is_edge_ra,
+                typename std::conditional< is_edge_ra::value,
                     stored_ra_edge_iter< vertex_descriptor, EdgeContainer,
                         EdgeProperty >,
                     stored_edge_iter< vertex_descriptor, EdgeIter,
@@ -2421,8 +2420,8 @@ namespace detail
                 graph_type >
                 DirectedEdgeIter;
 
-            typedef typename mpl::if_< on_edge_storage, DirectedEdgeIter,
-                UndirectedEdgeIter >::type edge_iterator;
+            typedef typename std::conditional< on_edge_storage::value,
+                DirectedEdgeIter, UndirectedEdgeIter >::type edge_iterator;
 
             // stored_vertex and StoredVertexList
             typedef typename container_gen< VertexListS, vertex_ptr >::type
@@ -2464,11 +2463,12 @@ namespace detail
                 InEdgeList m_in_edges;
                 VertexProperty m_property;
             };
-            typedef typename mpl::if_< is_rand_access,
-                typename mpl::if_< BidirectionalT, bidir_rand_stored_vertex,
-                    rand_stored_vertex >::type,
-                typename mpl::if_< BidirectionalT, bidir_seq_stored_vertex,
-                    seq_stored_vertex >::type >::type StoredVertex;
+            typedef typename std::conditional< is_rand_access::value,
+                typename std::conditional< BidirectionalT::value,
+                    bidir_rand_stored_vertex, rand_stored_vertex >::type,
+                typename std::conditional< BidirectionalT::value,
+                    bidir_seq_stored_vertex, seq_stored_vertex >::type >::type
+                StoredVertex;
             struct stored_vertex : public StoredVertex
             {
                 stored_vertex() {}
@@ -2477,17 +2477,19 @@ namespace detail
 
             typedef typename container_gen< VertexListS, stored_vertex >::type
                 RandStoredVertexList;
-            typedef typename mpl::if_< is_rand_access, RandStoredVertexList,
-                SeqStoredVertexList >::type StoredVertexList;
+            typedef typename std::conditional< is_rand_access::value,
+                RandStoredVertexList, SeqStoredVertexList >::type
+                StoredVertexList;
         }; // end of config
 
-        typedef typename mpl::if_< BidirectionalT,
+        typedef typename std::conditional< BidirectionalT::value,
             bidirectional_graph_helper_with_property< config >,
-            typename mpl::if_< DirectedT, directed_graph_helper< config >,
+            typename std::conditional< DirectedT::value,
+                directed_graph_helper< config >,
                 undirected_graph_helper< config > >::type >::type
             DirectedHelper;
 
-        typedef typename mpl::if_< is_rand_access,
+        typedef typename std::conditional< is_rand_access::value,
             vec_adj_list_impl< Graph, config, DirectedHelper >,
             adj_list_impl< Graph, config, DirectedHelper > >::type type;
     };
@@ -2687,7 +2689,7 @@ namespace detail
 {
     template < class Tag, class Graph, class Property >
     struct adj_list_choose_vertex_pa
-    : boost::mpl::if_< boost::is_same< Tag, vertex_all_t >,
+    : std::conditional< boost::is_same< Tag, vertex_all_t >::value,
           adj_list_all_vertex_pa, adj_list_any_vertex_pa >::type ::
           template bind_< Tag, Graph, Property >
     {

--- a/include/boost/graph/detail/compressed_sparse_row_struct.hpp
+++ b/include/boost/graph/detail/compressed_sparse_row_struct.hpp
@@ -40,7 +40,6 @@
 #include <boost/property_map/property_map.hpp>
 #include <boost/integer.hpp>
 #include <boost/iterator/iterator_facade.hpp>
-#include <boost/mpl/if.hpp>
 #include <boost/graph/graph_selectors.hpp>
 #include <boost/static_assert.hpp>
 #include <boost/functional/hash.hpp>

--- a/include/boost/graph/detail/index.hpp
+++ b/include/boost/graph/detail/index.hpp
@@ -9,6 +9,7 @@
 
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/properties.hpp>
+#include <type_traits>
 
 // The structures in this module are responsible for selecting and defining
 // types for accessing a builting index map. Note that the selection of these
@@ -67,8 +68,8 @@ namespace detail
     // VertexEdgeGraph - whichever type Key is selecting.
     template < typename Graph, typename Key > struct choose_indexer
     {
-        typedef typename mpl::if_<
-            is_same< Key, typename graph_traits< Graph >::vertex_descriptor >,
+        typedef typename std::conditional<
+            is_same< Key, typename graph_traits< Graph >::vertex_descriptor >::value,
             vertex_indexer< Graph >, edge_indexer< Graph > >::type indexer_type;
         typedef typename indexer_type::index_type index_type;
     };

--- a/include/boost/graph/detail/indexed_properties.hpp
+++ b/include/boost/graph/detail/indexed_properties.hpp
@@ -24,7 +24,6 @@
 #include <boost/integer.hpp>
 #include <boost/iterator/iterator_facade.hpp>
 #include <boost/property_map/property_map.hpp>
-#include <boost/mpl/if.hpp>
 
 namespace boost
 {

--- a/include/boost/graph/detail/is_distributed_selector.hpp
+++ b/include/boost/graph/detail/is_distributed_selector.hpp
@@ -15,13 +15,13 @@
 #ifndef BOOST_GRAPH_DETAIL_IS_DISTRIBUTED_SELECTOR_HPP
 #define BOOST_GRAPH_DETAIL_IS_DISTRIBUTED_SELECTOR_HPP
 
-#include <boost/mpl/bool.hpp>
+#include <type_traits>
 
 namespace boost
 {
 namespace detail
 {
-    template < typename > struct is_distributed_selector : boost::mpl::false_
+    template < typename > struct is_distributed_selector : std::false_type
     {
     };
 }

--- a/include/boost/graph/directed_graph.hpp
+++ b/include/boost/graph/directed_graph.hpp
@@ -12,7 +12,6 @@
 #include <boost/pending/property.hpp>
 #include <boost/property_map/transform_value_property_map.hpp>
 #include <boost/type_traits.hpp>
-#include <boost/mpl/if.hpp>
 
 namespace boost
 {

--- a/include/boost/graph/edge_list.hpp
+++ b/include/boost/graph/edge_list.hpp
@@ -13,8 +13,7 @@
 
 #include <iterator>
 #include <boost/config.hpp>
-#include <boost/mpl/if.hpp>
-#include <boost/mpl/bool.hpp>
+#include <type_traits>
 #include <boost/range/irange.hpp>
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/properties.hpp>
@@ -264,7 +263,7 @@ template < class Cat > struct is_random
     {
         RET = false
     };
-    typedef mpl::false_ type;
+    typedef std::false_type type;
 };
 template <> struct is_random< std::random_access_iterator_tag >
 {
@@ -272,7 +271,7 @@ template <> struct is_random< std::random_access_iterator_tag >
     {
         RET = true
     };
-    typedef mpl::true_ type;
+    typedef std::true_type type;
 };
 
 // The edge_list class conditionally inherits from one of the
@@ -287,7 +286,7 @@ template < class EdgeIter,
     class T, class D, class Cat >
 #endif
 class edge_list
-: public mpl::if_< typename is_random< Cat >::type,
+: public std::conditional< is_random< Cat >::type::value,
       edge_list_impl_ra< edge_list< EdgeIter, T, D, Cat >, EdgeIter, T, D >,
       edge_list_impl< edge_list< EdgeIter, T, D, Cat >, EdgeIter, T, D > >::type
 {

--- a/include/boost/graph/graph_concepts.hpp
+++ b/include/boost/graph/graph_concepts.hpp
@@ -21,7 +21,6 @@
 #include <boost/graph/buffer_concepts.hpp>
 #include <boost/concept_check.hpp>
 #include <boost/type_traits/is_same.hpp>
-#include <boost/mpl/not.hpp>
 #include <boost/static_assert.hpp>
 #include <boost/detail/workaround.hpp>
 #include <boost/concept/assert.hpp>
@@ -79,10 +78,8 @@ BOOST_concept(IncidenceGraph, (G)) : Graph< G >
     typedef typename graph_traits< G >::degree_size_type degree_size_type;
     typedef typename graph_traits< G >::traversal_category traversal_category;
 
-    BOOST_STATIC_ASSERT(
-        (boost::mpl::not_< boost::is_same< out_edge_iterator, void > >::value));
-    BOOST_STATIC_ASSERT(
-        (boost::mpl::not_< boost::is_same< degree_size_type, void > >::value));
+    BOOST_STATIC_ASSERT((!boost::is_same< out_edge_iterator, void >::value));
+    BOOST_STATIC_ASSERT((!boost::is_same< degree_size_type, void >::value));
 
     BOOST_CONCEPT_USAGE(IncidenceGraph)
     {
@@ -126,8 +123,7 @@ BOOST_concept(BidirectionalGraph, (G)) : IncidenceGraph< G >
         BOOST_CONCEPT_ASSERT(
             (Convertible< traversal_category, bidirectional_graph_tag >));
 
-        BOOST_STATIC_ASSERT((boost::mpl::not_<
-            boost::is_same< in_edge_iterator, void > >::value));
+        BOOST_STATIC_ASSERT((!boost::is_same< in_edge_iterator, void >::value));
 
         p = in_edges(v, g);
         n = in_degree(v, g);
@@ -160,8 +156,8 @@ BOOST_concept(AdjacencyGraph, (G)) : Graph< G >
         BOOST_CONCEPT_ASSERT(
             (Convertible< traversal_category, adjacency_graph_tag >));
 
-        BOOST_STATIC_ASSERT((boost::mpl::not_<
-            boost::is_same< adjacency_iterator, void > >::value));
+        BOOST_STATIC_ASSERT(
+            (!boost::is_same< adjacency_iterator, void >::value));
 
         p = adjacent_vertices(v, g);
         v = *p.first;
@@ -185,10 +181,9 @@ BOOST_concept(VertexListGraph, (G)) : Graph< G >
         BOOST_CONCEPT_ASSERT(
             (Convertible< traversal_category, vertex_list_graph_tag >));
 
-        BOOST_STATIC_ASSERT((boost::mpl::not_<
-            boost::is_same< vertex_iterator, void > >::value));
-        BOOST_STATIC_ASSERT((boost::mpl::not_<
-            boost::is_same< vertices_size_type, void > >::value));
+        BOOST_STATIC_ASSERT((!boost::is_same< vertex_iterator, void >::value));
+        BOOST_STATIC_ASSERT(
+            (!boost::is_same< vertices_size_type, void >::value));
 
 #ifdef BOOST_VECTOR_AS_GRAPH_GRAPH_ADL_HACK
         // dwa 2003/7/11 -- This clearly shouldn't be necessary, but if
@@ -239,10 +234,8 @@ BOOST_concept(EdgeListGraph, (G)) : Graph< G >
         BOOST_CONCEPT_ASSERT(
             (Convertible< traversal_category, edge_list_graph_tag >));
 
-        BOOST_STATIC_ASSERT(
-            (boost::mpl::not_< boost::is_same< edge_iterator, void > >::value));
-        BOOST_STATIC_ASSERT((boost::mpl::not_<
-            boost::is_same< edges_size_type, void > >::value));
+        BOOST_STATIC_ASSERT((!boost::is_same< edge_iterator, void >::value));
+        BOOST_STATIC_ASSERT((!boost::is_same< edges_size_type, void >::value));
 
         p = edges(g);
         e = *p.first;

--- a/include/boost/graph/graphml.hpp
+++ b/include/boost/graph/graphml.hpp
@@ -20,10 +20,6 @@
 #include <boost/graph/dll_import_export.hpp>
 #include <boost/graph/exception.hpp>
 #include <boost/graph/graph_traits.hpp>
-
-#include <boost/mpl/vector.hpp>
-#include <boost/mpl/find.hpp>
-#include <boost/mpl/for_each.hpp>
 #include <boost/property_map/dynamic_property_map.hpp>
 #include <boost/property_tree/detail/xml_parser_utils.hpp>
 #include <boost/throw_exception.hpp>

--- a/include/boost/graph/graphml.hpp
+++ b/include/boost/graph/graphml.hpp
@@ -21,7 +21,6 @@
 #include <boost/graph/exception.hpp>
 #include <boost/graph/graph_traits.hpp>
 
-#include <boost/mpl/bool.hpp>
 #include <boost/mpl/vector.hpp>
 #include <boost/mpl/find.hpp>
 #include <boost/mpl/for_each.hpp>

--- a/include/boost/graph/labeled_graph.hpp
+++ b/include/boost/graph/labeled_graph.hpp
@@ -10,10 +10,9 @@
 #include <boost/config.hpp>
 #include <vector>
 #include <map>
+#include <type_traits>
 
 #include <boost/static_assert.hpp>
-#include <boost/mpl/if.hpp>
-#include <boost/mpl/bool.hpp>
 #include <boost/unordered_map.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/type_traits/is_unsigned.hpp>
@@ -38,7 +37,8 @@ namespace graph_detail
 {
     /** Returns true if the selector is the default selector. */
     template < typename Selector >
-    struct is_default : mpl::bool_< is_same< Selector, defaultS >::value >
+    struct is_default
+    : std::integral_constant< bool, is_same< Selector, defaultS >::value >
     {
     };
 
@@ -48,7 +48,8 @@ namespace graph_detail
      */
     template < typename Label, typename Vertex > struct choose_default_map
     {
-        typedef typename mpl::if_< is_unsigned< Label >, std::vector< Vertex >,
+        typedef typename std::conditional< is_unsigned< Label >::value,
+            std::vector< Vertex >,
             std::map< Label, Vertex > // TODO: Should use unordered_map?
             >::type type;
     };
@@ -111,9 +112,9 @@ namespace graph_detail
     template < typename Selector, typename Label, typename Vertex >
     struct choose_map
     {
-        typedef typename mpl::eval_if< is_default< Selector >,
+        typedef typename std::conditional< is_default< Selector >::value,
             choose_default_map< Label, Vertex >,
-            choose_custom_map< Selector, Label, Vertex > >::type type;
+            choose_custom_map< Selector, Label, Vertex > >::type::type type;
     };
 
     /** @name Insert Labeled Vertex */

--- a/include/boost/graph/planar_detail/face_iterators.hpp
+++ b/include/boost/graph/planar_detail/face_iterators.hpp
@@ -10,7 +10,6 @@
 #define __FACE_ITERATORS_HPP__
 
 #include <boost/iterator/iterator_facade.hpp>
-#include <boost/mpl/bool.hpp>
 #include <boost/graph/graph_traits.hpp>
 
 namespace boost

--- a/include/boost/graph/plod_generator.hpp
+++ b/include/boost/graph/plod_generator.hpp
@@ -17,7 +17,7 @@
 #include <vector>
 #include <map>
 #include <boost/config/no_tr1/cmath.hpp>
-#include <boost/mpl/if.hpp>
+#include <type_traits>
 
 namespace boost
 {
@@ -248,15 +248,15 @@ private:
 
 template < typename RandomGenerator, typename Graph >
 class plod_iterator
-: public mpl::if_<
+: public std::conditional<
       is_convertible< typename graph_traits< Graph >::directed_category,
-          directed_tag >,
+          directed_tag >::value,
       out_directed_plod_iterator< RandomGenerator >,
       undirected_plod_iterator< RandomGenerator > >::type
 {
-    typedef typename mpl::if_<
+    typedef typename std::conditional<
         is_convertible< typename graph_traits< Graph >::directed_category,
-            directed_tag >,
+            directed_tag >::value,
         out_directed_plod_iterator< RandomGenerator >,
         undirected_plod_iterator< RandomGenerator > >::type inherited;
 

--- a/include/boost/graph/properties.hpp
+++ b/include/boost/graph/properties.hpp
@@ -23,9 +23,7 @@
 #include <boost/graph/graph_traits.hpp>
 #include <boost/type_traits.hpp>
 #include <boost/limits.hpp>
-#include <boost/mpl/and.hpp>
-#include <boost/mpl/not.hpp>
-#include <boost/mpl/if.hpp>
+#include <type_traits>
 
 namespace boost
 {
@@ -150,15 +148,15 @@ namespace detail
     template < typename G, typename R, typename T >
     struct property_kind_from_graph< G, R T::* >
     {
-        typedef typename boost::mpl::if_<
-            boost::is_base_of< T, typename vertex_bundle_type< G >::type >,
+        typedef typename std::conditional<
+            boost::is_base_of< T, typename vertex_bundle_type< G >::type >::value,
             vertex_property_tag,
-            typename boost::mpl::if_<
-                boost::is_base_of< T, typename edge_bundle_type< G >::type >,
+            typename std::conditional<
+                boost::is_base_of< T, typename edge_bundle_type< G >::type >::value,
                 edge_property_tag,
-                typename boost::mpl::if_<
+                typename std::conditional<
                     boost::is_base_of< T,
-                        typename graph_bundle_type< G >::type >,
+                        typename graph_bundle_type< G >::type >::value,
                     graph_property_tag, void >::type >::type >::type type;
     };
 #endif
@@ -232,9 +230,9 @@ namespace detail
 
 template < class Graph, class Property, class Enable = void >
 struct property_map
-: mpl::if_< is_same< typename detail::property_kind_from_graph< Graph,
-                         Property >::type,
-                edge_property_tag >,
+: std::conditional< is_same< typename detail::property_kind_from_graph< Graph,
+                        Property >::type,
+                        edge_property_tag >::value,
       detail::edge_property_map< Graph, Property >,
       detail::vertex_property_map< Graph, Property > >::type
 {

--- a/include/boost/graph/property_iter_range.hpp
+++ b/include/boost/graph/property_iter_range.hpp
@@ -20,7 +20,7 @@
 
 #include <boost/property_map/property_map_iterator.hpp>
 #include <boost/graph/properties.hpp>
-#include <boost/mpl/if.hpp>
+#include <type_traits>
 #include <boost/type_traits/same_traits.hpp>
 
 namespace boost
@@ -35,7 +35,7 @@ template < class Graph, class PropertyTag > class graph_property_iter_range
     typedef
         typename property_map< Graph, PropertyTag >::const_type const_map_type;
     typedef typename property_kind< PropertyTag >::type Kind;
-    typedef typename mpl::if_c< is_same< Kind, vertex_property_tag >::value,
+    typedef typename std::conditional< is_same< Kind, vertex_property_tag >::value,
         typename graph_traits< Graph >::vertex_iterator,
         typename graph_traits< Graph >::edge_iterator >::type iter;
 

--- a/include/boost/graph/random.hpp
+++ b/include/boost/graph/random.hpp
@@ -22,7 +22,7 @@
 
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/copy.hpp>
-#include <boost/mpl/if.hpp>
+#include <type_traits>
 #include <boost/type_traits/is_convertible.hpp>
 
 #include <iostream>
@@ -152,7 +152,7 @@ void generate_random_graph1(MutableGraph& g,
 
         typedef
             typename boost::graph_traits< MutableGraph >::directed_category dir;
-        typedef typename mpl::if_< is_convertible< dir, directed_tag >,
+        typedef typename std::conditional< is_convertible< dir, directed_tag >::value,
             directedS, undirectedS >::type select;
         adjacency_list< setS, vecS, select > g2;
         generate_random_graph1(g2, V, E, gen, true, self_edges);

--- a/include/boost/graph/random_layout.hpp
+++ b/include/boost/graph/random_layout.hpp
@@ -14,7 +14,6 @@
 #include <boost/random/uniform_01.hpp>
 #include <boost/random/uniform_real.hpp>
 #include <boost/type_traits/is_integral.hpp>
-#include <boost/mpl/if.hpp>
 #include <boost/graph/iteration_macros.hpp>
 
 namespace boost

--- a/include/boost/graph/subgraph.hpp
+++ b/include/boost/graph/subgraph.hpp
@@ -25,8 +25,7 @@
 #include <boost/static_assert.hpp>
 #include <boost/assert.hpp>
 #include <boost/type_traits.hpp>
-#include <boost/mpl/if.hpp>
-#include <boost/mpl/or.hpp>
+#include <type_traits>
 
 namespace boost
 {
@@ -893,8 +892,8 @@ class subgraph_global_property_map
     typedef property_traits< PropertyMap > Traits;
 
 public:
-    typedef typename mpl::if_<
-        is_const< typename remove_pointer< GraphPtr >::type >,
+    typedef typename std::conditional<
+        is_const< typename remove_pointer< GraphPtr >::type >::value,
         readable_property_map_tag, typename Traits::category >::type category;
     typedef typename Traits::value_type value_type;
     typedef typename Traits::key_type key_type;
@@ -926,8 +925,8 @@ class subgraph_local_property_map
     typedef property_traits< PropertyMap > Traits;
 
 public:
-    typedef typename mpl::if_<
-        is_const< typename remove_pointer< GraphPtr >::type >,
+    typedef typename std::conditional<
+        is_const< typename remove_pointer< GraphPtr >::type >::value,
         readable_property_map_tag, typename Traits::category >::type category;
     typedef typename Traits::value_type value_type;
     typedef typename Traits::key_type key_type;

--- a/include/boost/graph/undirected_graph.hpp
+++ b/include/boost/graph/undirected_graph.hpp
@@ -12,7 +12,6 @@
 #include <boost/pending/property.hpp>
 #include <boost/property_map/transform_value_property_map.hpp>
 #include <boost/type_traits.hpp>
-#include <boost/mpl/if.hpp>
 
 namespace boost
 {

--- a/include/boost/graph/vf2_sub_graph_iso.hpp
+++ b/include/boost/graph/vf2_sub_graph_iso.hpp
@@ -32,7 +32,7 @@
 #include <boost/graph/mcgregor_common_subgraphs.hpp> // for always_equivalent
 #include <boost/graph/named_function_params.hpp>
 #include <boost/type_traits/has_less.hpp>
-#include <boost/mpl/int.hpp>
+#include <type_traits>
 #include <boost/range/algorithm/sort.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/utility/enable_if.hpp>
@@ -450,21 +450,21 @@ namespace detail
         // test terminal set counts when testing for:
         // - graph sub-graph monomorphism, or
         inline bool comp_term_sets(graph1_size_type a, graph2_size_type b,
-            boost::mpl::int_< subgraph_mono >) const
+            std::integral_constant< int, subgraph_mono >) const
         {
             return a <= b;
         }
 
         // - graph sub-graph isomorphism, or
         inline bool comp_term_sets(graph1_size_type a, graph2_size_type b,
-            boost::mpl::int_< subgraph_iso >) const
+            std::integral_constant< int, subgraph_iso >) const
         {
             return a <= b;
         }
 
         // - graph isomorphism
         inline bool comp_term_sets(graph1_size_type a, graph2_size_type b,
-            boost::mpl::int_< isomorphism >) const
+            std::integral_constant< int, isomorphism >) const
         {
             return a == b;
         }
@@ -652,22 +652,22 @@ namespace detail
             if (problem_selection != subgraph_mono)
             { // subgraph_iso and isomorphism
                 return comp_term_sets(term_in1_count, term_in2_count,
-                           boost::mpl::int_< problem_selection >())
+                           std::integral_constant< int, problem_selection >())
                     && comp_term_sets(term_out1_count, term_out2_count,
-                        boost::mpl::int_< problem_selection >())
+                        std::integral_constant< int, problem_selection >())
                     && comp_term_sets(rest1_count, rest2_count,
-                        boost::mpl::int_< problem_selection >());
+                        std::integral_constant< int, problem_selection >());
             }
             else
             { // subgraph_mono
                 return comp_term_sets(term_in1_count, term_in2_count,
-                           boost::mpl::int_< problem_selection >())
+                           std::integral_constant< int, problem_selection >())
                     && comp_term_sets(term_out1_count, term_out2_count,
-                        boost::mpl::int_< problem_selection >())
+                        std::integral_constant< int, problem_selection >())
                     && comp_term_sets(
                         term_in1_count + term_out1_count + rest1_count,
                         term_in2_count + term_out2_count + rest2_count,
-                        boost::mpl::int_< problem_selection >());
+                        std::integral_constant< int, problem_selection >());
             }
         }
 
@@ -718,13 +718,13 @@ namespace detail
 
             return comp_term_sets(boost::get< 0 >(term1),
                        boost::get< 0 >(term2),
-                       boost::mpl::int_< problem_selection >())
+                       std::integral_constant< int, problem_selection >())
                 && comp_term_sets(boost::get< 1 >(term1),
                     boost::get< 1 >(term2),
-                    boost::mpl::int_< problem_selection >())
+                    std::integral_constant< int, problem_selection >())
                 && comp_term_sets(boost::get< 2 >(term1),
                     boost::get< 2 >(term2),
-                    boost::mpl::int_< problem_selection >());
+                    std::integral_constant< int, problem_selection >());
         }
 
         // Calls the user_callback with a graph (sub)graph mapping

--- a/include/boost/graph/visitors.hpp
+++ b/include/boost/graph/visitors.hpp
@@ -16,7 +16,7 @@
 #include <iosfwd>
 #include <boost/config.hpp>
 #include <boost/type_traits/is_same.hpp>
-#include <boost/mpl/bool.hpp>
+#include <type_traits>
 #include <boost/property_map/property_map.hpp>
 #include <boost/graph/graph_traits.hpp>
 #include <boost/limits.hpp>
@@ -220,13 +220,13 @@ struct null_visitor : public base_visitor< null_visitor >
 namespace detail
 {
     template < class Visitor, class T, class Graph >
-    inline void invoke_dispatch(Visitor& v, T x, Graph& g, mpl::true_)
+    inline void invoke_dispatch(Visitor& v, T x, Graph& g, std::true_type)
     {
         v(x, g);
     }
 
     template < class Visitor, class T, class Graph >
-    inline void invoke_dispatch(Visitor&, T, Graph&, mpl::false_)
+    inline void invoke_dispatch(Visitor&, T, Graph&, std::false_type)
     {
     }
 } // namespace detail
@@ -236,7 +236,7 @@ inline void invoke_visitors(
     std::pair< Visitor, Rest >& vlist, T x, Graph& g, Tag tag)
 {
     typedef typename Visitor::event_filter Category;
-    typedef typename is_same< Category, Tag >::type IsSameTag;
+    typedef typename std::is_same< Category, Tag >::type IsSameTag;
     detail::invoke_dispatch(vlist.first, x, g, IsSameTag());
     invoke_visitors(vlist.second, x, g, tag);
 }
@@ -244,7 +244,7 @@ template < class Visitor, class T, class Graph, class Tag >
 inline void invoke_visitors(Visitor& v, T x, Graph& g, Tag)
 {
     typedef typename Visitor::event_filter Category;
-    typedef typename is_same< Category, Tag >::type IsSameTag;
+    typedef typename std::is_same< Category, Tag >::type IsSameTag;
     detail::invoke_dispatch(v, x, g, IsSameTag());
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

Reducing dependencies deadweights.

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [ ] Bug fix
- [ ] New feature or API addition
- [x] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

<!-- A short summary of the change. -->

Migrates Boost.Graph's internal metaprogramming from Boost.MPL to the standard `<type_traits>`.

- Removed dead `boost/mpl` includes (included but unused)
    - `or.hpp` in `subgraph`, `void.hpp` in `graph_traits`, `print.hpp` + `if.hpp` in CSR
    - `if.hpp` in `directed_graph` / `undirected_graph` / `random_layout` / `detail/indexed_properties` /`detail/compressed_sparse_row_struct` / `graph_mutability_traits`
    - `bool.hpp` in `graphml` / `planar_detail/face_iterators`
    - `and.hpp` + `not.hpp` in `properties`

- Converted internal metafunctions off MPL (resolved type identical)
    - `mpl::if_<C,A,B>::type` to `std::conditional<C::value,A,B>::type` : `adjacency_matrix`, `subgraph`, `properties`, `plod_generator`, `random`, `edge_list`, `labeled_graph`, `adjacency_list`, `detail/adjacency_list`
    - `mpl::if_c<…>` to `std::conditional<…>` : `betweenness_centrality`, `property_iter_range`
    - `mpl::and_<A, mpl::not_<B>>::type` to `std::integral_constant<bool, A::value && !B::value>` : `adjacency_list`, `detail/adjacency_list`
    - `mpl::not_<is_same<X,void>>::value` to `!is_same<X,void>::value` : `graph_concepts`
    - `mpl::eval_if<C,F1,F2>::type` to `std::conditional<C::value,F1,F2>::type::type` (lazy branch instantiation preserved) : `labeled_graph`
    - `mpl::bool_<B>` to `std::integral_constant<bool,B>` : `labeled_graph` (`is_default`)
    - `mpl::int_<N>` to `std::integral_constant<int,N>` : internal tag dispatch in `vf2_sub_graph_iso`
    - internal `true_`/`false_` dispatch tags to `std::true_type`/`std::false_type` : `visitors`, `edge_list` (`is_random`), `adjacency_matrix`, `detail/is_distributed_selector`
    - `boost/mpl/*.hpp` to `<type_traits>`

### Motivation

<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->

MPL is an old dependency with long build times. It has been superseded by modern C++ standards and MP11.
This refactor switches to std and where possible.

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->

### Checklist

- [x] Existing tests pass (`b2` in the `test/` directory).
- [x] New behavior is covered by a test, or this is a docs / build / refactor change.
- [x] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.
