### PR TITLE
fix: codecov comment for PR only: patch mode

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,15 +6,16 @@
 
 codecov:
   max_report_age: off
-  require_ci_to_pass: yes
+  require_ci_to_pass: no
   notify:
-    # Increase this if you have multiple coverage collection jobs
-    after_n_builds: 1
-    wait_for_ci: yes
+    # posix + windows coverage jobs both upload, so wait for both
+    after_n_builds: 2
+    wait_for_ci: no
 
 # Change how pull request comments look
 comment:
-  layout: "reach,diff,flags,files,footer"
+  layout: "condensed_header, condensed_files, condensed_footer"
+  hide_project_coverage: true
 
 # Ignore specific files or folders. Glob patterns are supported.
 # See https://docs.codecov.com/docs/ignoring-paths


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [ ] Bug fix
- [ ] New feature or API addition
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [x] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

<!-- A short summary of the change. -->

Enable patch mode for code coverage reports: https://docs.codecov.com/docs/changing-your-pr-comment-format

### Motivation

<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->

Current comments are noisy.

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->

### Checklist

- [x] Existing tests pass (`b2` in the `test/` directory).
- [x] New behavior is covered by a test, or this is a docs / build / refactor change.
- [x] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.
