### PR TITLE
refactor: remove dependency on boost.tti using detector idiom

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,6 @@ target_link_libraries(boost_graph
     Boost::smart_ptr
     Boost::spirit
     Boost::throw_exception
-    Boost::tti
     Boost::tuple
     Boost::type_traits
     Boost::unordered

--- a/build.jam
+++ b/build.jam
@@ -35,7 +35,6 @@ constant boost_dependencies :
     /boost/smart_ptr//boost_smart_ptr
     /boost/spirit//boost_spirit
     /boost/throw_exception//boost_throw_exception
-    /boost/tti//boost_tti
     /boost/tuple//boost_tuple
     /boost/type_traits//boost_type_traits
     /boost/unordered//boost_unordered

--- a/include/boost/graph/depth_first_search.hpp
+++ b/include/boost/graph/depth_first_search.hpp
@@ -24,7 +24,8 @@
 #include <boost/optional.hpp>
 #include <boost/parameter.hpp>
 #include <boost/concept/assert.hpp>
-#include <boost/tti/has_member_function.hpp>
+#include <boost/type_traits/make_void.hpp>
+#include <type_traits>
 
 #include <vector>
 #include <utility>
@@ -68,7 +69,19 @@ namespace detail
         }
     };
 
-    BOOST_TTI_HAS_MEMBER_FUNCTION(finish_edge)
+    // has_finish_edge<Vis, E, G>::value is true when vis.finish_edge(e, g) is
+    // a valid call for e of type E and g of type const G&.
+    template < typename Vis, typename E, typename G, typename = void >
+    struct has_finish_edge : std::false_type
+    {
+    };
+    template < typename Vis, typename E, typename G >
+    struct has_finish_edge< Vis, E, G,
+        boost::void_t< decltype(std::declval< Vis& >().finish_edge(
+            std::declval< E& >(), std::declval< const G& >())) > >
+    : std::true_type
+    {
+    };
 
     template < bool IsCallable > struct do_call_finish_edge
     {
@@ -89,18 +102,9 @@ namespace detail
 
     template < typename E, typename G, typename Vis >
     void call_finish_edge(Vis& vis, E e, const G& g)
-    { // Only call if method exists
-#if ((defined(__GNUC__) && (__GNUC__ > 4)               \
-         || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 9))) \
-    || defined(__clang__)                               \
-    || (defined(__INTEL_COMPILER) && (__INTEL_COMPILER >= 1200)))
-        do_call_finish_edge< has_member_function_finish_edge< Vis, void,
-            boost::mpl::vector< E, const G& > >::value >::call_finish_edge(vis,
-            e, g);
-#else
-        do_call_finish_edge< has_member_function_finish_edge< Vis,
-            void >::value >::call_finish_edge(vis, e, g);
-#endif
+    { // Only call if the visitor has a callable finish_edge(e, g)
+        do_call_finish_edge< has_finish_edge< Vis, E, G >::value >::
+            call_finish_edge(vis, e, g);
     }
 
 // Define BOOST_RECURSIVE_DFS to use older, recursive version.


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

Remove dependency to Boost.TTI. Use void_t detector idiom instead.

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [ ] Bug fix
- [ ] New feature or API addition
- [x] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

<!-- A short summary of the change. -->

Removes Boost.Graph's dependency on Boost.TTI (and the last MPL use in DFS).

- `depth_first_search.hpp`: replaced the `BOOST_TTI_HAS_MEMBER_FUNCTION(finish_edge)` detector and its `__GNUC__`/`clang`/`intel` `#if` fork with a `void_t` expression-SFINAE detector, `has_finish_edge<Vis, E, G>`, that checks whether `vis.finish_edge(e, g)` is a valid call. D
- dropped `#include <boost/tti/has_member_function.hpp>`
- added `<boost/type_traits/make_void.hpp>` and `<type_traits>`.
- This also removes the `mpl::vector<E, const G&>` that only existed to feed TTI's signature, so the file is now MPL-free as well.
- `build.jam`: dropped `/boost/tti//boost_tti`.
- `CMakeLists.txt`: dropped `Boost::tti`.

All changes in `boost::detail`, detection is identical for `void finish_edge(Edge, const Graph&)` visitors, and the check now works uniformly on C++14 compilers.

### Motivation

<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->

It's not worth pulling a Boost dependency anymore now that the sfinae + detector idiom are available in C++14.

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->

### Checklist

- [ ] Existing tests pass (`b2` in the `test/` directory).
- [ ] New behavior is covered by a test, or this is a docs / build / refactor change.
- [ ] Documentation was updated if user-facing behavior changed.
- [ ] No new compiler warnings on the platforms I built against.
