### PR TITLE
remove BOOST_GRAPH_EVENT_STUB

### DIFF
--- a/include/boost/graph/breadth_first_search.hpp
+++ b/include/boost/graph/breadth_first_search.hpp
@@ -224,16 +224,6 @@ public:
         return graph::bfs_visitor_event_not_overridden();
     }
 
-    BOOST_GRAPH_EVENT_STUB(on_initialize_vertex, bfs)
-    BOOST_GRAPH_EVENT_STUB(on_discover_vertex, bfs)
-    BOOST_GRAPH_EVENT_STUB(on_examine_vertex, bfs)
-    BOOST_GRAPH_EVENT_STUB(on_examine_edge, bfs)
-    BOOST_GRAPH_EVENT_STUB(on_tree_edge, bfs)
-    BOOST_GRAPH_EVENT_STUB(on_non_tree_edge, bfs)
-    BOOST_GRAPH_EVENT_STUB(on_gray_target, bfs)
-    BOOST_GRAPH_EVENT_STUB(on_black_target, bfs)
-    BOOST_GRAPH_EVENT_STUB(on_finish_vertex, bfs)
-
 protected:
     Visitors m_vis;
 };

--- a/include/boost/graph/depth_first_search.hpp
+++ b/include/boost/graph/depth_first_search.hpp
@@ -365,16 +365,6 @@ public:
         invoke_visitors(m_vis, u, g, ::boost::on_finish_vertex());
     }
 
-    BOOST_GRAPH_EVENT_STUB(on_initialize_vertex, dfs)
-    BOOST_GRAPH_EVENT_STUB(on_start_vertex, dfs)
-    BOOST_GRAPH_EVENT_STUB(on_discover_vertex, dfs)
-    BOOST_GRAPH_EVENT_STUB(on_examine_edge, dfs)
-    BOOST_GRAPH_EVENT_STUB(on_tree_edge, dfs)
-    BOOST_GRAPH_EVENT_STUB(on_back_edge, dfs)
-    BOOST_GRAPH_EVENT_STUB(on_forward_or_cross_edge, dfs)
-    BOOST_GRAPH_EVENT_STUB(on_finish_edge, dfs)
-    BOOST_GRAPH_EVENT_STUB(on_finish_vertex, dfs)
-
 protected:
     Visitors m_vis;
 };

--- a/include/boost/graph/maximum_adjacency_search.hpp
+++ b/include/boost/graph/maximum_adjacency_search.hpp
@@ -104,11 +104,6 @@ public:
         invoke_visitors(m_vis, u, g, ::boost::on_finish_vertex());
     }
 
-    BOOST_GRAPH_EVENT_STUB(on_initialize_vertex, mas)
-    BOOST_GRAPH_EVENT_STUB(on_start_vertex, mas)
-    BOOST_GRAPH_EVENT_STUB(on_examine_edge, mas)
-    BOOST_GRAPH_EVENT_STUB(on_finish_vertex, mas)
-
 protected:
     Visitors m_vis;
 };

--- a/include/boost/graph/visitors.hpp
+++ b/include/boost/graph/visitors.hpp
@@ -59,13 +59,6 @@ namespace detail
         on_edge_not_minimized_num
     };
 
-    template < typename Event, typename Visitor >
-    struct functor_to_visitor : Visitor
-    {
-        typedef Event event_filter;
-        functor_to_visitor(const Visitor& visitor) : Visitor(visitor) {}
-    };
-
 } // namespace detail
 
 struct on_no_event
@@ -408,20 +401,6 @@ inline property_put< PropertyMap, EventTag > put_property(
 {
     return property_put< PropertyMap, EventTag >(property_map, value);
 }
-
-#define BOOST_GRAPH_EVENT_STUB(Event, Kind)                                 \
-    typedef ::boost::Event Event##_type;                                    \
-    template < typename Visitor >                                           \
-    Kind##_visitor< std::pair<                                              \
-        detail::functor_to_visitor< Event##_type, Visitor >, Visitors > >   \
-        do_##Event(Visitor visitor)                                         \
-    {                                                                       \
-        typedef std::pair<                                                  \
-            detail::functor_to_visitor< Event##_type, Visitor >, Visitors > \
-            visitor_list;                                                   \
-        typedef Kind##_visitor< visitor_list > result_type;                 \
-        return result_type(visitor_list(visitor, m_vis));                   \
-    }
 
 } /* namespace boost */
 


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [ ] Bug fix
- [ ] New feature or API addition
- [x] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

<!-- A short summary of the change. -->

Remove `BOOST_GRAPH_EVENT_STUB` utility.

### Motivation

<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->

`BOOST_GRAPH_EVENT_STUB` generates fluent `do_on_xxx()` builder methods on `bfs_visitor`, `dfs_visitor` and `mas_visitor`. Douglas Gregor added it during his postdoc in 2003 (SVN r18853) as a pre-lambda way to attach a bare function object to an event point. The problem it solved no longer exists, the feature was never adopted, and it now stands in the way of the namespace migration:

- Untested, undocumented, no usage example for 23 years.
- No known users. None of the 22 generated names, nor the macro itself are surfaced by web searches or main github users (CGAL etc)
- Obsolete by design: it was designed in a pre-lambda C++03 world.

This is also how the issue surfaced: while moving visitor classes from namespace `boost` to `boost::graph` in `maximum_adjacency_search.hpp`, the macro's unqualified `detail::functor_to_visitor` lookup started resolving into `boost::graph::detail` (declared in 20+ BGL headers since 2005) instead of `boost::detail`, failing with error: 'functor_to_visitor' is not a member of 'boost::graph::detail'. The macro could be fixed by fully qualifying the name, but that would mean patching and then maintaining an API that has had no documented user in 22 years. Deleting it is much cheaper/healthier.

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->

### Checklist

- [x] Existing tests pass (`b2` in the `test/` directory).
- [x] New behavior is covered by a test, or this is a docs / build / refactor change.
- [x] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.
