### PR TITLE
Migrate public traits from MPL to STL (breaking change)

### DIFF
--- a/include/boost/graph/adjacency_list.hpp
+++ b/include/boost/graph/adjacency_list.hpp
@@ -28,9 +28,9 @@
 #include <boost/mpl/if.hpp>
 #include <boost/mpl/and.hpp>
 #include <boost/mpl/not.hpp>
-#include <boost/mpl/bool.hpp>
 #include <boost/graph/detail/edge.hpp>
 #include <boost/type_traits/is_same.hpp>
+#include <type_traits>
 #include <boost/detail/workaround.hpp>
 #include <boost/graph/properties.hpp>
 #include <boost/graph/named_graph.hpp>
@@ -187,7 +187,7 @@ namespace detail
         {
             value = false
         };
-        typedef mpl::false_ type;
+        typedef std::false_type type;
     };
     template <> struct is_random_access< vecS >
     {
@@ -195,12 +195,12 @@ namespace detail
         {
             value = true
         };
-        typedef mpl::true_ type;
+        typedef std::true_type type;
     };
 
 } // namespace detail
 
-template < typename Selector > struct is_distributed_selector : mpl::false_
+template < typename Selector > struct is_distributed_selector : std::false_type
 {
 };
 

--- a/include/boost/graph/detail/labeled_graph_traits.hpp
+++ b/include/boost/graph/detail/labeled_graph_traits.hpp
@@ -9,6 +9,8 @@
 
 #include <boost/graph/graph_mutability_traits.hpp>
 
+#include <type_traits>
+
 namespace boost
 {
 
@@ -84,7 +86,7 @@ struct labeled_add_only_property_graph_tag
 
 template < typename Graph >
 struct graph_has_add_vertex_by_label
-: mpl::bool_<
+: std::integral_constant< bool,
       is_convertible< typename graph_mutability_traits< Graph >::category,
           labeled_add_vertex_tag >::value >
 {
@@ -92,7 +94,7 @@ struct graph_has_add_vertex_by_label
 
 template < typename Graph >
 struct graph_has_add_vertex_by_label_with_property
-: mpl::bool_<
+: std::integral_constant< bool,
       is_convertible< typename graph_mutability_traits< Graph >::category,
           labeled_add_vertex_property_tag >::value >
 {
@@ -100,7 +102,7 @@ struct graph_has_add_vertex_by_label_with_property
 
 template < typename Graph >
 struct graph_has_remove_vertex_by_label
-: mpl::bool_<
+: std::integral_constant< bool,
       is_convertible< typename graph_mutability_traits< Graph >::category,
           labeled_remove_vertex_tag >::value >
 {
@@ -108,7 +110,7 @@ struct graph_has_remove_vertex_by_label
 
 template < typename Graph >
 struct graph_has_add_edge_by_label
-: mpl::bool_<
+: std::integral_constant< bool,
       is_convertible< typename graph_mutability_traits< Graph >::category,
           labeled_add_edge_tag >::value >
 {
@@ -116,7 +118,7 @@ struct graph_has_add_edge_by_label
 
 template < typename Graph >
 struct graph_has_add_edge_by_label_with_property
-: mpl::bool_<
+: std::integral_constant< bool,
       is_convertible< typename graph_mutability_traits< Graph >::category,
           labeled_add_edge_property_tag >::value >
 {
@@ -124,7 +126,7 @@ struct graph_has_add_edge_by_label_with_property
 
 template < typename Graph >
 struct graph_has_remove_edge_by_label
-: mpl::bool_<
+: std::integral_constant< bool,
       is_convertible< typename graph_mutability_traits< Graph >::category,
           labeled_remove_edge_tag >::value >
 {
@@ -132,49 +134,55 @@ struct graph_has_remove_edge_by_label
 
 template < typename Graph >
 struct is_labeled_mutable_vertex_graph
-: mpl::and_< graph_has_add_vertex_by_label< Graph >,
-      graph_has_remove_vertex_by_label< Graph > >
+: std::integral_constant< bool,
+      graph_has_add_vertex_by_label< Graph >::value
+          && graph_has_remove_vertex_by_label< Graph >::value >
 {
 };
 
 template < typename Graph >
 struct is_labeled_mutable_vertex_property_graph
-: mpl::and_< graph_has_add_vertex_by_label< Graph >,
-      graph_has_remove_vertex_by_label< Graph > >
+: std::integral_constant< bool,
+      graph_has_add_vertex_by_label< Graph >::value
+          && graph_has_remove_vertex_by_label< Graph >::value >
 {
 };
 
 template < typename Graph >
 struct is_labeled_mutable_edge_graph
-: mpl::and_< graph_has_add_edge_by_label< Graph >,
-      graph_has_remove_edge_by_label< Graph > >
+: std::integral_constant< bool,
+      graph_has_add_edge_by_label< Graph >::value
+          && graph_has_remove_edge_by_label< Graph >::value >
 {
 };
 
 template < typename Graph >
 struct is_labeled_mutable_edge_property_graph
-: mpl::and_< graph_has_add_edge_by_label< Graph >,
-      graph_has_remove_edge_by_label< Graph > >
+: std::integral_constant< bool,
+      graph_has_add_edge_by_label< Graph >::value
+          && graph_has_remove_edge_by_label< Graph >::value >
 {
 };
 
 template < typename Graph >
 struct is_labeled_mutable_graph
-: mpl::and_< is_labeled_mutable_vertex_graph< Graph >,
-      is_labeled_mutable_edge_graph< Graph > >
+: std::integral_constant< bool,
+      is_labeled_mutable_vertex_graph< Graph >::value
+          && is_labeled_mutable_edge_graph< Graph >::value >
 {
 };
 
 template < typename Graph >
 struct is_labeled_mutable_property_graph
-: mpl::and_< is_labeled_mutable_vertex_property_graph< Graph >,
-      is_labeled_mutable_edge_property_graph< Graph > >
+: std::integral_constant< bool,
+      is_labeled_mutable_vertex_property_graph< Graph >::value
+          && is_labeled_mutable_edge_property_graph< Graph >::value >
 {
 };
 
 template < typename Graph >
 struct is_labeled_add_only_property_graph
-: mpl::bool_<
+: std::integral_constant< bool,
       is_convertible< typename graph_mutability_traits< Graph >::category,
           labeled_add_only_property_graph_tag >::value >
 {
@@ -182,7 +190,7 @@ struct is_labeled_add_only_property_graph
 
 template < typename Graph >
 struct is_labeled_graph
-: mpl::bool_<
+: std::integral_constant< bool,
       is_convertible< typename graph_mutability_traits< Graph >::category,
           label_vertex_tag >::value >
 {
@@ -197,13 +205,15 @@ namespace graph_detail
     // graph_mutability_traits specialization below.
     template < typename Graph > struct determine_mutability
     {
-        typedef typename mpl::if_< is_add_only_property_graph< Graph >,
+        typedef typename std::conditional<
+            is_add_only_property_graph< Graph >::value,
             labeled_add_only_property_graph_tag,
-            typename mpl::if_< is_mutable_property_graph< Graph >,
+            typename std::conditional< is_mutable_property_graph< Graph >::value,
                 labeled_mutable_property_graph_tag,
-                typename mpl::if_< is_mutable_graph< Graph >,
+                typename std::conditional< is_mutable_graph< Graph >::value,
                     labeled_mutable_graph_tag,
-                    typename mpl::if_< is_mutable_edge_graph< Graph >,
+                    typename std::conditional<
+                        is_mutable_edge_graph< Graph >::value,
                         labeled_graph_tag,
                         typename graph_mutability_traits< Graph >::category >::
                         type >::type >::type >::type type;

--- a/include/boost/graph/graph_mutability_traits.hpp
+++ b/include/boost/graph/graph_mutability_traits.hpp
@@ -8,9 +8,7 @@
 #define BOOST_GRAPH_MUTABILITY_TRAITS_HPP
 
 #include <boost/config.hpp>
-#include <boost/mpl/if.hpp>
-#include <boost/mpl/and.hpp>
-#include <boost/mpl/bool.hpp>
+#include <type_traits>
 #include <boost/type_traits/is_convertible.hpp>
 #include <boost/type_traits/is_same.hpp>
 
@@ -90,7 +88,7 @@ template < typename Graph > struct graph_mutability_traits
 
 template < typename Graph >
 struct graph_has_add_vertex
-: mpl::bool_<
+: std::integral_constant< bool,
       is_convertible< typename graph_mutability_traits< Graph >::category,
           add_vertex_tag >::value >
 {
@@ -98,7 +96,7 @@ struct graph_has_add_vertex
 
 template < typename Graph >
 struct graph_has_add_vertex_with_property
-: mpl::bool_<
+: std::integral_constant< bool,
       is_convertible< typename graph_mutability_traits< Graph >::category,
           add_vertex_property_tag >::value >
 {
@@ -106,7 +104,7 @@ struct graph_has_add_vertex_with_property
 
 template < typename Graph >
 struct graph_has_remove_vertex
-: mpl::bool_<
+: std::integral_constant< bool,
       is_convertible< typename graph_mutability_traits< Graph >::category,
           remove_vertex_tag >::value >
 {
@@ -114,7 +112,7 @@ struct graph_has_remove_vertex
 
 template < typename Graph >
 struct graph_has_add_edge
-: mpl::bool_<
+: std::integral_constant< bool,
       is_convertible< typename graph_mutability_traits< Graph >::category,
           add_edge_tag >::value >
 {
@@ -122,7 +120,7 @@ struct graph_has_add_edge
 
 template < typename Graph >
 struct graph_has_add_edge_with_property
-: mpl::bool_<
+: std::integral_constant< bool,
       is_convertible< typename graph_mutability_traits< Graph >::category,
           add_edge_property_tag >::value >
 {
@@ -130,7 +128,7 @@ struct graph_has_add_edge_with_property
 
 template < typename Graph >
 struct graph_has_remove_edge
-: mpl::bool_<
+: std::integral_constant< bool,
       is_convertible< typename graph_mutability_traits< Graph >::category,
           remove_edge_tag >::value >
 {
@@ -138,46 +136,55 @@ struct graph_has_remove_edge
 
 template < typename Graph >
 struct is_mutable_vertex_graph
-: mpl::and_< graph_has_add_vertex< Graph >, graph_has_remove_vertex< Graph > >
+: std::integral_constant< bool,
+      graph_has_add_vertex< Graph >::value
+          && graph_has_remove_vertex< Graph >::value >
 {
 };
 
 template < typename Graph >
 struct is_mutable_vertex_property_graph
-: mpl::and_< graph_has_add_vertex_with_property< Graph >,
-      graph_has_remove_vertex< Graph > >
+: std::integral_constant< bool,
+      graph_has_add_vertex_with_property< Graph >::value
+          && graph_has_remove_vertex< Graph >::value >
 {
 };
 
 template < typename Graph >
 struct is_mutable_edge_graph
-: mpl::and_< graph_has_add_edge< Graph >, graph_has_remove_edge< Graph > >
+: std::integral_constant< bool,
+      graph_has_add_edge< Graph >::value
+          && graph_has_remove_edge< Graph >::value >
 {
 };
 
 template < typename Graph >
 struct is_mutable_edge_property_graph
-: mpl::and_< graph_has_add_edge_with_property< Graph >,
-      graph_has_remove_edge< Graph > >
+: std::integral_constant< bool,
+      graph_has_add_edge_with_property< Graph >::value
+          && graph_has_remove_edge< Graph >::value >
 {
 };
 
 template < typename Graph >
 struct is_mutable_graph
-: mpl::and_< is_mutable_vertex_graph< Graph >, is_mutable_edge_graph< Graph > >
+: std::integral_constant< bool,
+      is_mutable_vertex_graph< Graph >::value
+          && is_mutable_edge_graph< Graph >::value >
 {
 };
 
 template < typename Graph >
 struct is_mutable_property_graph
-: mpl::and_< is_mutable_vertex_property_graph< Graph >,
-      is_mutable_edge_property_graph< Graph > >
+: std::integral_constant< bool,
+      is_mutable_vertex_property_graph< Graph >::value
+          && is_mutable_edge_property_graph< Graph >::value >
 {
 };
 
 template < typename Graph >
 struct is_add_only_property_graph
-: mpl::bool_<
+: std::integral_constant< bool,
       is_convertible< typename graph_mutability_traits< Graph >::category,
           add_only_property_graph_tag >::value >
 {

--- a/include/boost/graph/graph_selectors.hpp
+++ b/include/boost/graph/graph_selectors.hpp
@@ -10,7 +10,7 @@
 #ifndef BOOST_GRAPH_SELECTORS_HPP
 #define BOOST_GRAPH_SELECTORS_HPP
 
-#include <boost/mpl/bool.hpp>
+#include <type_traits>
 
 namespace boost
 {
@@ -26,8 +26,8 @@ struct directedS
         is_directed = true,
         is_bidir = false
     };
-    typedef mpl::true_ is_directed_t;
-    typedef mpl::false_ is_bidir_t;
+    using is_directed_t = std::true_type;
+    using is_bidir_t = std::false_type;
 };
 struct undirectedS
 {
@@ -36,8 +36,8 @@ struct undirectedS
         is_directed = false,
         is_bidir = false
     };
-    typedef mpl::false_ is_directed_t;
-    typedef mpl::false_ is_bidir_t;
+    using is_directed_t = std::false_type;
+    using is_bidir_t = std::false_type;
 };
 struct bidirectionalS
 {
@@ -46,8 +46,8 @@ struct bidirectionalS
         is_directed = true,
         is_bidir = true
     };
-    typedef mpl::true_ is_directed_t;
-    typedef mpl::true_ is_bidir_t;
+    using is_directed_t = std::true_type;
+    using is_bidir_t = std::true_type;
 };
 
 } // namespace boost

--- a/include/boost/graph/graph_traits.hpp
+++ b/include/boost/graph/graph_traits.hpp
@@ -14,9 +14,6 @@
 #include <iterator>
 #include <utility> /* Primarily for std::pair */
 #include <boost/tuple/tuple.hpp>
-#include <boost/mpl/bool.hpp>
-#include <boost/mpl/not.hpp>
-#include <boost/mpl/and.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/type_traits/make_void.hpp>
 #include <type_traits>
@@ -121,7 +118,7 @@ namespace graph_detail
 {
     template < typename Tag >
     struct is_directed_tag
-    : mpl::bool_< is_convertible< Tag, directed_tag >::value >
+    : std::integral_constant< bool, is_convertible< Tag, directed_tag >::value >
     {
     };
 } // namespace graph_detail
@@ -134,7 +131,8 @@ struct is_directed_graph
 };
 
 template < typename Graph >
-struct is_undirected_graph : mpl::not_< is_directed_graph< Graph > >
+struct is_undirected_graph
+: std::integral_constant< bool, !is_directed_graph< Graph >::value >
 {
 };
 //@}
@@ -169,8 +167,9 @@ template < typename Graph > bool allows_parallel_edges(const Graph&)
  */
 template < typename Graph >
 struct is_multigraph
-: mpl::bool_< is_same< typename graph_traits< Graph >::edge_parallel_category,
-      allow_parallel_edge_tag >::value >
+: std::integral_constant< bool,
+      is_same< typename graph_traits< Graph >::edge_parallel_category,
+          allow_parallel_edge_tag >::value >
 {
 };
 //@}
@@ -217,7 +216,7 @@ struct distributed_edge_list_graph_tag
 //@{
 template < typename Graph >
 struct is_incidence_graph
-: mpl::bool_<
+: std::integral_constant< bool,
       is_convertible< typename graph_traits< Graph >::traversal_category,
           incidence_graph_tag >::value >
 {
@@ -225,7 +224,7 @@ struct is_incidence_graph
 
 template < typename Graph >
 struct is_bidirectional_graph
-: mpl::bool_<
+: std::integral_constant< bool,
       is_convertible< typename graph_traits< Graph >::traversal_category,
           bidirectional_graph_tag >::value >
 {
@@ -233,7 +232,7 @@ struct is_bidirectional_graph
 
 template < typename Graph >
 struct is_vertex_list_graph
-: mpl::bool_<
+: std::integral_constant< bool,
       is_convertible< typename graph_traits< Graph >::traversal_category,
           vertex_list_graph_tag >::value >
 {
@@ -241,7 +240,7 @@ struct is_vertex_list_graph
 
 template < typename Graph >
 struct is_edge_list_graph
-: mpl::bool_<
+: std::integral_constant< bool,
       is_convertible< typename graph_traits< Graph >::traversal_category,
           edge_list_graph_tag >::value >
 {
@@ -249,7 +248,7 @@ struct is_edge_list_graph
 
 template < typename Graph >
 struct is_adjacency_matrix
-: mpl::bool_<
+: std::integral_constant< bool,
       is_convertible< typename graph_traits< Graph >::traversal_category,
           adjacency_matrix_tag >::value >
 {
@@ -264,14 +263,17 @@ struct is_adjacency_matrix
 //@{
 template < typename Graph >
 struct is_directed_unidirectional_graph
-: mpl::and_< is_directed_graph< Graph >,
-      mpl::not_< is_bidirectional_graph< Graph > > >
+: std::integral_constant< bool,
+      is_directed_graph< Graph >::value
+          && !is_bidirectional_graph< Graph >::value >
 {
 };
 
 template < typename Graph >
 struct is_directed_bidirectional_graph
-: mpl::and_< is_directed_graph< Graph >, is_bidirectional_graph< Graph > >
+: std::integral_constant< bool,
+      is_directed_graph< Graph >::value
+          && is_bidirectional_graph< Graph >::value >
 {
 };
 //@}
@@ -374,7 +376,8 @@ namespace graph_detail
     // A helper metafunction for determining whether or not a type is
     // bundled.
     template < typename T >
-    struct is_no_bundle : mpl::bool_< is_same< T, no_property >::value >
+    struct is_no_bundle
+    : std::integral_constant< bool, is_same< T, no_property >::value >
     {
     };
 } // namespace graph_detail
@@ -387,43 +390,49 @@ namespace graph_detail
 //@{
 template < typename Graph >
 struct has_graph_property
-: mpl::not_< typename detail::is_no_property<
-      typename graph_property_type< Graph >::type >::type >::type
+: std::integral_constant< bool,
+      !detail::is_no_property<
+          typename graph_property_type< Graph >::type >::value >
 {
 };
 
 template < typename Graph >
 struct has_bundled_graph_property
-: mpl::not_<
-      graph_detail::is_no_bundle< typename graph_bundle_type< Graph >::type > >
+: std::integral_constant< bool,
+      !graph_detail::is_no_bundle<
+          typename graph_bundle_type< Graph >::type >::value >
 {
 };
 
 template < typename Graph >
 struct has_vertex_property
-: mpl::not_< typename detail::is_no_property<
-      typename vertex_property_type< Graph >::type > >::type
+: std::integral_constant< bool,
+      !detail::is_no_property<
+          typename vertex_property_type< Graph >::type >::value >
 {
 };
 
 template < typename Graph >
 struct has_bundled_vertex_property
-: mpl::not_<
-      graph_detail::is_no_bundle< typename vertex_bundle_type< Graph >::type > >
+: std::integral_constant< bool,
+      !graph_detail::is_no_bundle<
+          typename vertex_bundle_type< Graph >::type >::value >
 {
 };
 
 template < typename Graph >
 struct has_edge_property
-: mpl::not_< typename detail::is_no_property<
-      typename edge_property_type< Graph >::type > >::type
+: std::integral_constant< bool,
+      !detail::is_no_property<
+          typename edge_property_type< Graph >::type >::value >
 {
 };
 
 template < typename Graph >
 struct has_bundled_edge_property
-: mpl::not_<
-      graph_detail::is_no_bundle< typename edge_bundle_type< Graph >::type > >
+: std::integral_constant< bool,
+      !graph_detail::is_no_bundle<
+          typename edge_bundle_type< Graph >::type >::value >
 {
 };
 //@}

--- a/include/boost/graph/reverse_graph.hpp
+++ b/include/boost/graph/reverse_graph.hpp
@@ -11,7 +11,7 @@
 #include <boost/iterator/transform_iterator.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/type_traits.hpp>
-#include <boost/mpl/if.hpp>
+#include <type_traits>
 
 namespace boost
 {
@@ -477,15 +477,15 @@ struct property_map< reverse_graph< BidirGraph, GRef >, Property >
         is_edge_prop;
     typedef boost::is_const< typename boost::remove_reference< GRef >::type >
         is_ref_const;
-    typedef typename boost::mpl::if_< is_ref_const,
+    typedef typename std::conditional< is_ref_const::value,
         typename property_map< BidirGraph, Property >::const_type,
         typename property_map< BidirGraph, Property >::type >::type orig_type;
     typedef typename property_map< BidirGraph, Property >::const_type
         orig_const_type;
-    typedef typename boost::mpl::if_< is_edge_prop,
+    typedef typename std::conditional< is_edge_prop::value,
         detail::reverse_graph_edge_property_map< orig_type >, orig_type >::type
         type;
-    typedef typename boost::mpl::if_< is_edge_prop,
+    typedef typename std::conditional< is_edge_prop::value,
         detail::reverse_graph_edge_property_map< orig_const_type >,
         orig_const_type >::type const_type;
 };
@@ -499,7 +499,7 @@ struct property_map< const reverse_graph< BidirGraph, GRef >, Property >
         is_edge_prop;
     typedef typename property_map< BidirGraph, Property >::const_type
         orig_const_type;
-    typedef typename boost::mpl::if_< is_edge_prop,
+    typedef typename std::conditional< is_edge_prop::value,
         detail::reverse_graph_edge_property_map< orig_const_type >,
         orig_const_type >::type const_type;
     typedef const_type type;
@@ -585,11 +585,11 @@ public:
     typedef detail::underlying_edge_desc_map_type< ed > const_type;
 };
 
-template < typename T > struct is_reverse_graph : boost::mpl::false_
+template < typename T > struct is_reverse_graph : std::false_type
 {
 };
 template < typename G, typename R >
-struct is_reverse_graph< reverse_graph< G, R > > : boost::mpl::true_
+struct is_reverse_graph< reverse_graph< G, R > > : std::true_type
 {
 };
 
@@ -641,8 +641,8 @@ inline void set_property(const reverse_graph< BidirectionalGraph, GRef >& g,
 }
 
 template < typename BidirectionalGraph, typename GRef, typename Tag >
-inline typename boost::mpl::if_<
-    boost::is_const< typename boost::remove_reference< GRef >::type >,
+inline typename std::conditional<
+    boost::is_const< typename boost::remove_reference< GRef >::type >::value,
     const typename graph_property< BidirectionalGraph, Tag >::type&,
     typename graph_property< BidirectionalGraph, Tag >::type& >::type
 get_property(const reverse_graph< BidirectionalGraph, GRef >& g, Tag tag)

--- a/include/boost/pending/property.hpp
+++ b/include/boost/pending/property.hpp
@@ -7,9 +7,8 @@
 #define BOOST_PROPERTY_HPP
 
 #include <boost/config.hpp>
-#include <boost/mpl/bool.hpp>
-#include <boost/mpl/if.hpp>
 #include <boost/mpl/has_xxx.hpp>
+#include <type_traits>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits.hpp>
 #include <boost/static_assert.hpp>
@@ -256,10 +255,10 @@ template < typename T, typename Tag > struct lookup_one_property< const T, Tag >
 // instead with a nested kind type and num.  Also, we may want to
 // switch BGL back to using class types for properties at some point.
 
-template < class P > struct has_property : boost::mpl::true_
+template < class P > struct has_property : std::true_type
 {
 };
-template <> struct has_property< no_property > : boost::mpl::false_
+template <> struct has_property< no_property > : std::false_type
 {
 };
 
@@ -294,7 +293,8 @@ namespace detail
 
     /** This trait returns true if T is no_property. */
     template < typename T >
-    struct is_no_property : mpl::bool_< is_same< T, no_property >::value >
+    struct is_no_property
+    : std::integral_constant< bool, is_same< T, no_property >::value >
     {
     };
 
@@ -358,7 +358,7 @@ namespace detail
             typedef typename boost::function_traits< F >::arg1_type a1;
             typedef typename boost::remove_reference< a1 >::type non_ref;
             typedef typename non_ref::next_type nx;
-            typedef typename boost::mpl::if_< boost::is_const< non_ref >,
+            typedef typename std::conditional< boost::is_const< non_ref >::value,
                 boost::add_const< nx >, nx >::type with_const;
             typedef typename boost::add_reference< with_const >::type type;
         };

--- a/test/test_construction.hpp
+++ b/test/test_construction.hpp
@@ -7,6 +7,7 @@
 #ifndef TEST_CONSTRUCTION_HPP
 #define TEST_CONSTRUCTION_HPP
 
+#include <type_traits>
 #include <boost/concept/assert.hpp>
 #include <utility>
 
@@ -25,7 +26,7 @@ void build_graph(Graph& g, Add, Label)
 
 // This matches MutableGraph, so just add some vertices.
 template < typename Graph >
-void build_graph(Graph& g, boost::mpl::true_, boost::mpl::false_)
+void build_graph(Graph& g, std::true_type, std::false_type)
 {
     using namespace boost;
     BOOST_CONCEPT_ASSERT((VertexListGraphConcept< Graph >));
@@ -41,7 +42,7 @@ void build_graph(Graph& g, boost::mpl::true_, boost::mpl::false_)
 
 // This will match labeled graphs.
 template < typename Graph >
-void build_graph(Graph& g, boost::mpl::false_, boost::mpl::true_)
+void build_graph(Graph& g, std::false_type, std::true_type)
 {
     using namespace boost;
     BOOST_CONCEPT_ASSERT((VertexListGraphConcept< Graph >));
@@ -69,7 +70,7 @@ void build_property_graph(Graph const& g, Add, Label)
 }
 
 template < typename Graph >
-void build_property_graph(Graph const&, boost::mpl::true_, boost::mpl::false_)
+void build_property_graph(Graph const&, std::true_type, std::false_type)
 {
     using namespace boost;
     BOOST_CONCEPT_ASSERT((VertexMutablePropertyGraphConcept< Graph >));
@@ -93,7 +94,7 @@ void build_property_graph(Graph const&, boost::mpl::true_, boost::mpl::false_)
  */
 //@{
 template < typename Graph, typename VertexSet >
-void connect_graph(Graph& g, VertexSet const& verts, boost::mpl::false_)
+void connect_graph(Graph& g, VertexSet const& verts, std::false_type)
 {
     using namespace boost;
     BOOST_CONCEPT_ASSERT((AdjacencyMatrixConcept< Graph >));
@@ -113,7 +114,7 @@ void connect_graph(Graph& g, VertexSet const& verts, boost::mpl::false_)
 }
 
 template < typename Graph, typename VertexSet >
-void connect_graph(Graph& g, VertexSet const& verts, boost::mpl::true_)
+void connect_graph(Graph& g, VertexSet const& verts, std::true_type)
 {
     using namespace boost;
     BOOST_CONCEPT_ASSERT((AdjacencyMatrixConcept< Graph >));

--- a/test/test_destruction.hpp
+++ b/test/test_destruction.hpp
@@ -7,6 +7,7 @@
 #ifndef TEST_DESTRUCTION_HPP
 #define TEST_DESTRUCTION_HPP
 
+#include <type_traits>
 #include <boost/concept/assert.hpp>
 #include <utility>
 
@@ -23,7 +24,7 @@ void destroy_graph(Graph&, VertexSet const&, Remove, Label)
 // This matches MutableGraph, so just remove a vertex and then clear.
 template < typename Graph, typename VertexSet >
 void destroy_graph(
-    Graph& g, VertexSet const& verts, boost::mpl::true_, boost::mpl::false_)
+    Graph& g, VertexSet const& verts, std::true_type, std::false_type)
 {
     using namespace boost;
     BOOST_CONCEPT_ASSERT((VertexListGraphConcept< Graph >));
@@ -38,7 +39,7 @@ void destroy_graph(
 // This will match labeled graphs.
 template < typename Graph, typename VertexSet >
 void destroy_graph(
-    Graph& g, VertexSet const&, boost::mpl::false_, boost::mpl::true_)
+    Graph& g, VertexSet const&, std::false_type, std::true_type)
 {
     using namespace boost;
     BOOST_CONCEPT_ASSERT((VertexListGraphConcept< Graph >));
@@ -62,7 +63,7 @@ void destroy_graph(
 //@{
 
 template < typename Graph, typename VertexSet >
-void disconnect_graph(Graph& g, VertexSet const& verts, boost::mpl::false_)
+void disconnect_graph(Graph& g, VertexSet const& verts, std::false_type)
 {
     using namespace boost;
     BOOST_CONCEPT_ASSERT((EdgeListGraphConcept< Graph >));
@@ -90,7 +91,7 @@ void disconnect_graph(Graph& g, VertexSet const& verts, boost::mpl::false_)
 }
 
 template < typename Graph, typename VertexSet >
-void disconnect_graph(Graph& g, VertexSet const&, boost::mpl::true_)
+void disconnect_graph(Graph& g, VertexSet const&, std::true_type)
 {
     using namespace boost;
     BOOST_CONCEPT_ASSERT((EdgeListGraphConcept< Graph >));

--- a/test/test_direction.hpp
+++ b/test/test_direction.hpp
@@ -7,6 +7,7 @@
 #ifndef TEST_DIRECTION_HPP
 #define TEST_DIRECTION_HPP
 
+#include <type_traits>
 #include <algorithm>
 #include <boost/range.hpp>
 #include <boost/concept/assert.hpp>
@@ -17,7 +18,7 @@
 //@{
 template < typename Graph, typename VertexSet >
 void test_outdirected_graph(
-    Graph const& g, VertexSet const& verts, boost::mpl::true_)
+    Graph const& g, VertexSet const& verts, std::true_type)
 {
     using namespace boost;
     BOOST_CONCEPT_ASSERT((IncidenceGraphConcept< Graph >));
@@ -53,7 +54,7 @@ void test_outdirected_graph(
 }
 
 template < typename Graph, typename VertexSet >
-void test_outdirected_graph(Graph const&, VertexSet const&, boost::mpl::false_)
+void test_outdirected_graph(Graph const&, VertexSet const&, std::false_type)
 {
 }
 //@}
@@ -64,7 +65,7 @@ void test_outdirected_graph(Graph const&, VertexSet const&, boost::mpl::false_)
 //@{
 template < typename Graph, typename VertexSet >
 void test_indirected_graph(
-    Graph const& g, VertexSet const& verts, boost::mpl::true_)
+    Graph const& g, VertexSet const& verts, std::true_type)
 {
     using namespace boost;
     BOOST_CONCEPT_ASSERT((BidirectionalGraphConcept< Graph >));
@@ -96,7 +97,7 @@ void test_indirected_graph(
 }
 
 template < typename Graph, typename VertexSet >
-void test_indirected_graph(Graph const&, VertexSet const&, boost::mpl::false_)
+void test_indirected_graph(Graph const&, VertexSet const&, std::false_type)
 {
 }
 //@}
@@ -106,7 +107,7 @@ void test_indirected_graph(Graph const&, VertexSet const&, boost::mpl::false_)
  */
 template < typename Graph, typename VertexSet >
 void test_undirected_graph(
-    Graph const& g, VertexSet const& verts, boost::mpl::true_)
+    Graph const& g, VertexSet const& verts, std::true_type)
 {
     using namespace boost;
     BOOST_CONCEPT_ASSERT((IncidenceGraphConcept< Graph >));
@@ -134,7 +135,7 @@ void test_undirected_graph(
 }
 
 template < typename Graph, typename VertexSet >
-void test_undirected_graph(Graph const&, VertexSet const&, boost::mpl::false_)
+void test_undirected_graph(Graph const&, VertexSet const&, std::false_type)
 {
 }
 //@}

--- a/test/test_properties.hpp
+++ b/test/test_properties.hpp
@@ -7,12 +7,13 @@
 #ifndef TEST_PROPERTIES_HPP
 #define TEST_PROPERTIES_HPP
 
+#include <type_traits>
 #include <boost/concept/assert.hpp>
 
 template < typename T > T const& as_const(T& x) { return x; }
 template < typename T > void ignore(T const&) {}
 
-template < typename Graph > void test_graph_bundle(Graph& g, boost::mpl::true_)
+template < typename Graph > void test_graph_bundle(Graph& g, std::true_type)
 {
     using namespace boost;
     std::cout << "...test_graph_bundle\n";
@@ -28,7 +29,7 @@ template < typename Graph > void test_graph_bundle(Graph& g, boost::mpl::true_)
     ignore(cb2);
 }
 
-template < typename Graph > void test_graph_bundle(Graph& g, boost::mpl::false_)
+template < typename Graph > void test_graph_bundle(Graph& g, std::false_type)
 {
 }
 
@@ -38,7 +39,7 @@ template < typename Graph > void test_graph_bundle(Graph& g, boost::mpl::false_)
  */
 //@{
 template < typename Graph, typename VertexSet >
-void test_vertex_bundle(Graph& g, VertexSet const& verts, boost::mpl::true_)
+void test_vertex_bundle(Graph& g, VertexSet const& verts, std::true_type)
 {
     using namespace boost;
     BOOST_CONCEPT_ASSERT((GraphConcept< Graph >));
@@ -68,7 +69,7 @@ void test_vertex_bundle(Graph& g, VertexSet const& verts, boost::mpl::true_)
 }
 
 template < typename Graph, typename VertexSet >
-void test_vertex_bundle(Graph&, VertexSet const&, boost::mpl::false_)
+void test_vertex_bundle(Graph&, VertexSet const&, std::false_type)
 {
 }
 //@}
@@ -79,7 +80,7 @@ void test_vertex_bundle(Graph&, VertexSet const&, boost::mpl::false_)
  */
 //@{
 template < typename Graph, typename VertexSet >
-void test_edge_bundle(Graph& g, VertexSet const& verts, boost::mpl::true_)
+void test_edge_bundle(Graph& g, VertexSet const& verts, std::true_type)
 {
     using namespace boost;
     BOOST_CONCEPT_ASSERT((GraphConcept< Graph >));
@@ -110,7 +111,7 @@ void test_edge_bundle(Graph& g, VertexSet const& verts, boost::mpl::true_)
 }
 
 template < typename Graph, typename VertexSet >
-void test_edge_bundle(Graph&, VertexSet const&, boost::mpl::false_)
+void test_edge_bundle(Graph&, VertexSet const&, std::false_type)
 {
 }
 //@}


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

Reduce the number of MPL dependencies. Probably not relevant for 1.92 given how late we are in the cycle. 

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [ ] Bug fix
- [ ] New feature or API addition
- [x] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [] Other (specify below)

### Does this PR introduce a breaking change?

- [x] Yes (describe migration impact below)
- [ ] No

- Patterns that break (all need the same two things at once: an overload set keyed on the exact `mpl::` type, fed a BGL trait's `::type`, which is the type that changed):
  - `mpl::true_`/`mpl::false_` overloads driven by a BGL trait's `::type`. The tag no longer matches the overload:
    - Ex: `f(typename is_directed_graph<G>::type())` against `void f(mpl::true_)` / `void f(mpl::false_)`. 
  - Exact-type checks
      - Ex: `static_assert(is_same<is_directed_graph<G>::type, mpl::true_>::value)`.
  - Template specializations keyed on `mpl::true_`/`mpl::false_` that are instantiated with a BGL trait's `::type`.

- Patterns that still work:
  - Anything reading `::value` (overwhelming majority ?)
      - Ex: `if (is_directed_graph<G>::value)`
      - Ex: `if constexpr (is_directed_graph<G>::value)`
  - Feeding the trait into `mpl::if_` / `mpl::and_` / `mpl::not_` and similar. Those read `::value`, so `std::integral_constant` works.
  - Overloads that take a generic `template<class B>` parameter and read `B::value` instead of matching a concrete tag type.
  - Overloads already written on `std::true_type` / `std::false_type`. Before this change they would have had to convert first.

### What this PR does

<!-- A short summary of the change. -->

Converts Boost.Graph's public traits from Boost.MPL to standard `<type_traits>`. This is a breaking change: the traits now derive from `std::integral_constant` / `std::true_type` / `std::false_type` instead of `boost::mpl::bool_` / `true_` / `false_`.

- `graph_selectors.hpp`: `directedS`/`undirectedS`/`bidirectionalS`'s `is_directed_t` and `is_bidir_t` now `std::true_type`/`std::false_type`.
- `graph_traits.hpp`: `is_directed_graph`, `is_undirected_graph`, `is_multigraph`, `is_incidence/bidirectional/vertex_list/edge_list_graph`, `is_adjacency_matrix`, `is_directed_uni/bidirectional_graph`, `has_*_property`, `has_bundled_*`, and `is_no_bundle` now derive from `std::integral_constant` (file MPL-free)
- `graph_mutability_traits.hpp`: the whole `graph_has_*` and `is_mutable_*` family now derive from `std::integral_constant` (file MPL-free)
- `reverse_graph.hpp`: `is_reverse_graph` now `std::true_type`/`std::false_type`; internal `mpl::if_` to `std::conditional` (file MPL-free)
- `labeled_graph_traits.hpp`: converted the labeled mutability traits (`graph_has_*_by_label`, `is_labeled_mutable_*`) and `determine_mutability` from `mpl::bool_`/`and_`/`if_` to `std::integral_constant`/`std::conditional`, (file MPL-free)
- `pending/property.hpp`: `has_property` and `is_no_property` now on `std`; internal `mpl::if_` to `std::conditional`.
- `test/`: `test_direction`, `test_properties`, `test_construction`, `test_destruction` update their tag-dispatch overloads from `boost::mpl::true_`/`false_` to `std::true_type`/`std::false_type` to match the new trait types.
- `adjacency_list.hpp`: converted `is_random_access` and `is_distributed_selector` from `mpl::true_/false_` to `std::true_type/false_type` making public `adjacency_list_traits::is_rand_access` a `std` type.

### Motivation

<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->

Reduce the number of MPL dependencies.

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->

### Checklist

- [x] Existing tests pass (`b2` in the `test/` directory).
- [x] New behavior is covered by a test, or this is a docs / build / refactor change.
- [x] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.