### PR TITLE
fix: fields initialized

### DIFF
--- a/test/graphviz_test.cpp
+++ b/test/graphviz_test.cpp
@@ -30,10 +30,10 @@ typedef std::map< edge_t, Weight > expected_weights_t;
 
 struct Fixture
 {
-    std::string graphviz_text;
-    size_t correct_num_vertices;
-    expected_masses_t masses;
-    expected_weights_t weights;
+    std::string graphviz_text = {};
+    size_t correct_num_vertices = 0;
+    expected_masses_t masses = {};
+    expected_weights_t weights = {};
 };
 
 namespace Samples


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

#496 

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [x] Bug fix
- [ ] New feature or API addition
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

<!-- A short summary of the change. -->

Initalize fields to solve multiple `-Wmissing-field-initializers`

### Motivation

<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->

### Checklist

- [x] Existing tests pass (`b2` in the `test/` directory).
- [x] New behavior is covered by a test, or this is a docs / build / refactor change.
- [x] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.
