### PR TITLE
fix: remove dependency to MPL in graph_traits using detector idiom

### DIFF
--- a/include/boost/graph/graph_traits.hpp
+++ b/include/boost/graph/graph_traits.hpp
@@ -14,15 +14,12 @@
 #include <iterator>
 #include <utility> /* Primarily for std::pair */
 #include <boost/tuple/tuple.hpp>
-#include <boost/mpl/if.hpp>
-#include <boost/mpl/eval_if.hpp>
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/not.hpp>
-#include <boost/mpl/has_xxx.hpp>
-#include <boost/mpl/void.hpp>
-#include <boost/mpl/identity.hpp>
 #include <boost/mpl/and.hpp>
 #include <boost/type_traits/is_same.hpp>
+#include <boost/type_traits/make_void.hpp>
+#include <type_traits>
 #include <boost/iterator/iterator_categories.hpp>
 #include <boost/iterator/iterator_adaptor.hpp>
 #include <boost/pending/property.hpp>
@@ -33,16 +30,18 @@ namespace boost
 
 namespace detail
 {
-#define BOOST_GRAPH_MEMBER_OR_VOID(name)                                                                                            \
-    BOOST_MPL_HAS_XXX_TRAIT_DEF(name)                                                                                               \
-    template < typename T > struct BOOST_JOIN(get_member_, name)                                                                    \
-    {                                                                                                                               \
-        typedef typename T::name type;                                                                                              \
-    };                                                                                                                              \
-    template < typename T >                                                                                                         \
-    struct BOOST_JOIN(get_opt_member_, name)                                                                                        \
-    : boost::mpl::eval_if_c< BOOST_JOIN(has_, name) < T >::value, BOOST_JOIN(get_member_, name)< T >, boost::mpl::identity< void > >\
-    {                                                                                                                               \
+// get_opt_member_##name<T>::type is T::name when that member type exists, void otherwise.
+#define BOOST_GRAPH_MEMBER_OR_VOID(name)                                       \
+    template < typename T, typename = void >                                   \
+    struct BOOST_JOIN(get_opt_member_, name)                                   \
+    {                                                                          \
+        using type = void;                                                     \
+    };                                                                         \
+    template < typename T >                                                    \
+    struct BOOST_JOIN(get_opt_member_, name)< T,                               \
+        boost::void_t< typename T::name > >                                    \
+    {                                                                          \
+        using type = typename T::name;                                         \
     };
     BOOST_GRAPH_MEMBER_OR_VOID(adjacency_iterator)
     BOOST_GRAPH_MEMBER_OR_VOID(out_edge_iterator)
@@ -282,40 +281,47 @@ typedef boost::forward_traversal_tag multi_pass_input_iterator_tag;
 
 namespace detail
 {
-    BOOST_MPL_HAS_XXX_TRAIT_DEF(graph_property_type)
-    BOOST_MPL_HAS_XXX_TRAIT_DEF(edge_property_type)
-    BOOST_MPL_HAS_XXX_TRAIT_DEF(vertex_property_type)
-
-    template < typename G > struct get_graph_property_type
+    // When the member type is present these expose it as ::type
+    //  when absent they inherit no_property and expose no nested ::type.
+    template < typename G, typename = void >
+    struct get_graph_property_type : no_property
     {
-        typedef typename G::graph_property_type type;
     };
-    template < typename G > struct get_edge_property_type
+    template < typename G >
+    struct get_graph_property_type< G, boost::void_t< typename G::graph_property_type > >
     {
-        typedef typename G::edge_property_type type;
+        using type = typename G::graph_property_type;
     };
-    template < typename G > struct get_vertex_property_type
+    template < typename G, typename = void >
+    struct get_edge_property_type : no_property
     {
-        typedef typename G::vertex_property_type type;
+    };
+    template < typename G >
+    struct get_edge_property_type< G, boost::void_t< typename G::edge_property_type > >
+    {
+        using type = typename G::edge_property_type;
+    };
+    template < typename G, typename = void >
+    struct get_vertex_property_type : no_property
+    {
+    };
+    template < typename G >
+    struct get_vertex_property_type< G, boost::void_t< typename G::vertex_property_type > >
+    {
+        using type = typename G::vertex_property_type;
     };
 }
 
 template < typename G >
-struct graph_property_type
-: boost::mpl::eval_if< detail::has_graph_property_type< G >,
-      detail::get_graph_property_type< G >, no_property >
+struct graph_property_type : detail::get_graph_property_type< G >
 {
 };
 template < typename G >
-struct edge_property_type
-: boost::mpl::eval_if< detail::has_edge_property_type< G >,
-      detail::get_edge_property_type< G >, no_property >
+struct edge_property_type : detail::get_edge_property_type< G >
 {
 };
 template < typename G >
-struct vertex_property_type
-: boost::mpl::eval_if< detail::has_vertex_property_type< G >,
-      detail::get_vertex_property_type< G >, no_property >
+struct vertex_property_type : detail::get_vertex_property_type< G >
 {
 };
 
@@ -341,7 +347,8 @@ namespace graph
         template < typename Graph, typename Descriptor > class bundled_result
         {
             typedef typename graph_traits< Graph >::vertex_descriptor Vertex;
-            typedef typename mpl::if_c< (is_same< Descriptor, Vertex >::value),
+            typedef typename std::conditional<
+                (is_same< Descriptor, Vertex >::value),
                 vertex_bundle_type< Graph >, edge_bundle_type< Graph > >::type
                 bundler;
 


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

Reducing dependencies to MPL is important for compile time, dependency graph and general hygiene, as similar behavior is available with modern C++.

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [ ] Bug fix
- [ ] New feature or API addition
- [x] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

<!-- A short summary of the change. -->

`graph_traits` reports a graph's associated types (vertex type, edge type...). Not every graph defines all of them, so `graph_traits` needs to check if a member type exists on the graph, use it if it does, and fall back to `void` if it doesn't.

That check was built with Boost.MPL. It used `BOOST_MPL_HAS_XXX_TRAIT_DEF` macro to generate a "has member X" trait, then `mpl::eval_if` and `mpl::identity` to pick either the member or the fallback. This pulled in five `boost/mpl` headers just to answer "does this type have member X".

This PR refactors it using standard C++ `void_t` [detector idiom](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4502.pdf). Two small template overloads do the check directly: one matches when the member type exists and exposes it, the other is the fallback. Same result, no MPL, no new dependency, behavior is unchanged.

### Motivation

<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->

Reducing dependencies to MPL is important for compile time, dependency graph and general hygiene, as similar behavior is available with modern C++.

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->

### Checklist

- [x] Existing tests pass (`b2` in the `test/` directory).
- [x] New behavior is covered by a test, or this is a docs / build / refactor change.
- [x] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.
