### PR TITLE
test: increase coverage in graphviz round trip test

### DIFF
--- a/test/graphviz_round_trip_test.cpp
+++ b/test/graphviz_round_trip_test.cpp
@@ -36,11 +36,12 @@ using graph_t = boost::adjacency_list< boost::vecS, boost::vecS,
     boost::directedS, vertex_props, edge_props >;
 
 // First four are valid unquoted DOT ids/numerals
-// the rest force quoting or escaping (space, embedded quote, digit-led identifier, multi-dot numeral).
+// the rest force quoting or escaping: space, embedded quote, digit-led
+// identifier, multi-dot numeral, a lone dash, and a leading non-id character.
 const std::vector< std::string >& boundary_labels()
 {
     static const std::vector< std::string > labels = { "plain", "id_123", "42",
-        "-3.14", "has space", "has\"quote", "9lives", "1.2.3" };
+        "-3.14", "has space", "has\"quote", "9lives", "1.2.3", "-", "@home" };
     return labels;
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [ ] Bug fix
- [ ] New feature or API addition
- [x] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

<!-- A short summary of the change. -->

Better case coverage.

### Motivation

<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->

#566 had uncovered lines.

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->

### Checklist

- [x] Existing tests pass (`b2` in the `test/` directory).
- [x] New behavior is covered by a test, or this is a docs / build / refactor change.
- [x] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.
