### PR TITLE
refactor: drops boost::multiprecision for boost::int128

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ target_link_libraries(boost_graph
     Boost::mp11
     Boost::mpl
     Boost::multi_index
-    Boost::multiprecision
+    Boost::int128
     Boost::optional
     Boost::parameter
     Boost::preprocessor

--- a/build.jam
+++ b/build.jam
@@ -22,7 +22,7 @@ constant boost_dependencies :
     /boost/mp11//boost_mp11
     /boost/mpl//boost_mpl
     /boost/multi_index//boost_multi_index
-    /boost/multiprecision//boost_multiprecision
+    /boost/int128//boost_int128
     /boost/optional//boost_optional
     /boost/parameter//boost_parameter
     /boost/preprocessor//boost_preprocessor

--- a/include/boost/graph/is_straight_line_drawing.hpp
+++ b/include/boost/graph/is_straight_line_drawing.hpp
@@ -15,7 +15,7 @@
 #include <boost/property_map/property_map.hpp>
 #include <boost/graph/properties.hpp>
 #include <boost/graph/planar_detail/bucket_sort.hpp>
-#include <boost/multiprecision/cpp_int.hpp>
+#include <boost/int128.hpp>
 
 #include <algorithm>
 #include <vector>
@@ -54,7 +54,7 @@ bool crosses(typename graph_traits<Graph>::edge_descriptor e,
     const auto& q1 = drawing[source(f, g)];
     const auto& q2 = drawing[target(f, g)];
 
-    using boost::multiprecision::int128_t;
+    using int128_t = boost::int128::int128;
     int o1 = orientation2d<int128_t>(p1.x, p1.y, p2.x, p2.y, q1.x, q1.y);
     int o2 = orientation2d<int128_t>(p1.x, p1.y, p2.x, p2.y, q2.x, q2.y);
     int o3 = orientation2d<int128_t>(q1.x, q1.y, q2.x, q2.y, p1.x, p1.y);


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [ ] Bug fix
- [ ] New feature or API addition
- [x] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

<!-- A short summary of the change. -->

Replace Boost.Multiprecision (25 dependencies) int128 with Boost.Int128 (0 dependency).

### Motivation

<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->

Better type, faster, less dependencies.

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->

### Checklist

- [x] Existing tests pass (`b2` in the `test/` directory).
- [x] New behavior is covered by a test, or this is a docs / build / refactor change.
- [x] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.
