### PR TITLE
refactor: drop direct dependency on Boost.Serialization

### DIFF
--- a/include/boost/graph/adj_list_serialize.hpp
+++ b/include/boost/graph/adj_list_serialize.hpp
@@ -17,9 +17,8 @@
 #include <boost/config.hpp>
 #include <boost/detail/workaround.hpp>
 
-#include <boost/serialization/collections_save_imp.hpp>
-#include <boost/serialization/collections_load_imp.hpp>
-#include <boost/serialization/split_free.hpp>
+#include <boost/core/serialization.hpp>
+#include <boost/type_traits/integral_constant.hpp>
 
 namespace boost
 {
@@ -29,13 +28,16 @@ namespace serialization
 
     // Turn off tracking for adjacency_list. It's not polymorphic, and we
     // need to do this to enable saving of non-const adjacency lists.
+    // Specializing tracking_level_impl (not tracking_level) avoids including
+    // <boost/serialization/tracking.hpp>. boost::integral_constant carries the
+    // integral_c_tag the archive expects.
+    template < class T > struct tracking_level_impl;
     template < class OEL, class VL, class D, class VP, class EP, class GP,
         class EL >
-    struct tracking_level< boost::adjacency_list< OEL, VL, D, VP, EP, GP, EL > >
+    struct tracking_level_impl<
+        const boost::adjacency_list< OEL, VL, D, VP, EP, GP, EL > >
+    : boost::integral_constant< int, 0 /* track_never */ >
     {
-        typedef mpl::integral_c_tag tag;
-        typedef mpl::int_< track_never > type;
-        BOOST_STATIC_CONSTANT(int, value = tracking_level::type::value);
     };
 
     template < class Archive, class OEL, class VL, class D, class VP, class EP,
@@ -50,8 +52,8 @@ namespace serialization
 
         const auto V = num_vertices(graph);
         const auto E = num_edges(graph);
-        ar << BOOST_SERIALIZATION_NVP(V);
-        ar << BOOST_SERIALIZATION_NVP(E);
+        ar << BOOST_NVP(V);
+        ar << BOOST_NVP(E);
 
         // assign indices to vertices
         std::unordered_map< Vertex, Vertex > indices(V);
@@ -59,20 +61,20 @@ namespace serialization
         BGL_FORALL_VERTICES_T(v, graph, Graph)
         {
             indices[v] = num++;
-            ar << serialization::make_nvp(
+            ar << boost::make_nvp(
                 "vertex_property", get(vertex_all_t(), graph, v));
         }
 
         // write edges
         BGL_FORALL_EDGES_T(e, graph, Graph)
         {
-            ar << serialization::make_nvp("u", indices[source(e, graph)]);
-            ar << serialization::make_nvp("v", indices[target(e, graph)]);
-            ar << serialization::make_nvp(
+            ar << boost::make_nvp("u", indices[source(e, graph)]);
+            ar << boost::make_nvp("v", indices[target(e, graph)]);
+            ar << boost::make_nvp(
                 "edge_property", get(edge_all_t(), graph, e));
         }
 
-        ar << serialization::make_nvp(
+        ar << boost::make_nvp(
             "graph_property", get_property(graph, graph_all_t()));
     }
 
@@ -89,10 +91,10 @@ namespace serialization
         using VertexSizeType = typename graph_traits< Graph >::vertices_size_type;
 
         VertexSizeType V;
-        ar >> BOOST_SERIALIZATION_NVP(V);
+        ar >> BOOST_NVP(V);
         
         VertexSizeType E;
-        ar >> BOOST_SERIALIZATION_NVP(E);
+        ar >> BOOST_NVP(E);
 
         std::vector< Vertex > verts(V);
         size_t i = 0;
@@ -100,7 +102,7 @@ namespace serialization
         {
             const auto v = add_vertex(graph);
             verts[i++] = v;
-            ar >> serialization::make_nvp(
+            ar >> boost::make_nvp(
                 "vertex_property", get(vertex_all_t(), graph, v));
         }
         
@@ -108,16 +110,16 @@ namespace serialization
         {
             Vertex u;
             Vertex v;
-            ar >> BOOST_SERIALIZATION_NVP(u);
-            ar >> BOOST_SERIALIZATION_NVP(v);
+            ar >> BOOST_NVP(u);
+            ar >> BOOST_NVP(v);
 
             Edge e;
             bool inserted;
             boost::tie(e, inserted) = add_edge(verts[u], verts[v], graph);
-            ar >> serialization::make_nvp(
+            ar >> boost::make_nvp(
                 "edge_property", get(edge_all_t(), graph, e));
         }
-        ar >> serialization::make_nvp(
+        ar >> boost::make_nvp(
             "graph_property", get_property(graph, graph_all_t()));
     }
 
@@ -127,7 +129,7 @@ namespace serialization
         boost::adjacency_list< OEL, VL, D, VP, EP, GP, EL >& graph,
         const unsigned int file_version)
     {
-        boost::serialization::split_free(ar, graph, file_version);
+        boost::core::split_free(ar, graph, file_version);
     }
 
 } // serialization

--- a/include/boost/pending/property_serialize.hpp
+++ b/include/boost/pending/property_serialize.hpp
@@ -12,7 +12,9 @@
 // Only the Parallel BGL (MPI) specializations below need Boost.Serialization,
 // so keep its header out of the default build.
 #ifdef BOOST_GRAPH_USE_MPI
-#include <boost/serialization/is_bitwise_serializable.hpp>
+#define BOOST_GRAPH_BLOCK_BOOSTDEP_HEADER <boost/serialization/is_bitwise_serializable.hpp>
+#include BOOST_GRAPH_BLOCK_BOOSTDEP_HEADER
+#undef BOOST_GRAPH_BLOCK_BOOSTDEP_HEADER
 #endif
 
 namespace boost

--- a/include/boost/pending/property_serialize.hpp
+++ b/include/boost/pending/property_serialize.hpp
@@ -7,9 +7,13 @@
 #define BOOST_PROPERTY_SERIALIZE_HPP
 
 #include <boost/pending/property.hpp>
+#include <boost/core/nvp.hpp>
+
+// Only the Parallel BGL (MPI) specializations below need Boost.Serialization,
+// so keep its header out of the default build.
+#ifdef BOOST_GRAPH_USE_MPI
 #include <boost/serialization/is_bitwise_serializable.hpp>
-#include <boost/serialization/base_object.hpp>
-#include <boost/serialization/nvp.hpp>
+#endif
 
 namespace boost
 {
@@ -22,8 +26,8 @@ template < class Archive, class Tag, class T, class Base >
 void serialize(
     Archive& ar, property< Tag, T, Base >& prop, const unsigned int /*version*/)
 {
-    ar& serialization::make_nvp("property_value", prop.m_value);
-    ar& serialization::make_nvp("property_base", prop.m_base);
+    ar& boost::make_nvp("property_value", prop.m_value);
+    ar& boost::make_nvp("property_base", prop.m_base);
 }
 
 #ifdef BOOST_GRAPH_USE_MPI

--- a/test/serialize.cpp
+++ b/test/serialize.cpp
@@ -16,6 +16,7 @@
 #include <boost/graph/adj_list_serialize.hpp>
 #include <boost/archive/xml_iarchive.hpp>
 #include <boost/archive/xml_oarchive.hpp>
+#include <boost/serialization/tracking.hpp>
 
 struct vertex_properties
 {
@@ -46,6 +47,10 @@ typedef adjacency_list< vecS, vecS, undirectedS, vertex_properties,
     Graph;
 
 typedef graph_traits< Graph >::vertex_descriptor vd_type;
+
+static_assert(boost::serialization::tracking_level< Graph >::value
+        == boost::serialization::track_never,
+    "adjacency_list tracking_level must be track_never");
 
 typedef adjacency_list< vecS, vecS, undirectedS, vertex_properties >
     Graph_no_edge_property;


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

Remove dependency to Boost.Serialization

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [ ] Bug fix
- [ ] New feature or API addition
- [x] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

<!-- A short summary of the change. -->

- Phase out of serialization `nvp` utilities to boost.core.serialization
- Use a forward declaration trick to decouple BGL from Serialization.

### Motivation

<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->

Boost.Serialization is one of the heaviest Boost.Library along with Spirit: 22 direct dependencies, 55 total, effectively dragging most of Boost in default build: https://alandefreitas.github.io/boostdep_graph/libs/serialization.html

In contrast, Boost.Core.Serialization has 3 dependencies: https://alandefreitas.github.io/boostdep_graph/libs/core.html

We switch to Boost.Core.Serialization dependencies and use a forward declaration trick inspired by Peter Dimov uuid trick to remove direct coupling on Boost.Serialization (the user who needs Serialization will pull its headers anyway): https://github.com/boostorg/uuid/blob/2aa25a3afe023c5324d1b13015a65f67bfaef08c/include/boost/uuid/uuid.hpp#L344-L357

Some Serialization stuff for property map is behind an MPI guard: this is actually Boost.Parallel territory, and looks like a remnant of modularization BGL/PBGL. This should be exported to PBGL rather than polluting BGL, but it's a cross-repo PR and outside of the current scope.

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->

The current test is unchanged, we just add a static assertion to verify the tracking level is unchanged (it exists to guarantee that non-const graphs can be serialized, removing it would cause a compilation error deep inside Serialization if the user tries to serialize a non-const graph).

### Checklist

- [x] Existing tests pass (`b2` in the `test/` directory).
- [x] New behavior is covered by a test, or this is a docs / build / refactor change.
- [x] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.
