### PR TITLE
Fix \param tags in mcr_howard and put_property

### DIFF
--- a/include/boost/graph/howard_cycle_ratio.hpp
+++ b/include/boost/graph/howard_cycle_ratio.hpp
@@ -141,11 +141,9 @@ namespace detail
          * Constructor
          * \param g = (V, E) - a directed multigraph.
          * \param vim  Vertex Index Map. Read property Map: V -> [0,
-         * num_vertices(g)). \param ewm  edge weight map. Read property map: E
-         * -> R \param ew2m  edge weight map. Read property map: E -> R+ \param
-         * infty A big enough value to guaranty that there exist a cycle with
-         *  better ratio.
-         * \param cmp The compare operator for float_ts.
+         *  num_vertices(g)).
+         * \param ewm  edge weight map. Read property map: E -> R
+         * \param ew2m  edge weight map. Read property map: E -> R+
          */
         mcr_howard(const Graph& g, VertexIndexMap vim, EdgeWeight1 ewm,
             EdgeWeight2 ew2m)

--- a/include/boost/graph/visitors.hpp
+++ b/include/boost/graph/visitors.hpp
@@ -395,9 +395,11 @@ private:
  * Creates a property_put functor which just sets a given value to a vertex or
  * edge.
  *
+ * The third argument is an unnamed event filter tag, used only to select the
+ * event the returned functor responds to.
+ *
  * @param property_map Given writeable property map
  * @param value Fixed value of the map
- * @param tag Event Filter
  * @return The functor.
  */
 


### PR DESCRIPTION
Two Doxygen comments where the tags do not line up with the code. Documentation only, no code touched.

### `mcr_howard`, `howard_cycle_ratio.hpp`

Two separate problems in one comment.

Three `\param` tags are written mid-line, after the text of the previous parameter:

```
 * \param vim  Vertex Index Map. Read property Map: V -> [0,
 * num_vertices(g)). \param ewm  edge weight map. Read property map: E
 * -> R \param ew2m  edge weight map. Read property map: E -> R+ \param
 * infty A big enough value ...
```

Doxygen only recognises a command at the start of a line, so `ewm` and `ew2m` are currently read as prose belonging to `vim`, and the two parameters come out undocumented. Looks like a reflow that ran over the tags at some point.

The other half: `infty` and `cmp` are documented, but the constructor does not take them. It takes `(g, vim, ewm, ew2m)`, and `grep` finds no other `mcr_howard(` in the file. `m_cmp` exists as a member and is default-constructed, so the comment may date from a version that took a comparator; `infty` does not appear anywhere in the file outside this comment.

I removed those two and put each remaining tag on its own line.

### `put_property`, `visitors.hpp`

```
 * @param tag Event Filter
...
inline property_put< PropertyMap, EventTag > put_property(
    PropertyMap property_map,
    typename property_traits< PropertyMap >::value_type value, EventTag)
```

The third argument has no name, and Doxygen cannot attach a `@param` to an unnamed parameter. Naming it would document the tag but goes against what the rest of the file does (every `EventTag` argument in `visitors.hpp` is unnamed), so I moved the explanation into the description instead and left the signature alone.

Both are what `clang -Wdocumentation` reports as `parameter '...' not found in the function declaration`.

I can split this into two pull requests if you would rather review them separately.
