### PR TITLE
fix: codecov report informational only for project, gated on PR

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,6 +12,17 @@ codecov:
     after_n_builds: 2
     wait_for_ci: no
 
+# project = whole-codebase %; report it but never let it gate a merge.
+# patch = coverage of the lines this PR changed; that stays the real gate.
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        target: 100%
+
 # Change how pull request comments look
 comment:
   layout: "condensed_header, condensed_files, condensed_footer"


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [ ] Bug fix
- [ ] New feature or API addition
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [x] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [ ] No

### What this PR does

<!-- A short summary of the change. -->

### Motivation

<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->

Trying to adjust the gating behavior of codecov CI checks. It's frustrating that a check fails if the project randomely shows a -0.03% change in coverage ... 

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->

### Checklist

- [x] Existing tests pass (`b2` in the `test/` directory).
- [x] New behavior is covered by a test, or this is a docs / build / refactor change.
- [x] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.
