### PR TITLE
fix: handroll mpl facilities in graphml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ target_link_libraries(boost_graph
     Boost::integer
     Boost::iterator
     Boost::lexical_cast
+    Boost::mp11
     Boost::mpl
     Boost::multi_index
     Boost::multiprecision

--- a/build.jam
+++ b/build.jam
@@ -20,6 +20,7 @@ constant boost_dependencies :
     /boost/integer//boost_integer
     /boost/iterator//boost_iterator
     /boost/lexical_cast//boost_lexical_cast
+    /boost/mp11//boost_mp11
     /boost/mpl//boost_mpl
     /boost/multi_index//boost_multi_index
     /boost/multiprecision//boost_multiprecision

--- a/include/boost/graph/graphml.hpp
+++ b/include/boost/graph/graphml.hpp
@@ -15,6 +15,8 @@
 #include <boost/config.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/any.hpp>
+#include <boost/mp11/algorithm.hpp>
+#include <boost/mp11/list.hpp>
 #include <boost/type_traits/is_convertible.hpp>
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/dll_import_export.hpp>
@@ -30,49 +32,6 @@
 
 namespace boost
 {
-
-namespace graphml_detail
-{
-    // The fixed list of value types GraphML understands
-    template < typename... Ts > struct value_type_list {};
-
-    template < typename List > struct for_each_value_type_impl;
-
-    template < typename... Ts >
-    struct for_each_value_type_impl< value_type_list< Ts... > >
-    {
-        // f can accumulate state (type_found)
-        template < typename F > static void apply(F& f)
-        {
-            // an array of 0 but with the side effect of calling the functor on each type
-            const int expand[] = { 0, (f(Ts()), 0)... };
-            (void)expand;
-        }
-    };
-
-    // Calls f once for each type in List, in order
-    template < typename List, typename F > 
-    void for_each_value_type(F f)
-    {
-        for_each_value_type_impl< List >::apply(f);
-    }
-
-    // ::value is the position of T in List.
-    template < typename List, typename T > 
-    struct index_of_value_type;
-    
-    template < typename T, typename... Rest >
-    struct index_of_value_type< value_type_list< T, Rest... >, T >
-    {
-        static const int value = 0;
-    };
-    
-    template < typename T, typename Head, typename... Rest >
-    struct index_of_value_type< value_type_list< Head, Rest... >, T >
-    {
-        static const int value = 1 + index_of_value_type< value_type_list< Rest... >, T >::value;
-    };
-} // namespace graphml_detail
 
 /////////////////////////////////////////////////////////////////////////////
 // Graph reader exceptions
@@ -150,7 +109,7 @@ public:
         bool type_found = false;
         try
         {
-            graphml_detail::for_each_value_type< value_types >(
+            mp11::mp_for_each< value_types >(
                 put_property< MutableGraph*, value_types >(name, m_dp, &m_g,
                     value, value_type, m_type_names, type_found));
         }
@@ -172,7 +131,7 @@ public:
         bool type_found = false;
         try
         {
-            graphml_detail::for_each_value_type< value_types >(
+            mp11::mp_for_each< value_types >(
                 put_property< vertex_descriptor, value_types >(name, m_dp,
                     any_cast< vertex_descriptor >(vertex), value, value_type,
                     m_type_names, type_found));
@@ -195,7 +154,7 @@ public:
         bool type_found = false;
         try
         {
-            graphml_detail::for_each_value_type< value_types >(
+            mp11::mp_for_each< value_types >(
                 put_property< edge_descriptor, value_types >(name, m_dp,
                     any_cast< edge_descriptor >(edge), value, value_type,
                     m_type_names, type_found));
@@ -231,8 +190,7 @@ public:
         template < class Value > void operator()(Value)
         {
             if (m_value_type
-                == m_type_names[graphml_detail::index_of_value_type<
-                    ValueVector, Value >::value])
+                == m_type_names[mp11::mp_find< ValueVector, Value >::value])
             {
                 put(m_name, m_dp, m_key, lexical_cast< Value >(m_value));
                 m_type_found = true;
@@ -252,7 +210,7 @@ public:
 protected:
     MutableGraph& m_g;
     dynamic_properties& m_dp;
-    using value_types = graphml_detail::value_type_list< bool, int, long, float, double, std::string >;
+    using value_types = mp11::mp_list< bool, int, long, float, double, std::string >;
     static const char* m_type_names[];
 };
 
@@ -282,8 +240,7 @@ public:
     template < typename Type > void operator()(Type)
     {
         if (typeid(Type) == m_type)
-            m_type_name = m_type_names[graphml_detail::index_of_value_type<
-                Types, Type >::value];
+            m_type_name = m_type_names[mp11::mp_find< Types, Type >::value];
     }
 
 private:
@@ -313,7 +270,7 @@ void write_graphml(std::ostream& out, const Graph& g,
            "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "
            "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">\n";
 
-    using value_types = graphml_detail::value_type_list< bool, short,
+    using value_types = mp11::mp_list< bool, short,
         unsigned short, int, unsigned int, long, unsigned long, long long,
         unsigned long long, float, double, long double, std::string >;
     const char* type_names[] = { "boolean", "int", "int", "int", "int", "long",
@@ -336,7 +293,7 @@ void write_graphml(std::ostream& out, const Graph& g,
         else
             continue;
         std::string type_name = "string";
-        graphml_detail::for_each_value_type< value_types >(
+        mp11::mp_for_each< value_types >(
             get_type_name< value_types >(
                 i->second->value(), type_names, type_name));
         out << "  <key id=\"" << encode_char_entities(key_id) << "\" for=\""

--- a/include/boost/graph/graphml.hpp
+++ b/include/boost/graph/graphml.hpp
@@ -21,10 +21,6 @@
 #include <boost/graph/exception.hpp>
 #include <boost/graph/graph_traits.hpp>
 
-#include <boost/mpl/bool.hpp>
-#include <boost/mpl/vector.hpp>
-#include <boost/mpl/find.hpp>
-#include <boost/mpl/for_each.hpp>
 #include <boost/property_map/dynamic_property_map.hpp>
 #include <boost/property_tree/detail/xml_parser_utils.hpp>
 #include <boost/throw_exception.hpp>
@@ -34,6 +30,49 @@
 
 namespace boost
 {
+
+namespace graphml_detail
+{
+    // The fixed list of value types GraphML understands
+    template < typename... Ts > struct value_type_list {};
+
+    template < typename List > struct for_each_value_type_impl;
+
+    template < typename... Ts >
+    struct for_each_value_type_impl< value_type_list< Ts... > >
+    {
+        // f can accumulate state (type_found)
+        template < typename F > static void apply(F& f)
+        {
+            // an array of 0 but with the side effect of calling the functor on each type
+            const int expand[] = { 0, (f(Ts()), 0)... };
+            (void)expand;
+        }
+    };
+
+    // Calls f once for each type in List, in order
+    template < typename List, typename F > 
+    void for_each_value_type(F f)
+    {
+        for_each_value_type_impl< List >::apply(f);
+    }
+
+    // ::value is the position of T in List.
+    template < typename List, typename T > 
+    struct index_of_value_type;
+    
+    template < typename T, typename... Rest >
+    struct index_of_value_type< value_type_list< T, Rest... >, T >
+    {
+        static const int value = 0;
+    };
+    
+    template < typename T, typename Head, typename... Rest >
+    struct index_of_value_type< value_type_list< Head, Rest... >, T >
+    {
+        static const int value = 1 + index_of_value_type< value_type_list< Rest... >, T >::value;
+    };
+} // namespace graphml_detail
 
 /////////////////////////////////////////////////////////////////////////////
 // Graph reader exceptions
@@ -111,7 +150,7 @@ public:
         bool type_found = false;
         try
         {
-            mpl::for_each< value_types >(
+            graphml_detail::for_each_value_type< value_types >(
                 put_property< MutableGraph*, value_types >(name, m_dp, &m_g,
                     value, value_type, m_type_names, type_found));
         }
@@ -133,7 +172,7 @@ public:
         bool type_found = false;
         try
         {
-            mpl::for_each< value_types >(
+            graphml_detail::for_each_value_type< value_types >(
                 put_property< vertex_descriptor, value_types >(name, m_dp,
                     any_cast< vertex_descriptor >(vertex), value, value_type,
                     m_type_names, type_found));
@@ -156,7 +195,7 @@ public:
         bool type_found = false;
         try
         {
-            mpl::for_each< value_types >(
+            graphml_detail::for_each_value_type< value_types >(
                 put_property< edge_descriptor, value_types >(name, m_dp,
                     any_cast< edge_descriptor >(edge), value, value_type,
                     m_type_names, type_found));
@@ -192,8 +231,8 @@ public:
         template < class Value > void operator()(Value)
         {
             if (m_value_type
-                == m_type_names[mpl::find< ValueVector,
-                    Value >::type::pos::value])
+                == m_type_names[graphml_detail::index_of_value_type<
+                    ValueVector, Value >::value])
             {
                 put(m_name, m_dp, m_key, lexical_cast< Value >(m_value));
                 m_type_found = true;
@@ -213,8 +252,7 @@ public:
 protected:
     MutableGraph& m_g;
     dynamic_properties& m_dp;
-    typedef mpl::vector< bool, int, long, float, double, std::string >
-        value_types;
+    using value_types = graphml_detail::value_type_list< bool, int, long, float, double, std::string >;
     static const char* m_type_names[];
 };
 
@@ -244,8 +282,8 @@ public:
     template < typename Type > void operator()(Type)
     {
         if (typeid(Type) == m_type)
-            m_type_name
-                = m_type_names[mpl::find< Types, Type >::type::pos::value];
+            m_type_name = m_type_names[graphml_detail::index_of_value_type<
+                Types, Type >::value];
     }
 
 private:
@@ -275,10 +313,9 @@ void write_graphml(std::ostream& out, const Graph& g,
            "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "
            "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">\n";
 
-    typedef mpl::vector< bool, short, unsigned short, int, unsigned int, long,
-        unsigned long, long long, unsigned long long, float, double,
-        long double, std::string >
-        value_types;
+    using value_types = graphml_detail::value_type_list< bool, short,
+        unsigned short, int, unsigned int, long, unsigned long, long long,
+        unsigned long long, float, double, long double, std::string >;
     const char* type_names[] = { "boolean", "int", "int", "int", "int", "long",
         "long", "long", "long", "float", "double", "double", "string" };
     std::map< std::string, std::string > graph_key_ids;
@@ -299,8 +336,9 @@ void write_graphml(std::ostream& out, const Graph& g,
         else
             continue;
         std::string type_name = "string";
-        mpl::for_each< value_types >(get_type_name< value_types >(
-            i->second->value(), type_names, type_name));
+        graphml_detail::for_each_value_type< value_types >(
+            get_type_name< value_types >(
+                i->second->value(), type_names, type_name));
         out << "  <key id=\"" << encode_char_entities(key_id) << "\" for=\""
             << (i->second->key() == typeid(Graph*)
                        ? "graph"


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

Continue removing MPL from the codebase to limit build times and dependencies.
But this time there is no direct C++ equivalent to the MPL features, so there is a small utility `graphml_detail` namespace.

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [ ] Bug fix
- [ ] New feature or API addition
- [x] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

The GraphML reader and writer kept a compile-time list of the value types they support (`bool`, `int`, `double`, `string`, and so on) and used three Boost.MPL tools on it: 
- `mpl::vector` (the list of types), 
- `mpl::for_each` (visit each type once, to try each candidate when parsing),
-  `mpl::find` (get a type's position to look up its name). 

We added a new dependency (MP11) to use the modern equivalent.

No behavior change.

### Motivation

Part of the ongoing effort to shrink Boost.Graph's dependency footprint. Boost.MPL is an old, heavy, slow-to-compile library that modern C++ (`<type_traits>` plus small hand-written helpers) can replace directly. This removes the last direct MPL use from BGL that would not be breaking public API.

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->

### Checklist

- [x] Existing tests pass (`b2` in the `test/` directory).
- [x] New behavior is covered by a test, or this is a docs / build / refactor change.
- [x] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.