### PR TITLE
[hawick] Support passing std::reference_wrapper to boost::hawick_circuits

### DIFF
--- a/doc/modules/ROOT/pages/algorithms/cycle_detection/hawick_circuits.adoc
+++ b/doc/modules/ROOT/pages/algorithms/cycle_detection/hawick_circuits.adoc
@@ -120,4 +120,4 @@ The algorithm is described in detail in https://www.researchgate.net/publication
 == Notes
 
 * `hawick_circuits` enumerates all elementary circuits including redundant ones caused by parallel edges. Use `hawick_unique_circuits` to suppress those duplicates.
-* The visitor is passed by value. If your visitor contains state, consider holding it by pointer or reference so that changes made during the algorithm are visible to the caller.
+* The visitor is passed by value. If your visitor contains state, consider holding it by pointer or reference so that changes made during the algorithm are visible to the caller. If `visitor` is a `std::reference_wrapper`, it will be unwrapped before the `.cycle` method is called on it, which allows passing a visitor that shouldn't be copied.

--- a/include/boost/graph/hawick_circuits.hpp
+++ b/include/boost/graph/hawick_circuits.hpp
@@ -94,12 +94,10 @@ namespace hawick_circuits_detail
         typedef T type;
     };
 
-#if __cplusplus >= 201103L
     template < typename T >
     struct unwrap_reference_wrapper<std::reference_wrapper<T> > {
         typedef T& type;
     };
-#endif
 
     /*!
      * @internal

--- a/include/boost/graph/hawick_circuits.hpp
+++ b/include/boost/graph/hawick_circuits.hpp
@@ -20,6 +20,7 @@
 #include <boost/tuple/tuple.hpp> // for boost::tie
 #include <boost/type_traits/remove_reference.hpp>
 #include <boost/utility/result_of.hpp>
+#include <functional> // for std::reference_wrapper
 #include <set>
 #include <utility> // for std::pair
 #include <vector>
@@ -87,6 +88,18 @@ namespace hawick_circuits_detail
     {
         return std::find(boost::begin(c), boost::end(c), v) != boost::end(c);
     }
+
+    template < typename T >
+    struct unwrap_reference_wrapper {
+        typedef T type;
+    };
+
+#if __cplusplus >= 201103L
+    template < typename T >
+    struct unwrap_reference_wrapper<std::reference_wrapper<T> > {
+        typedef T& type;
+    };
+#endif
 
     /*!
      * @internal
@@ -313,8 +326,9 @@ namespace hawick_circuits_detail
 
         typedef std::vector< Vertex > Stack;
         typedef std::vector< std::vector< Vertex > > ClosedMatrix;
+        typedef typename unwrap_reference_wrapper<Visitor>::type VisitorNoRef;
 
-        typedef hawick_circuits_from< Graph, Visitor, VertexIndexMap, Stack,
+        typedef hawick_circuits_from< Graph, VisitorNoRef, VertexIndexMap, Stack,
             ClosedMatrix, GetAdjacentVertices >
             SubAlgorithm;
 

--- a/test/hawick_circuits.cpp
+++ b/test/hawick_circuits.cpp
@@ -37,15 +37,13 @@ struct call_hawick_unique_circuits
 struct not_copyable
 {
     not_copyable() { }
+    not_copyable(not_copyable const&) = delete;
 
     template < typename Path, typename Graph >
     void cycle(Path const&, Graph const&)
     {
 
     }
-
-private:
-    not_copyable(not_copyable const&);
 };
 
 int main()

--- a/test/hawick_circuits.cpp
+++ b/test/hawick_circuits.cpp
@@ -79,7 +79,6 @@ int main()
     }
 
     // Make sure we can pass a reference_wrapper to the algorithm.
-#if __cplusplus >= 201103L
     {
         typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::directedS> Graph;
         typedef std::pair<std::size_t, std::size_t> Pair;
@@ -96,7 +95,6 @@ int main()
         not_copyable visitor;
         boost::hawick_circuits(G, std::ref(visitor));
     }
-#endif // >= C++11
 
     std::cout << "\n\n";
     return boost::report_errors();

--- a/test/hawick_circuits.cpp
+++ b/test/hawick_circuits.cpp
@@ -6,6 +6,8 @@
 
 #include "cycle_test.hpp"
 #include <boost/graph/hawick_circuits.hpp>
+#include <cstddef>
+#include <functional>
 #include <iostream>
 
 struct call_hawick_circuits
@@ -30,6 +32,20 @@ struct call_hawick_unique_circuits
     {
         boost::hawick_unique_circuits(g, v, max_length);
     }
+};
+
+struct not_copyable
+{
+    not_copyable() { }
+
+    template < typename Path, typename Graph >
+    void cycle(Path const&, Graph const&)
+    {
+
+    }
+
+private:
+    not_copyable(not_copyable const&);
 };
 
 int main()
@@ -61,6 +77,26 @@ int main()
         std::cout << ")---------\n";
         cycle_test(call_hawick_unique_circuits(ml), nc3[ml], nc4[ml]);
     }
+
+    // Make sure we can pass a reference_wrapper to the algorithm.
+#if __cplusplus >= 201103L
+    {
+        typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::directedS> Graph;
+        typedef std::pair<std::size_t, std::size_t> Pair;
+        Pair edges[3] = {
+            Pair(0, 1), // a->b
+            Pair(1, 2), // b->c
+            Pair(2, 0), // c->a
+        };
+
+        Graph G(3);
+        for (int i = 0; i < 3; ++i)
+            add_edge(edges[i].first, edges[i].second, G);
+
+        not_copyable visitor;
+        boost::hawick_circuits(G, std::ref(visitor));
+    }
+#endif // >= C++11
 
     std::cout << "\n\n";
     return boost::report_errors();


### PR DESCRIPTION
Reported as ldionne/hawick_circuits#1.