### PR TITLE
refactor: drop direct dependency on Boost.SmartPtr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,6 @@ target_link_libraries(boost_graph
     Boost::random
     Boost::range
     Boost::serialization
-    Boost::smart_ptr
     Boost::spirit
     Boost::throw_exception
     Boost::tti

--- a/build.jam
+++ b/build.jam
@@ -32,7 +32,6 @@ constant boost_dependencies :
     /boost/random//boost_random
     /boost/range//boost_range
     /boost/serialization//boost_serialization
-    /boost/smart_ptr//boost_smart_ptr
     /boost/spirit//boost_spirit
     /boost/throw_exception//boost_throw_exception
     /boost/tti//boost_tti

--- a/include/boost/graph/adjacency_list.hpp
+++ b/include/boost/graph/adjacency_list.hpp
@@ -19,7 +19,7 @@
 
 #include <boost/unordered_set.hpp>
 
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/graph_mutability_traits.hpp>
@@ -407,7 +407,7 @@ public:
 #endif
 
     //  protected:  (would be protected if friends were more portable)
-    typedef scoped_ptr< graph_property_type > property_ptr;
+    using property_ptr = std::unique_ptr< graph_property_type >;
     property_ptr m_property;
 };
 

--- a/include/boost/graph/detail/d_ary_heap.hpp
+++ b/include/boost/graph/detail/d_ary_heap.hpp
@@ -17,7 +17,7 @@
 #include <utility>
 #include <boost/assert.hpp>
 #include <boost/static_assert.hpp>
-#include <boost/shared_array.hpp>
+#include <memory>
 #include <boost/property_map/property_map.hpp>
 
 // WARNING: it is not safe to copy a d_ary_heap_indirect and then modify one of
@@ -45,23 +45,25 @@ namespace detail
 {
     template < typename Value > class fixed_max_size_vector
     {
-        boost::shared_array< Value > m_data;
+        // todo : C++17: replace with std::shared_ptr<T[]>
+        std::shared_ptr< Value > m_data;
         std::size_t m_size;
 
     public:
         typedef std::size_t size_type;
         fixed_max_size_vector(std::size_t max_size)
-        : m_data(new Value[max_size]), m_size(0)
+        : m_data(new Value[max_size], std::default_delete< Value[] >())
+        , m_size(0)
         {
         }
         std::size_t size() const { return m_size; }
         bool empty() const { return m_size == 0; }
-        Value& operator[](std::size_t i) { return m_data[i]; }
-        const Value& operator[](std::size_t i) const { return m_data[i]; }
-        void push_back(Value v) { m_data[m_size++] = v; }
+        Value& operator[](std::size_t i) { return m_data.get()[i]; }
+        const Value& operator[](std::size_t i) const { return m_data.get()[i]; }
+        void push_back(Value v) { m_data.get()[m_size++] = v; }
         void pop_back() { --m_size; }
-        Value& back() { return m_data[m_size - 1]; }
-        const Value& back() const { return m_data[m_size - 1]; }
+        Value& back() { return m_data.get()[m_size - 1]; }
+        const Value& back() const { return m_data.get()[m_size - 1]; }
     };
 }
 

--- a/include/boost/graph/dijkstra_shortest_paths.hpp
+++ b/include/boost/graph/dijkstra_shortest_paths.hpp
@@ -23,7 +23,7 @@
 #include <boost/pending/indirect_cmp.hpp>
 #include <boost/graph/exception.hpp>
 #include <boost/graph/overloading.hpp>
-#include <boost/smart_ptr.hpp>
+#include <memory>
 #include <boost/graph/detail/d_ary_heap.hpp>
 #include <boost/graph/two_bit_color_map.hpp>
 #include <boost/graph/detail/mpi_include.hpp>
@@ -237,7 +237,7 @@ namespace detail
     {
         typedef boost::iterator_property_map< Value*, IndexMap > type;
         static type build(const Graph& g, const IndexMap& index,
-            boost::scoped_array< Value >& array_holder)
+            std::unique_ptr< Value[] >& array_holder)
         {
             array_holder.reset(new Value[num_vertices(g)]);
             std::fill(array_holder.get(), array_holder.get() + num_vertices(g),
@@ -251,7 +251,7 @@ namespace detail
     {
         typedef boost::vector_property_map< Value, IndexMap > type;
         static type build(const Graph& g, const IndexMap& index,
-            boost::scoped_array< Value >& array_holder)
+            std::unique_ptr< Value[] >& array_holder)
         {
             return boost::make_vector_property_map< Value >(index);
         }
@@ -268,7 +268,7 @@ namespace detail
             helper;
         typedef typename helper::type type;
         static type build(const Graph& g, const IndexMap& index,
-            boost::scoped_array< Value >& array_holder)
+            std::unique_ptr< Value[] >& array_holder)
         {
             return helper::build(g, index, array_holder);
         }
@@ -368,7 +368,7 @@ inline void dijkstra_shortest_paths_no_init(const Graph& g,
     typedef typename graph_traits< Graph >::vertex_descriptor Vertex;
 
     // Now the default: use a d-ary heap
-    boost::scoped_array< std::size_t > index_in_heap_map_holder;
+    std::unique_ptr< std::size_t[] > index_in_heap_map_holder;
     typedef detail::vertex_property_map_generator< Graph, IndexMap,
         std::size_t >
         IndexInHeapMapHelper;

--- a/include/boost/graph/dijkstra_shortest_paths_no_color_map.hpp
+++ b/include/boost/graph/dijkstra_shortest_paths_no_color_map.hpp
@@ -16,6 +16,7 @@
 #include <boost/graph/detail/d_ary_heap.hpp>
 #include <boost/graph/dijkstra_shortest_paths.hpp>
 #include <boost/graph/iteration_macros.hpp>
+#include <memory>
 
 namespace boost
 {
@@ -51,7 +52,7 @@ void dijkstra_shortest_paths_no_color_map_no_init(const Graph& graph,
         DistanceCompare >
         VertexQueue;
 
-    boost::scoped_array< std::size_t > index_in_heap_map_holder;
+    std::unique_ptr< std::size_t[] > index_in_heap_map_holder;
     IndexInHeapMap index_in_heap = IndexInHeapMapHelper::build(
         graph, index_map, index_in_heap_map_holder);
     VertexQueue vertex_queue(distance_map, index_in_heap, distance_compare);

--- a/include/boost/graph/erdos_renyi_generator.hpp
+++ b/include/boost/graph/erdos_renyi_generator.hpp
@@ -13,7 +13,7 @@
 #include <boost/assert.hpp>
 #include <iterator>
 #include <utility>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <boost/random/uniform_int.hpp>
 #include <boost/graph/graph_traits.hpp>
 #include <boost/random/geometric_distribution.hpp>
@@ -207,7 +207,7 @@ private:
             src = (std::numeric_limits< vertices_size_type >::max)();
     }
 
-    shared_ptr< uniform_01< RandomGenerator* > > gen;
+    std::shared_ptr< uniform_01< RandomGenerator* > > gen;
     geometric_distribution< vertices_size_type > rand_vertex;
     vertices_size_type n;
     bool allow_self_loops;

--- a/include/boost/graph/gursoy_atun_layout.hpp
+++ b/include/boost/graph/gursoy_atun_layout.hpp
@@ -27,7 +27,6 @@
 #include <boost/graph/properties.hpp>
 #include <boost/random/uniform_01.hpp>
 #include <boost/random/linear_congruential.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/graph/breadth_first_search.hpp>
 #include <boost/graph/dijkstra_shortest_paths.hpp>
 #include <boost/graph/named_function_params.hpp>

--- a/include/boost/graph/incremental_components.hpp
+++ b/include/boost/graph/incremental_components.hpp
@@ -16,7 +16,7 @@
 #include <boost/tuple/tuple.hpp>
 #include <boost/graph/detail/incremental_components.hpp>
 #include <boost/iterator/counting_iterator.hpp>
-#include <boost/smart_ptr/make_shared.hpp>
+#include <memory>
 #include <boost/pending/disjoint_sets.hpp>
 #include <iterator>
 
@@ -126,8 +126,8 @@ public:
     component_index(ParentIterator parent_start, ParentIterator parent_end,
         const ElementIndexMap& index_map)
     : m_num_elements(std::distance(parent_start, parent_end))
-    , m_components(make_shared< IndexContainer >())
-    , m_index_list(make_shared< IndexContainer >(m_num_elements))
+    , m_components(std::make_shared< IndexContainer >())
+    , m_index_list(std::make_shared< IndexContainer >(m_num_elements))
     {
 
         build_index_lists(parent_start, index_map);
@@ -137,8 +137,8 @@ public:
     template < typename ParentIterator >
     component_index(ParentIterator parent_start, ParentIterator parent_end)
     : m_num_elements(std::distance(parent_start, parent_end))
-    , m_components(make_shared< IndexContainer >())
-    , m_index_list(make_shared< IndexContainer >(m_num_elements))
+    , m_components(std::make_shared< IndexContainer >())
+    , m_index_list(std::make_shared< IndexContainer >(m_num_elements))
     {
 
         build_index_lists(parent_start, boost::identity_property_map());
@@ -225,7 +225,7 @@ private:
 
 protected:
     IndexType m_num_elements;
-    shared_ptr< IndexContainer > m_components, m_index_list;
+    std::shared_ptr< IndexContainer > m_components, m_index_list;
 
 }; // class component_index
 

--- a/include/boost/graph/isomorphism.hpp
+++ b/include/boost/graph/isomorphism.hpp
@@ -12,7 +12,6 @@
 #include <algorithm>
 #include <boost/config.hpp>
 #include <boost/assert.hpp>
-#include <boost/smart_ptr.hpp>
 #include <boost/graph/depth_first_search.hpp>
 #include <boost/detail/algorithm.hpp>
 #include <boost/unordered_map.hpp>

--- a/include/boost/graph/mcgregor_common_subgraphs.hpp
+++ b/include/boost/graph/mcgregor_common_subgraphs.hpp
@@ -14,7 +14,7 @@
 #include <vector>
 #include <stack>
 
-#include <boost/make_shared.hpp>
+#include <memory>
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/filtered_graph.hpp>
 #include <boost/graph/graph_utility.hpp>
@@ -559,7 +559,7 @@ namespace detail
         , m_graph2(graph2)
         , m_vindex_map1(vindex_map1)
         , m_vindex_map2(vindex_map2)
-        , m_subgraphs(make_shared< SubGraphList >())
+        , m_subgraphs(std::make_shared< SubGraphList >())
         , m_user_callback(user_callback)
         {
         }
@@ -627,7 +627,7 @@ namespace detail
         const GraphFirst& m_graph2;
         const VertexIndexMapFirst m_vindex_map1;
         const VertexIndexMapSecond m_vindex_map2;
-        shared_ptr< SubGraphList > m_subgraphs;
+        std::shared_ptr< SubGraphList > m_subgraphs;
         SubGraphCallback m_user_callback;
     };
 
@@ -732,8 +732,8 @@ namespace detail
         , m_graph2(graph2)
         , m_vindex_map1(vindex_map1)
         , m_vindex_map2(vindex_map2)
-        , m_subgraphs(make_shared< SubGraphList >())
-        , m_largest_size_so_far(make_shared< VertexSizeFirst >(0))
+        , m_subgraphs(std::make_shared< SubGraphList >())
+        , m_largest_size_so_far(std::make_shared< VertexSizeFirst >(0))
         , m_user_callback(user_callback)
         {
         }
@@ -801,8 +801,8 @@ namespace detail
         const GraphFirst& m_graph2;
         const VertexIndexMapFirst m_vindex_map1;
         const VertexIndexMapSecond m_vindex_map2;
-        shared_ptr< SubGraphList > m_subgraphs;
-        shared_ptr< VertexSizeFirst > m_largest_size_so_far;
+        std::shared_ptr< SubGraphList > m_subgraphs;
+        std::shared_ptr< VertexSizeFirst > m_largest_size_so_far;
         SubGraphCallback m_user_callback;
     };
 
@@ -910,8 +910,8 @@ namespace detail
         , m_graph2(graph2)
         , m_vindex_map1(vindex_map1)
         , m_vindex_map2(vindex_map2)
-        , m_subgraphs(make_shared< SubGraphList >())
-        , m_largest_size_so_far(make_shared< VertexSizeFirst >(0))
+        , m_subgraphs(std::make_shared< SubGraphList >())
+        , m_largest_size_so_far(std::make_shared< VertexSizeFirst >(0))
         , m_user_callback(user_callback)
         {
         }
@@ -996,8 +996,8 @@ namespace detail
         const GraphFirst& m_graph2;
         const VertexIndexMapFirst m_vindex_map1;
         const VertexIndexMapSecond m_vindex_map2;
-        shared_ptr< SubGraphList > m_subgraphs;
-        shared_ptr< VertexSizeFirst > m_largest_size_so_far;
+        std::shared_ptr< SubGraphList > m_subgraphs;
+        std::shared_ptr< VertexSizeFirst > m_largest_size_so_far;
         SubGraphCallback m_user_callback;
     };
 

--- a/include/boost/graph/metric_tsp_approx.hpp
+++ b/include/boost/graph/metric_tsp_approx.hpp
@@ -28,7 +28,6 @@
 
 #include <vector>
 
-#include <boost/shared_ptr.hpp>
 #include <boost/concept_check.hpp>
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/graph_as_tree.hpp>

--- a/include/boost/graph/one_bit_color_map.hpp
+++ b/include/boost/graph/one_bit_color_map.hpp
@@ -17,7 +17,7 @@
 #include <boost/property_map/property_map.hpp>
 #include <boost/graph/properties.hpp>
 #include <boost/graph/detail/mpi_include.hpp>
-#include <boost/shared_array.hpp>
+#include <memory>
 #include <boost/config.hpp>
 #include <boost/assert.hpp>
 #include <algorithm>
@@ -45,7 +45,8 @@ template < typename IndexMap = identity_property_map > struct one_bit_color_map
         int, bits_per_char = std::numeric_limits< unsigned char >::digits);
     std::size_t n;
     IndexMap index;
-    shared_array< unsigned char > data;
+    // todo : C++17: replace with std::shared_ptr<T[]>
+    std::shared_ptr< unsigned char > data;
 
     typedef typename property_traits< IndexMap >::key_type key_type;
     typedef one_bit_color_type value_type;
@@ -56,7 +57,8 @@ template < typename IndexMap = identity_property_map > struct one_bit_color_map
         std::size_t n, const IndexMap& index = IndexMap())
     : n(n)
     , index(index)
-    , data(new unsigned char[(n + bits_per_char - 1) / bits_per_char]())
+    , data(new unsigned char[(n + bits_per_char - 1) / bits_per_char](),
+          std::default_delete< unsigned char[] >())
     {
     }
 };

--- a/include/boost/graph/planar_detail/boyer_myrvold_impl.hpp
+++ b/include/boost/graph/planar_detail/boyer_myrvold_impl.hpp
@@ -12,7 +12,7 @@
 #include <list>
 #include <boost/next_prior.hpp>
 #include <boost/config.hpp> //for std::min macros
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <boost/tuple/tuple.hpp>
 #include <boost/property_map/property_map.hpp>
 #include <boost/graph/graph_traits.hpp>
@@ -150,8 +150,8 @@ class boyer_myrvold_impl
     typedef std::vector< edge_t > edge_vector_t;
     typedef std::list< vertex_t > vertex_list_t;
     typedef std::list< face_handle_t > face_handle_list_t;
-    typedef boost::shared_ptr< face_handle_list_t > face_handle_list_ptr_t;
-    typedef boost::shared_ptr< vertex_list_t > vertex_list_ptr_t;
+    using face_handle_list_ptr_t = std::shared_ptr< face_handle_list_t >;
+    using vertex_list_ptr_t = std::shared_ptr< vertex_list_t >;
     typedef boost::tuple< vertex_t, bool, bool > merge_stack_frame_t;
     typedef std::vector< merge_stack_frame_t > merge_stack_t;
 

--- a/include/boost/graph/planar_detail/face_handles.hpp
+++ b/include/boost/graph/planar_detail/face_handles.hpp
@@ -11,7 +11,7 @@
 
 #include <list>
 #include <boost/graph/graph_traits.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 // A "face handle" is an optimization meant to serve two purposes in
 // the implementation of the Boyer-Myrvold planarity test: (1) it holds
@@ -74,7 +74,7 @@ namespace graph
 
         template < typename DataType > struct lazy_list_node
         {
-            typedef shared_ptr< lazy_list_node< DataType > > ptr_t;
+            using ptr_t = std::shared_ptr< lazy_list_node< DataType > >;
 
             lazy_list_node(const DataType& data)
             : m_reversed(false), m_data(data), m_has_data(true)
@@ -92,8 +92,8 @@ namespace graph
             bool m_reversed;
             DataType m_data;
             bool m_has_data;
-            shared_ptr< lazy_list_node > m_left_child;
-            shared_ptr< lazy_list_node > m_right_child;
+            std::shared_ptr< lazy_list_node > m_left_child;
+            std::shared_ptr< lazy_list_node > m_right_child;
         };
 
         template < typename StoreOldHandlesPolicy, typename Vertex,
@@ -136,7 +136,7 @@ namespace graph
         struct edge_list_storage< recursive_lazy_list, Edge >
         {
             typedef lazy_list_node< Edge > node_type;
-            typedef shared_ptr< node_type > type;
+            using type = std::shared_ptr< node_type >;
             type value;
 
             void push_back(Edge e)
@@ -443,7 +443,7 @@ namespace graph
 
             void store_old_face_handles_dispatch(no_old_handles) {}
 
-            boost::shared_ptr< impl_t > pimpl;
+            std::shared_ptr< impl_t > pimpl;
         };
 
     } /* namespace detail */

--- a/include/boost/graph/plod_generator.hpp
+++ b/include/boost/graph/plod_generator.hpp
@@ -12,7 +12,7 @@
 #include <iterator>
 #include <utility>
 #include <boost/random/uniform_int.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <boost/graph/graph_traits.hpp>
 #include <vector>
 #include <map>
@@ -240,7 +240,7 @@ private:
 
     RandomGenerator* gen;
     std::size_t n;
-    shared_ptr< out_degrees_t > out_degrees;
+    std::shared_ptr< out_degrees_t > out_degrees;
     std::size_t degrees_left;
     bool allow_self_loops;
     value_type current;

--- a/include/boost/graph/r_c_shortest_paths.hpp
+++ b/include/boost/graph/r_c_shortest_paths.hpp
@@ -13,8 +13,7 @@
 #include <vector>
 #include <list>
 
-#include <boost/make_shared.hpp>
-#include <boost/enable_shared_from_this.hpp>
+#include <memory>
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/iteration_macros.hpp>
 #include <boost/property_map/property_map.hpp>
@@ -25,15 +24,13 @@ namespace boost
 // r_c_shortest_paths_label struct
 template < class Graph, class Resource_Container >
 struct r_c_shortest_paths_label
-: public boost::enable_shared_from_this<
-      r_c_shortest_paths_label< Graph, Resource_Container > >
 {
     r_c_shortest_paths_label(const unsigned long n,
         const Resource_Container& rc = Resource_Container(),
-        const boost::shared_ptr<
+        const std::shared_ptr<
             r_c_shortest_paths_label< Graph, Resource_Container > >
             pl
-        = boost::shared_ptr<
+        = std::shared_ptr<
             r_c_shortest_paths_label< Graph, Resource_Container > >(),
         const typename graph_traits< Graph >::edge_descriptor& ed
         = graph_traits< Graph >::edge_descriptor(),
@@ -59,7 +56,7 @@ struct r_c_shortest_paths_label
     }
     const unsigned long num;
     Resource_Container cumulated_resource_consumption;
-    const boost::shared_ptr<
+    const std::shared_ptr<
         r_c_shortest_paths_label< Graph, Resource_Container > >
         p_pred_label;
     const typename graph_traits< Graph >::edge_descriptor pred_edge;
@@ -119,48 +116,18 @@ inline bool operator>=(
     return l2 < l1 || l1 == l2;
 }
 
-template < typename Graph, typename Resource_Container >
-inline bool operator<(
-    const boost::shared_ptr<
-        r_c_shortest_paths_label< Graph, Resource_Container > >& t,
-    const boost::shared_ptr<
-        r_c_shortest_paths_label< Graph, Resource_Container > >& u)
-{
-    return *t < *u;
-}
-
-template < typename Graph, typename Resource_Container >
-inline bool operator<=(
-    const boost::shared_ptr<
-        r_c_shortest_paths_label< Graph, Resource_Container > >& t,
-    const boost::shared_ptr<
-        r_c_shortest_paths_label< Graph, Resource_Container > >& u)
-{
-    return *t <= *u;
-}
-
-template < typename Graph, typename Resource_Container >
-inline bool operator>(
-    const boost::shared_ptr<
-        r_c_shortest_paths_label< Graph, Resource_Container > >& t,
-    const boost::shared_ptr<
-        r_c_shortest_paths_label< Graph, Resource_Container > >& u)
-{
-    return *t > *u;
-}
-
-template < typename Graph, typename Resource_Container >
-inline bool operator>=(
-    const boost::shared_ptr<
-        r_c_shortest_paths_label< Graph, Resource_Container > >& t,
-    const boost::shared_ptr<
-        r_c_shortest_paths_label< Graph, Resource_Container > >& u)
-{
-    return *t >= *u;
-}
-
 namespace detail
 {
+
+    // Order by the pointed-to value, not by pointer identity. Works on any
+    // dereferenceable type.
+    template < class Pointer > struct deref_greater
+    {
+        bool operator()(const Pointer& a, const Pointer& b) const
+        {
+            return *a > *b;
+        }
+    };
 
     // r_c_shortest_paths_dispatch function (body/implementation)
     template < class Graph, class VertexIndexMap, class EdgeIndexMap,
@@ -200,18 +167,18 @@ namespace detail
         typedef std::allocator_traits< LAlloc > LTraits;
 #endif
         LAlloc l_alloc;
-        typedef boost::shared_ptr<
+        typedef std::shared_ptr<
             r_c_shortest_paths_label< Graph, Resource_Container > >
             Splabel;
         std::priority_queue< Splabel, std::vector< Splabel >,
-            std::greater< Splabel > >
+            deref_greater< Splabel > >
             unprocessed_labels;
 
         bool b_feasible = true;
-        Splabel splabel_first_label = boost::allocate_shared<
+        Splabel splabel_first_label = std::allocate_shared<
             r_c_shortest_paths_label< Graph, Resource_Container > >(l_alloc,
             i_label_num++, rc,
-            boost::shared_ptr<
+            std::shared_ptr<
                 r_c_shortest_paths_label< Graph, Resource_Container > >(),
             typename graph_traits< Graph >::edge_descriptor(), s);
 
@@ -400,7 +367,7 @@ namespace detail
                      oei != oei_end; ++oei)
                 {
                     b_feasible = true;
-                    Splabel new_label = boost::allocate_shared<
+                    Splabel new_label = std::allocate_shared<
                         r_c_shortest_paths_label< Graph, Resource_Container > >(
                         l_alloc, i_label_num++,
                         cur_label->cumulated_resource_consumption, cur_label,
@@ -433,7 +400,8 @@ namespace detail
         std::list< Splabel > dsplabels = get(vec_vertex_labels, t);
         if(!b_all_pareto_optimal_solutions)
         {
-            dsplabels.sort();
+            dsplabels.sort([](const Splabel& a, const Splabel& b)
+                { return *a < *b; });
         }
         typename std::list< Splabel >::const_iterator csi = dsplabels.begin();
         typename std::list< Splabel >::const_iterator csi_end = dsplabels.end();
@@ -444,7 +412,7 @@ namespace detail
             {
                 std::vector< typename graph_traits< Graph >::edge_descriptor >
                     cur_pareto_optimal_path;
-                boost::shared_ptr<
+                std::shared_ptr<
                     r_c_shortest_paths_label< Graph, Resource_Container > >
                     p_cur_label = *csi;
                 pareto_optimal_resource_containers.push_back(

--- a/include/boost/graph/rmat_graph_generator.hpp
+++ b/include/boost/graph/rmat_graph_generator.hpp
@@ -15,7 +15,7 @@
 #include <vector>
 #include <queue>
 #include <map>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <boost/assert.hpp>
 #include <boost/random/uniform_int.hpp>
 #include <boost/random/uniform_01.hpp>
@@ -25,7 +25,6 @@
 #include <boost/type_traits/is_same.hpp>
 // #include <boost/test/floating_point_comparison.hpp>
 
-using boost::shared_ptr;
 using boost::uniform_01;
 
 // Returns floor(log_2(n)), and -1 when n is 0
@@ -84,7 +83,8 @@ void generate_permutation_vector(
 
 template < typename RandomGenerator, typename T >
 std::pair< T, T > generate_edge(
-    shared_ptr< uniform_01< RandomGenerator > > prob, T n, unsigned int SCALE,
+    std::shared_ptr< uniform_01< RandomGenerator > > prob, T n,
+    unsigned int SCALE,
     double a, double b, double c, double d)
 {
     T u = 0, v = 0;
@@ -233,7 +233,7 @@ public:
 
 private:
     // Parameters
-    shared_ptr< uniform_01< RandomGenerator > > gen;
+    std::shared_ptr< uniform_01< RandomGenerator > > gen;
     vertices_size_type n;
     double a, b, c, d;
     int edge;
@@ -359,7 +359,7 @@ public:
 
 private:
     // Parameters
-    shared_ptr< uniform_01< RandomGenerator > > gen;
+    std::shared_ptr< uniform_01< RandomGenerator > > gen;
     bool permute_vertices;
 
     // Internal data structures
@@ -484,7 +484,7 @@ public:
 
 private:
     // Parameters
-    shared_ptr< uniform_01< RandomGenerator > > gen;
+    std::shared_ptr< uniform_01< RandomGenerator > > gen;
 
     // Internal data structures
     std::vector< value_type > values;
@@ -645,7 +645,7 @@ public:
 
 private:
     // Parameters
-    shared_ptr< uniform_01< RandomGenerator > > gen;
+    std::shared_ptr< uniform_01< RandomGenerator > > gen;
     bool bidirectional;
 
     // Internal data structures

--- a/include/boost/graph/topology.hpp
+++ b/include/boost/graph/topology.hpp
@@ -16,7 +16,7 @@
 #include <cmath>
 #include <boost/random/uniform_01.hpp>
 #include <boost/random/linear_congruential.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <cmath>
 
@@ -302,8 +302,8 @@ public:
     }
 
 private:
-    shared_ptr< RandomNumberGenerator > gen_ptr;
-    shared_ptr< rand_t > rand;
+    std::shared_ptr< RandomNumberGenerator > gen_ptr;
+    std::shared_ptr< rand_t > rand;
     double scaling;
 };
 
@@ -411,8 +411,8 @@ public:
     }
 
 private:
-    shared_ptr< RandomNumberGenerator > gen_ptr;
-    shared_ptr< rand_t > rand;
+    std::shared_ptr< RandomNumberGenerator > gen_ptr;
+    std::shared_ptr< rand_t > rand;
     double left, top, right, bottom;
 };
 
@@ -518,8 +518,8 @@ public:
     }
 
 private:
-    shared_ptr< RandomNumberGenerator > gen_ptr;
-    shared_ptr< rand_t > rand;
+    std::shared_ptr< RandomNumberGenerator > gen_ptr;
+    std::shared_ptr< rand_t > rand;
     double radius;
 };
 
@@ -694,8 +694,8 @@ public:
     }
 
 private:
-    shared_ptr< RandomNumberGenerator > gen_ptr;
-    shared_ptr< rand_t > rand;
+    std::shared_ptr< RandomNumberGenerator > gen_ptr;
+    std::shared_ptr< rand_t > rand;
 };
 
 } // namespace boost

--- a/include/boost/graph/two_bit_color_map.hpp
+++ b/include/boost/graph/two_bit_color_map.hpp
@@ -16,7 +16,7 @@
 #include <boost/property_map/property_map.hpp>
 #include <boost/graph/properties.hpp>
 #include <boost/graph/detail/mpi_include.hpp>
-#include <boost/shared_array.hpp>
+#include <memory>
 #include <boost/config.hpp>
 #include <boost/assert.hpp>
 #include <algorithm>
@@ -45,7 +45,8 @@ template < typename IndexMap = identity_property_map > struct two_bit_color_map
 {
     std::size_t n;
     IndexMap index;
-    shared_array< unsigned char > data;
+    // todo : C++17: replace with std::shared_ptr<T[]>
+    std::shared_ptr< unsigned char > data;
 
     BOOST_STATIC_CONSTANT(
         int, bits_per_char = std::numeric_limits< unsigned char >::digits);
@@ -59,7 +60,8 @@ template < typename IndexMap = identity_property_map > struct two_bit_color_map
         std::size_t n, const IndexMap& index = IndexMap())
     : n(n)
     , index(index)
-    , data(new unsigned char[(n + elements_per_char - 1) / elements_per_char]())
+    , data(new unsigned char[(n + elements_per_char - 1) / elements_per_char](),
+          std::default_delete< unsigned char[] >())
     {
     }
 };


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

General hygiene related to Boost.SmartPtr

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [ ] Bug fix
- [ ] New feature or API addition
- [x] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

<!-- A short summary of the change. -->

- Remove dead includes
- Refactor smart pointers from Boost to STL
- Removed the dead `r_c_shortest_paths_label` base `boost::enable_shared_from_this`. `shared_from_this()` was never called.
- Deleted 4 free comparison operators for `shared_ptr<label>` that dereferenced the pointer to sort (by label). With `std::shared_ptr` those would compete with STL comparison (by pointer).
- Replaced them with comparators dereferencing the pointer: a small `splabel_greater` functor for the `priority_queue`, and a lambda for `list::sort`.

### Motivation

<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->

Boost.SmartPtr does not have heavy dependencies (config, assert, throw_excpetion and core), but dead includes and C++14 STL is proper hygiene: https://github.com/cppalliance/cppalliance.github.io

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->

Unchanged tests in CI

### Checklist

- [x] Existing tests pass (`b2` in the `test/` directory).
- [x] New behavior is covered by a test, or this is a docs / build / refactor change.
- [x] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.
