### PR TITLE
test: `random_matching_test.cpp` modernized, made self-contained and assertive

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -159,7 +159,7 @@ alias graph_test_regular :
     [ run incremental_components_test.cpp ]
     [ run two_graphs_common_spanning_trees_test.cpp ]
     [ run random_spanning_tree_test.cpp /boost/graph//boost_graph ]
-    [ run random_matching_test.cpp : 1000 1020 ]
+    [ run random_matching_test.cpp ]
     [ run graphml_test.cpp /boost/graph//boost_graph : : "graphml_test.xml" ]
     [ run mas_test.cpp : $(TEST_DIR) ]
     [ run stoer_wagner_test.cpp : $(TEST_DIR) ]

--- a/test/random_matching_test.cpp
+++ b/test/random_matching_test.cpp
@@ -1,64 +1,46 @@
 //=======================================================================
 // Copyright (c) 2005 Aaron Windsor
+// Copyright (c) 2026 Arnaud Becheler
 //
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 //
 //=======================================================================
-#include <cstdlib>
 #include <iostream>
+#include <random>
 #include <boost/property_map/vector_property_map.hpp>
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/random.hpp>
-#include <boost/random.hpp>
 
 #include <boost/graph/max_cardinality_matching.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 using namespace boost;
 
-typedef adjacency_list< vecS, vecS, undirectedS,
-    property< vertex_index_t, int > >
-    undirected_graph;
+using undirected_graph = adjacency_list< vecS, vecS, undirectedS, property< vertex_index_t, int > >;
+using vertex_index_map_t = property_map< undirected_graph, vertex_index_t >::type;
+using mate_t = vector_property_map< graph_traits< undirected_graph >::vertex_descriptor, vertex_index_map_t >;
+using vertex_iterator_t = graph_traits< undirected_graph >::vertex_iterator;
+using vertex_descriptor_t = graph_traits< undirected_graph >::vertex_descriptor;
+using v_size_t = graph_traits< undirected_graph >::vertices_size_type;
 
-typedef property_map< undirected_graph, vertex_index_t >::type
-    vertex_index_map_t;
-typedef vector_property_map<
-    graph_traits< undirected_graph >::vertex_descriptor, vertex_index_map_t >
-    mate_t;
-typedef graph_traits< undirected_graph >::vertex_iterator vertex_iterator_t;
-typedef graph_traits< undirected_graph >::vertex_descriptor vertex_descriptor_t;
-typedef graph_traits< undirected_graph >::vertices_size_type v_size_t;
-
-int main(int argc, char** argv)
+int main()
 {
-    if (argc < 3)
-    {
-        std::cout << "Usage: " << argv[0] << " n m" << std::endl
-                  << "Tests the checked matching on a random graph w/ n "
-                     "vertices and m edges"
-                  << std::endl;
-        exit(-1);
-    }
-
-    int n = atoi(argv[1]);
-    int m = atoi(argv[2]);
-
+    // Test the checked matching on a random graph with n vertices and m edges.
+    constexpr int n = 1000;
+    constexpr int m = 1020;
+    
     undirected_graph g(n);
-
-    typedef boost::mt19937 base_generator_type;
-    base_generator_type generator(42);
-    boost::uniform_int<> distribution(0, n - 1);
-    boost::variate_generator< base_generator_type&, boost::uniform_int<> >
-        rand_num(generator, distribution);
+    std::mt19937 generator(42);
 
     int num_edges = 0;
     bool success;
 
     while (num_edges < m)
     {
-        vertex_descriptor_t u = random_vertex(g, rand_num);
-        vertex_descriptor_t v = random_vertex(g, rand_num);
+        vertex_descriptor_t u = random_vertex(g, generator);
+        vertex_descriptor_t v = random_vertex(g, generator);
         if (u != v)
         {
             if (!edge(u, v, g).second)
@@ -72,15 +54,12 @@ int main(int argc, char** argv)
     }
 
     mate_t mate(n);
-    bool random_graph_result
-        = checked_edmonds_maximum_cardinality_matching(g, mate);
+    bool random_graph_result = checked_edmonds_maximum_cardinality_matching(g, mate);
 
     if (!random_graph_result)
     {
-        std::cout << "TEST 1 FAILED!!!" << std::endl << std::endl;
-
         std::cout << "Graph has edges: ";
-        typedef graph_traits< undirected_graph >::edge_iterator edge_iterator_t;
+        using edge_iterator_t = graph_traits< undirected_graph >::edge_iterator;
         edge_iterator_t ei, ei_end;
         for (boost::tie(ei, ei_end) = edges(g); ei != ei_end; ++ei)
             std::cout << *ei << ", ";
@@ -94,6 +73,7 @@ int main(int argc, char** argv)
                 std::cout << "{" << *vi << "," << mate[*vi] << "}, ";
         std::cout << std::endl;
     }
+    BOOST_TEST(random_graph_result);
 
     // Now remove an edge from the random_mate matching.
     vertex_iterator_t vi, vi_end;
@@ -104,27 +84,25 @@ int main(int argc, char** argv)
     mate[mate[*vi]] = graph_traits< undirected_graph >::null_vertex();
     mate[*vi] = graph_traits< undirected_graph >::null_vertex();
 
-    //...and run the matching verifier - it should tell us that the matching
-    // isn't a maximum matching.
+    // the verifier should report this modified matching isn't maximum
     bool modified_random_verification_result
         = maximum_cardinality_matching_verifier< undirected_graph, mate_t,
             vertex_index_map_t >::verify_matching(g, mate,
             get(vertex_index, g));
 
-    if (modified_random_verification_result)
-    {
-        std::cout << "TEST 2 FAILED!!!" << std::endl;
-    }
+    BOOST_TEST(!modified_random_verification_result);
 
     // find a greedy matching on the graph
     mate_t greedy_mate(n);
     greedy_matching< undirected_graph, mate_t >::find_matching(g, greedy_mate);
 
-    if (matching_size(g, mate) > matching_size(g, greedy_mate)
+    // a verified maximum greedy matching can't be smaller than mate
+    bool greedy_contradicts_verifier
+        = matching_size(g, mate) > matching_size(g, greedy_mate)
         && maximum_cardinality_matching_verifier< undirected_graph, mate_t,
             vertex_index_map_t >::verify_matching(g, greedy_mate,
-            get(vertex_index, g)))
-        std::cout << "TEST 3 FAILED!!!" << std::endl;
+            get(vertex_index, g));
+    BOOST_TEST(!greedy_contradicts_verifier);
 
-    return 0;
+    return boost::report_errors();
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

Code coverage is very unstable, I am fixing unit tests, and many are not asserting much and only printing to cout, which is never checked: failed test still show as PASS.

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [x] Bug fix
- [ ] New feature or API addition
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

<!-- A short summary of the change. -->

- test now fails the build, not just stdout
- self-contained: hardcoded `n`/`m` as constexpr, dropped `argc`/`argv` + usage message; removed args from Jamfile.
- standard RNG: just use bare std::mt19937.
- Modernized typedefs
- Trimmed comments to single-line

### Motivation

<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->

Our coverage is not great, code coverage flickers in CI

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->

### Checklist

- [x] Existing tests pass (`b2` in the `test/` directory).
- [x] New behavior is covered by a test, or this is a docs / build / refactor change.
- [x] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.
