### PR TITLE
fix: remove unused arguments

### DIFF
--- a/example/astar-cities.cpp
+++ b/example/astar-cities.cpp
@@ -116,7 +116,7 @@ private:
     Vertex m_goal;
 };
 
-int main(int argc, char** argv)
+int main()
 {
 
     // specify some types

--- a/example/bipartite_example.cpp
+++ b/example/bipartite_example.cpp
@@ -74,7 +74,7 @@ template < typename Graph > void print_bipartite(const Graph& g)
     }
 }
 
-int main(int argc, char** argv)
+int main()
 {
     using vector_graph_t = adjacency_list< vecS, vecS, undirectedS >;
     using E = std::pair< int, int >;

--- a/example/bron_kerbosch_clique_number.cpp
+++ b/example/bron_kerbosch_clique_number.cpp
@@ -22,7 +22,7 @@ using Graph = undirected_graph<>;
 using Vertex = graph_traits< Graph >::vertex_descriptor;
 using Edge = graph_traits< Graph >::edge_descriptor;
 
-int main(int argc, char* argv[])
+int main()
 {
     // Create the graph and read it from standard input.
     Graph g;

--- a/example/bron_kerbosch_print_cliques.cpp
+++ b/example/bron_kerbosch_print_cliques.cpp
@@ -50,7 +50,7 @@ using Edge = graph_traits< Graph >::edge_descriptor;
 // each vertex. This is used during graph creation.
 using NameMap = property_map< Graph, string Actor::* >::type;
 
-int main(int argc, char* argv[])
+int main()
 {
     // Create the graph and and its name map accessor.
     Graph g;

--- a/example/canonical_ordering.cpp
+++ b/example/canonical_ordering.cpp
@@ -18,7 +18,7 @@
 
 using namespace boost;
 
-int main(int argc, char** argv)
+int main()
 {
 
     using graph = adjacency_list< vecS, vecS, undirectedS,

--- a/example/closeness_centrality.cpp
+++ b/example/closeness_centrality.cpp
@@ -49,7 +49,7 @@ using ClosenessProperty = boost::exterior_vertex_property< Graph, float >;
 using ClosenessContainer = ClosenessProperty::container_type;
 using ClosenessMap = ClosenessProperty::map_type;
 
-int main(int argc, char* argv[])
+int main()
 {
     // Create the graph and a property map that provides access to[
     // tha actor names.

--- a/example/clustering_coefficient.cpp
+++ b/example/clustering_coefficient.cpp
@@ -37,7 +37,7 @@ using ClusteringProperty = exterior_vertex_property< Graph, float >;
 using ClusteringContainer = ClusteringProperty::container_type;
 using ClusteringMap = ClusteringProperty::map_type;
 
-int main(int argc, char* argv[])
+int main()
 {
     // Create the graph and a name map that provides access to
     // then actor names.

--- a/example/cycle_ratio_example.cpp
+++ b/example/cycle_ratio_example.cpp
@@ -38,7 +38,7 @@ template < typename TG > void gen_rand_graph(TG& g, size_t nV, size_t nE)
     randomize_property< edge_weight2_t >(g, ew2rg);
 }
 
-int main(int argc, char* argv[])
+int main()
 {
     using std::cout;
     using std::endl;

--- a/example/degree_centrality.cpp
+++ b/example/degree_centrality.cpp
@@ -38,7 +38,7 @@ using CentralityProperty = exterior_vertex_property< Graph, unsigned >;
 using CentralityContainer = CentralityProperty::container_type;
 using CentralityMap = CentralityProperty::map_type;
 
-int main(int argc, char* argv[])
+int main()
 {
     // Create the graph and a property map that provides access
     // to the actor names.

--- a/example/eccentricity.cpp
+++ b/example/eccentricity.cpp
@@ -48,7 +48,7 @@ using EccentricityProperty = boost::exterior_vertex_property< Graph, int >;
 using EccentricityContainer = EccentricityProperty::container_type;
 using EccentricityMap = EccentricityProperty::map_type;
 
-int main(int argc, char* argv[])
+int main()
 {
     // Create the graph and a name map that provides access to
     // then actor names.

--- a/example/grid_graph_example.cpp
+++ b/example/grid_graph_example.cpp
@@ -24,7 +24,7 @@ void print_vertex(Traits::vertex_descriptor vertex_to_print)
               << vertex_to_print[2] << ")" << std::endl;
 }
 
-int main(int argc, char* argv[])
+int main()
 {
 
     // Define a 3x5x7 grid_graph where the second dimension doesn't wrap

--- a/example/grid_graph_properties.cpp
+++ b/example/grid_graph_properties.cpp
@@ -11,7 +11,7 @@
 #include <boost/array.hpp>
 #include <boost/graph/grid_graph.hpp>
 
-int main(int argc, char* argv[])
+int main()
 {
     // A 2D grid graph
     using GraphType = boost::grid_graph< 2 >;

--- a/example/inclusive_mean_geodesic.cpp
+++ b/example/inclusive_mean_geodesic.cpp
@@ -84,7 +84,7 @@ using GeodesicMap = GeodesicProperty::map_type;
 static float exclusive_geodesics(const Graph&, DistanceMatrixMap, GeodesicMap);
 static float inclusive_geodesics(const Graph&, DistanceMatrixMap, GeodesicMap);
 
-int main(int argc, char* argv[])
+int main()
 {
     // Create the graph, a name map that providse abstract access
     // to the web page names, and the weight map as an accessor to

--- a/example/incremental-components-eg.cpp
+++ b/example/incremental-components-eg.cpp
@@ -18,7 +18,7 @@
 
 using namespace boost;
 
-int main(int argc, char* argv[])
+int main()
 {
     using Graph = adjacency_list< vecS, vecS, undirectedS >;
     using Vertex = graph_traits< Graph >::vertex_descriptor;

--- a/example/incremental_components.cpp
+++ b/example/incremental_components.cpp
@@ -47,7 +47,7 @@
 
 using namespace boost;
 
-int main(int argc, char* argv[])
+int main()
 {
     using Graph = adjacency_list< vecS, vecS, undirectedS >;
     using Vertex = graph_traits< Graph >::vertex_descriptor;

--- a/example/influence_prestige.cpp
+++ b/example/influence_prestige.cpp
@@ -39,7 +39,7 @@ using CentralityProperty = exterior_vertex_property< Graph, unsigned >;
 using CentralityContainer = CentralityProperty::container_type;
 using CentralityMap = CentralityProperty::map_type;
 
-int main(int argc, char* argv[])
+int main()
 {
     // Create the graph and a property map that provides
     // access to the actor names.

--- a/example/kuratowski_subgraph.cpp
+++ b/example/kuratowski_subgraph.cpp
@@ -18,7 +18,7 @@
 
 using namespace boost;
 
-int main(int argc, char** argv)
+int main()
 {
 
     using graph = adjacency_list< vecS, vecS, undirectedS,

--- a/example/make_biconnected_planar.cpp
+++ b/example/make_biconnected_planar.cpp
@@ -19,7 +19,7 @@
 
 using namespace boost;
 
-int main(int argc, char** argv)
+int main()
 {
 
     using graph = adjacency_list< vecS, vecS, undirectedS,

--- a/example/make_connected.cpp
+++ b/example/make_connected.cpp
@@ -17,7 +17,7 @@
 
 using namespace boost;
 
-int main(int argc, char** argv)
+int main()
 {
 
     using graph = adjacency_list< vecS, vecS, undirectedS,

--- a/example/make_maximal_planar.cpp
+++ b/example/make_maximal_planar.cpp
@@ -34,7 +34,7 @@ struct face_counter : public planar_face_traversal_visitor
     int count;
 };
 
-int main(int argc, char** argv)
+int main()
 {
 
     using graph = adjacency_list< vecS, vecS, undirectedS,

--- a/example/mcgregor_subgraphs_example.cpp
+++ b/example/mcgregor_subgraphs_example.cpp
@@ -71,7 +71,7 @@ private:
     VertexSizeFirst m_max_subgraph_size;
 };
 
-int main(int argc, char* argv[])
+int main()
 {
 
     // Using a vecS graph here so that we don't have to mess around with

--- a/example/mean_geodesic.cpp
+++ b/example/mean_geodesic.cpp
@@ -48,7 +48,7 @@ using GeodesicProperty = exterior_vertex_property< Graph, float >;
 using GeodesicContainer = GeodesicProperty::container_type;
 using GeodesicMap = GeodesicProperty::map_type;
 
-int main(int argc, char* argv[])
+int main()
 {
     // Create the graph and a property map that provides access
     // to the actor names.

--- a/example/planar_face_traversal.cpp
+++ b/example/planar_face_traversal.cpp
@@ -40,7 +40,7 @@ struct edge_output_visitor : public output_visitor
     template < typename Edge > void next_edge(Edge e) { std::cout << e << " "; }
 };
 
-int main(int argc, char** argv)
+int main()
 {
 
     using graph = adjacency_list< vecS, vecS, undirectedS,

--- a/example/scaled_closeness_centrality.cpp
+++ b/example/scaled_closeness_centrality.cpp
@@ -75,7 +75,7 @@ using ClosenessProperty = boost::exterior_vertex_property< Graph, float >;
 using ClosenessContainer = ClosenessProperty::container_type;
 using ClosenessMap = ClosenessProperty::map_type;
 
-int main(int argc, char* argv[])
+int main()
 {
     // Create the graph and a property map that provides access
     // to the actor names.

--- a/example/simple_planarity_test.cpp
+++ b/example/simple_planarity_test.cpp
@@ -9,7 +9,7 @@
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/boyer_myrvold_planar_test.hpp>
 
-int main(int argc, char** argv)
+int main()
 {
 
     // This program illustrates a simple use of boyer_myrvold_planar_embedding

--- a/example/straight_line_drawing.cpp
+++ b/example/straight_line_drawing.cpp
@@ -26,7 +26,7 @@ struct coord_t
     std::size_t y;
 };
 
-int main(int argc, char** argv)
+int main()
 {
     using graph = adjacency_list< vecS, vecS, undirectedS,
         property< vertex_index_t, int > >;

--- a/example/tiernan_girth_circumference.cpp
+++ b/example/tiernan_girth_circumference.cpp
@@ -20,7 +20,7 @@ using Graph = directed_graph<>;
 using Vertex = graph_traits< Graph >::vertex_descriptor;
 using Edge = graph_traits< Graph >::edge_descriptor;
 
-int main(int argc, char* argv[])
+int main()
 {
     // Create the graph and read it from standard input.
     Graph g;

--- a/example/tiernan_print_cycles.cpp
+++ b/example/tiernan_print_cycles.cpp
@@ -46,7 +46,7 @@ using Graph = directed_graph<>;
 using Vertex = graph_traits< Graph >::vertex_descriptor;
 using Edge = graph_traits< Graph >::edge_descriptor;
 
-int main(int argc, char* argv[])
+int main()
 {
     // Create the graph and read it from standard input.
     Graph g;

--- a/example/two_graphs_common_spanning_trees.cpp
+++ b/example/two_graphs_common_spanning_trees.cpp
@@ -32,7 +32,7 @@ using vertex_iterator = boost::graph_traits< Graph >::vertex_iterator;
 
 using edge_iterator = boost::graph_traits< Graph >::edge_iterator;
 
-int main(int argc, char** argv)
+int main()
 {
     Graph iG, vG;
     vector< edge_descriptor > iG_o = { boost::add_edge(0, 1, iG).first,

--- a/example/weighted_matching_example.cpp
+++ b/example/weighted_matching_example.cpp
@@ -20,7 +20,7 @@ using EdgeProperty
 using my_graph
     = adjacency_list< vecS, vecS, undirectedS, no_property, EdgeProperty >;
 
-int main(int argc, const char* argv[])
+int main()
 {
     graph_traits< my_graph >::vertex_iterator vi, vi_end;
     const int n_vertices = 18;

--- a/test/bipartite_test.cpp
+++ b/test/bipartite_test.cpp
@@ -113,7 +113,7 @@ void check_bipartite(const Graph& g, IndexMap index_map, bool is_bipartite)
     }
 }
 
-int main(int argc, char** argv)
+int main()
 {
     typedef boost::adjacency_list< boost::vecS, boost::vecS,
         boost::undirectedS >

--- a/test/delete_edge.cpp
+++ b/test/delete_edge.cpp
@@ -14,7 +14,7 @@
 
 #include <boost/core/lightweight_test.hpp>
 
-int main(int argc, char* argv[])
+int main()
 {
     typedef int Vertex;
     typedef int Edge;

--- a/test/generator_test.cpp
+++ b/test/generator_test.cpp
@@ -20,7 +20,7 @@
 
 using namespace boost;
 
-int main(int argc, char** argv)
+int main()
 {
 
     typedef rand48 RandomGenerator;

--- a/test/graphml_test.cpp
+++ b/test/graphml_test.cpp
@@ -36,7 +36,7 @@
 using namespace std;
 using namespace boost;
 
-int main(int argc, char** argv)
+int main(int, char** argv)
 {
     typedef adjacency_list< vecS, vecS, directedS,
         property< vertex_color_t, int, property< vertex_name_t, string > >,

--- a/test/min_degree_empty.cpp
+++ b/test/min_degree_empty.cpp
@@ -16,7 +16,7 @@
 
 typedef boost::adjacency_list< boost::vecS, boost::vecS, boost::directedS > G;
 
-int main(int argc, char** argv)
+int main()
 {
     size_t n = 10;
     G g(n);

--- a/test/subgraph_props.cpp
+++ b/test/subgraph_props.cpp
@@ -124,7 +124,7 @@ struct TestBundles
     }
 };
 
-int main(int argc, char* argv[])
+int main()
 {
     TestProps::run();
     TestBundles::run();

--- a/test/two_graphs_common_spanning_trees_test.cpp
+++ b/test/two_graphs_common_spanning_trees_test.cpp
@@ -100,7 +100,7 @@ void two_graphs_common_spanning_trees_test()
 
 }
 
-int main(int argc, char** argv)
+int main()
 {
     boost::two_graphs_common_spanning_trees_test();
     return boost::report_errors();

--- a/test/vf2_sub_graph_iso_test_2.cpp
+++ b/test/vf2_sub_graph_iso_test_2.cpp
@@ -201,7 +201,7 @@ BOOST_TEST(!got_hit);
 }
 }
 
-int main(int argc, char* argv[])
+int main()
 {
     test_empty_graph_cases();
     test_return_value();


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

#496 

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [x] Bug fix
- [ ] New feature or API addition
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

<!-- A short summary of the change. -->

Numerous examples and test files `int main(` have unused arguments. 

### Motivation

<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->

Way too many warnings with `-Wextra -Wall`

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->

### Checklist

- [x] Existing tests pass (`b2` in the `test/` directory).
- [x] New behavior is covered by a test, or this is a docs / build / refactor change.
- [x] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.
