### PR TITLE
fix: remove xpressive dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,6 @@ target_link_libraries(boost_graph
     Boost::type_traits
     Boost::unordered
     Boost::utility
-    Boost::xpressive
   PRIVATE
     Boost::regex
 )

--- a/build.jam
+++ b/build.jam
@@ -37,8 +37,7 @@ constant boost_dependencies :
     /boost/tuple//boost_tuple
     /boost/type_traits//boost_type_traits
     /boost/unordered//boost_unordered
-    /boost/utility//boost_utility
-    /boost/xpressive//boost_xpressive ;
+    /boost/utility//boost_utility ;
 
 project /boost/graph
     ;

--- a/include/boost/graph/graphviz.hpp
+++ b/include/boost/graph/graphviz.hpp
@@ -33,7 +33,6 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/static_assert.hpp>
 #include <boost/algorithm/string/replace.hpp>
-#include <boost/xpressive/xpressive_static.hpp>
 
 namespace boost
 {
@@ -56,13 +55,60 @@ struct default_writer
     template < class VorE > void operator()(std::ostream&, const VorE&) const {}
 };
 
+namespace detail
+{
+
+    inline bool dot_id_is_alpha(char c)
+    {
+        return c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+    }
+
+    inline bool dot_id_is_digit(char c) { return c >= '0' && c <= '9'; }
+
+    inline bool dot_id_is_word(char c)
+    {
+        return dot_id_is_alpha(c) || dot_id_is_digit(c);
+    }
+
+    // True when s matches the DOT grammar for an ID that needs no quoting:
+    //   identifier  [A-Za-z_][A-Za-z0-9_]*
+    //   numeral     -?( .[0-9]* | [0-9]+(.[0-9]*)? )
+    inline bool is_dot_unquoted_id(const std::string& s)
+    {
+        using size_type = std::string::size_type;
+        if (s.empty())
+            return false;
+        if (dot_id_is_alpha(s[0]))
+        {
+            for (size_type i = 1; i < s.size(); ++i)
+                if (!dot_id_is_word(s[i]))
+                    return false;
+            return true;
+        }
+        size_type i = 0;
+        if (s[i] == '-')
+            ++i;
+        if (i >= s.size())
+            return false;
+        if (s[i] != '.' && !dot_id_is_digit(s[i]))
+            return false;
+        if (dot_id_is_digit(s[i]))
+            while (i < s.size() && dot_id_is_digit(s[i]))
+                ++i;
+        if (i < s.size() && s[i] == '.')
+            ++i;
+        for (; i < s.size(); ++i)
+            if (!dot_id_is_digit(s[i]))
+                return false;
+        return true;
+    }
+
+} // namespace detail
+
 template < typename T > inline std::string escape_dot_string(const T& obj)
 {
-    using namespace boost::xpressive;
-    static sregex valid_unquoted_id = (((alpha | '_') >> *_w)
-        | (!as_xpr('-') >> (('.' >> *_d) | (+_d >> !('.' >> *_d)))));
     std::string s(boost::lexical_cast< std::string >(obj));
-    if (regex_match(s, valid_unquoted_id))
+    if (detail::is_dot_unquoted_id(s))
     {
         return s;
     }


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

#496 

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [ ] Bug fix
- [ ] New feature or API addition
- [x] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

<!-- A short summary of the change. -->

- drop dependency to Boost.Xpressive, that pulls in 34 dependency for a simple string predicate ( https://alandefreitas.github.io/boostdep_graph/libs/xpressive.html )
- removing this 1 line using xpressive  removes ~54% of warnings for gcc/clang.
- #567 brought round-trip test for graphviz to develop so we gard against regressions.

### Motivation

<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->

Too many warnings come from xpressive and its dependencies proto and fusion.

Context:

DOT is the plain-text graph language Graphviz uses, the format that `write_graphviz` produces and `read_graphviz` parses (for example, `digraph { a -> b [label="hello world"] }`). In that text, every name and value is a token the grammar calls an ID: node names like `a`, attribute names like `label`, and attribute values like `"hello world"`. The grammar allows an ID in four forms:

- An identifier-like name: a letter or underscore followed by letters, digits, or underscores (`foo`, `node_1`, `_x`).
- A numeral: `42`, `-3.14`, `.5`.
- A double-quoted string: `"hello world"`, `"has \"quotes\""`. This form can hold any characters, with `\"` for an embedded quote.
- An HTML string (`<...>`), not relevant here.

The first two forms may be written bare. Anything that is not a valid bare name or numeral (it contains a space, punctuation, or a quote, starts with a digit and then has letters like `9lives`, has two dots like `1.2.3`, or is empty) must use the quoted form, or the parser breaks. Deciding which case a value falls into is exactly the job of `escape_dot_string`.

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->

Naive -O2 benchmark on a small corpus (https://godbolt.org/z/4MP8T95h8):

- boost::regex ~91× slower than the hand-rolled predicate
- std::regex ~47× slower
- plus a one-time ~6–17 µs construction the hand-rolled version skips entirely

escape_dot_string runs once per written value (node id + every vertex/edge/graph attribute), so this constant factor just multiplies with graph size: on a large, attribute-heavy graph it's the same 50–90× penalty applied many times over. I haven't measured that end-to-end, but it can't be a good sign.

### Checklist

- [x] Existing tests pass (`b2` in the `test/` directory).
- [x] New behavior is covered by a test, or this is a docs / build / refactor change.
- [x] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.
