### PR TITLE
fix: add Jamfile to follow unordered doc infra

### DIFF
--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -1,0 +1,27 @@
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+import path ;
+
+make html_ : build_antora.sh : @run-script ;
+
+actions run-script
+{
+    bash $(>)
+}
+
+path-constant DOC_DIR : . ;
+.node_modules = [ path.join $(DOC_DIR) node_modules ] ;
+
+make cleanup_node_modules_ : html_ : @cleanup-node-modules ;
+
+actions cleanup-node-modules
+{
+    rm -rf $(.node_modules)
+}
+
+###############################################################################
+alias boostdoc ;
+explicit boostdoc ;
+alias boostrelease : html_ cleanup_node_modules_ ;
+explicit boostrelease ;


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [x] Bug fix
- [ ] New feature or API addition
- [ ] Refactor (no behavior change)
- [x] Documentation
- [x] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

<!-- A short summary of the change. -->

Follow unordered documentation infra pattern for doc building.

### Motivation

<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->

Current documentation does not render in 1.92 beta.

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->

### Checklist

- [x] Existing tests pass (`b2` in the `test/` directory).
- [x] New behavior is covered by a test, or this is a docs / build / refactor change.
- [x] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.
