### PR TITLE
refactor: remove dependency to boost.math

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,6 @@ target_link_libraries(boost_graph
     Boost::integer
     Boost::iterator
     Boost::lexical_cast
-    Boost::math
     Boost::mpl
     Boost::multi_index
     Boost::multiprecision

--- a/build.jam
+++ b/build.jam
@@ -20,7 +20,6 @@ constant boost_dependencies :
     /boost/integer//boost_integer
     /boost/iterator//boost_iterator
     /boost/lexical_cast//boost_lexical_cast
-    /boost/math//boost_math_tr1
     /boost/mpl//boost_mpl
     /boost/multi_index//boost_multi_index
     /boost/multiprecision//boost_multiprecision

--- a/include/boost/graph/circle_layout.hpp
+++ b/include/boost/graph/circle_layout.hpp
@@ -9,7 +9,6 @@
 #ifndef BOOST_GRAPH_CIRCLE_LAYOUT_HPP
 #define BOOST_GRAPH_CIRCLE_LAYOUT_HPP
 #include <boost/config/no_tr1/cmath.hpp>
-#include <boost/math/constants/constants.hpp>
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/iteration_macros.hpp>
 #include <boost/graph/topology.hpp>
@@ -34,7 +33,7 @@ void circle_graph_layout(
 {
     BOOST_STATIC_ASSERT(
         property_traits< PositionMap >::value_type::dimensions >= 2);
-    const double pi = boost::math::constants::pi< double >();
+    const double pi = 3.14159265358979323846;
 
 #ifndef BOOST_NO_STDC_NAMESPACE
     using std::cos;

--- a/include/boost/graph/topology.hpp
+++ b/include/boost/graph/topology.hpp
@@ -13,8 +13,7 @@
 #include <boost/algorithm/minmax.hpp>
 #include <boost/config.hpp> // For BOOST_STATIC_CONSTANT
 #include <boost/config/no_tr1/cmath.hpp>
-#include <boost/math/constants/constants.hpp> // For root_two
-#include <boost/math/special_functions/hypot.hpp>
+#include <cmath>
 #include <boost/random/uniform_01.hpp>
 #include <boost/random/linear_congruential.hpp>
 #include <boost/shared_ptr.hpp>
@@ -155,7 +154,7 @@ public:
         for (std::size_t i = 0; i < Dims; ++i)
         {
             double diff = b[i] - a[i];
-            dist = boost::math::hypot(dist, diff);
+            dist = std::hypot(dist, diff);
         }
         // Exact properties of the distance are not important, as long as
         // < on what this returns matches real distances; l_2 is used because
@@ -209,7 +208,7 @@ public:
     {
         double n = 0.;
         for (std::size_t i = 0; i < Dims; ++i)
-            n = boost::math::hypot(n, delta[i]);
+            n = std::hypot(n, delta[i]);
         return n;
     }
 
@@ -476,7 +475,7 @@ public:
         BOOST_USING_STD_MAX();
         double r = 0.;
         for (std::size_t i = 0; i < Dims; ++i)
-            r = boost::math::hypot(r, a[i]);
+            r = std::hypot(r, a[i]);
         if (r <= radius)
             return a;
         double scaling_factor = radius / r;
@@ -490,7 +489,7 @@ public:
     {
         double r = 0.;
         for (std::size_t i = 0; i < Dims; ++i)
-            r = boost::math::hypot(r, a[i]);
+            r = std::hypot(r, a[i]);
         return radius - r;
     }
 
@@ -560,6 +559,8 @@ template < typename RandomNumberGenerator = minstd_rand > class heart_topology
     // Circle centered at (500, -500) radius 500*sqrt(2)
     // Bounding box (-1000, -2000) - (1000, 500*(sqrt(2) - 1))
 
+    static constexpr double root_two = 1.41421356237309504880; // sqrt(2)
+
     struct point
     {
         point()
@@ -590,11 +591,11 @@ template < typename RandomNumberGenerator = minstd_rand > class heart_topology
             return false; // Bottom
         if (p[1] <= -1000)
             return true; // Diagonal of square
-        if (boost::math::hypot(p[0] - -500, p[1] - -500)
-            <= 500. * boost::math::constants::root_two< double >())
+        if (std::hypot(p[0] - -500, p[1] - -500)
+            <= 500. * root_two)
             return true; // Left circle
-        if (boost::math::hypot(p[0] - 500, p[1] - -500)
-            <= 500. * boost::math::constants::root_two< double >())
+        if (std::hypot(p[0] - 500, p[1] - -500)
+            <= 500. * root_two)
             return true; // Right circle
         return false;
     }
@@ -635,12 +636,12 @@ public:
         {
             result[0] = (*rand)()
                     * (1000
-                        + 1000 * boost::math::constants::root_two< double >())
-                - (500 + 500 * boost::math::constants::root_two< double >());
+                        + 1000 * root_two)
+                - (500 + 500 * root_two);
             result[1] = (*rand)()
                     * (2000
                         + 500
-                            * (boost::math::constants::root_two< double >()
+                            * (root_two
                                 - 1))
                 - 2000;
         } while (!in_heart(result));
@@ -655,13 +656,13 @@ public:
         if (segment_within_heart(a, b))
         {
             // Straight line
-            return boost::math::hypot(b[0] - a[0], b[1] - a[1]);
+            return std::hypot(b[0] - a[0], b[1] - a[1]);
         }
         else
         {
             // Straight line bending around (0, 0)
-            return boost::math::hypot(a[0], a[1])
-                + boost::math::hypot(b[0], b[1]);
+            return std::hypot(a[0], a[1])
+                + std::hypot(b[0], b[1]);
         }
     }
 
@@ -675,8 +676,8 @@ public:
         }
         else
         {
-            double distance_to_point_a = boost::math::hypot(a[0], a[1]);
-            double distance_to_point_b = boost::math::hypot(b[0], b[1]);
+            double distance_to_point_a = std::hypot(a[0], a[1]);
+            double distance_to_point_b = std::hypot(b[0], b[1]);
             double location_of_point = distance_to_point_a
                 / (distance_to_point_a + distance_to_point_b);
             if (fraction < location_of_point)


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [ ] Bug fix
- [ ] New feature or API addition
- [x] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

<!-- A short summary of the change. -->

- remove boost.math headers and deps in CML/build.jam
- use C++11 std::hypot
- define a local pi and square root constant

### Motivation

<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->

Remove dependency on Boost.Math: it's overkill here for just one STL function and 2 constants.

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->

### Checklist

- [x] Existing tests pass (`b2` in the `test/` directory).
- [x] New behavior is covered by a test, or this is a docs / build / refactor change.
- [x] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.
