### PR TITLE
Reinstantiate 'Distance' type for template expansion.

### DIFF
--- a/example/miles_span.cpp
+++ b/example/miles_span.cpp
@@ -31,7 +31,7 @@ struct total_length_visitor : public boost::dijkstra_visitor<>
     }
     template < class Vertex, class Graph >
     inline void finish_vertex(Vertex s, Graph& g)
-    {
+    { (void)g;
         _total_length += boost::get(_distance, s);
     }
     D& _total_length;

--- a/example/miles_span.cpp
+++ b/example/miles_span.cpp
@@ -105,7 +105,7 @@ int main(int argc, char* argv[])
         auto d = get(z_property< long >(), g);
         // Use the "w" property for parent
         auto p = get(w_property< Vertex* >(), g);
-        typedef property_map< Graph*, z_property< long > >::type Distance;
+        using Distance = property_map< Graph*, z_property< long > >::type;
         total_length_visitor< Distance > length_vis(sp_length, d);
 
         prim_minimum_spanning_tree(g, p,

--- a/example/miles_span.cpp
+++ b/example/miles_span.cpp
@@ -105,8 +105,9 @@ int main(int argc, char* argv[])
         auto d = get(z_property< long >(), g);
         // Use the "w" property for parent
         auto p = get(w_property< Vertex* >(), g);
-        using Distance = property_map< Graph*, z_property< long > >::type;
-        total_length_visitor< Distance > length_vis(sp_length, d);
+        total_length_visitor<
+            property_map< Graph*, z_property< long > >::type
+            > length_vis(sp_length, d);
 
         prim_minimum_spanning_tree(g, p,
             distance_map(get(z_property< long >(), g))

--- a/example/miles_span.cpp
+++ b/example/miles_span.cpp
@@ -105,6 +105,7 @@ int main(int argc, char* argv[])
         auto d = get(z_property< long >(), g);
         // Use the "w" property for parent
         auto p = get(w_property< Vertex* >(), g);
+        typedef property_map< Graph*, z_property< long > >::type Distance;
         total_length_visitor< Distance > length_vis(sp_length, d);
 
         prim_minimum_spanning_tree(g, p,

--- a/example/miles_span.cpp
+++ b/example/miles_span.cpp
@@ -105,9 +105,8 @@ int main(int argc, char* argv[])
         auto d = get(z_property< long >(), g);
         // Use the "w" property for parent
         auto p = get(w_property< Vertex* >(), g);
-        total_length_visitor<
-            property_map< Graph*, z_property< long > >::type
-            > length_vis(sp_length, d);
+        using Distance = property_map< Graph*, z_property< long > >::type;
+        total_length_visitor< Distance > length_vis(sp_length, d);
 
         prim_minimum_spanning_tree(g, p,
             distance_map(get(z_property< long >(), g))


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [x] Bug fix
- [ ] New feature or API addition
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

<!-- A short summary of the change. -->
It fixes the example program `miles_span.cpp` for compilation.

### Motivation

<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->
Recently I upgraded the `PROTOTYPES` changefiles for The Stanford GraphBase (see <https://github.com/ascherer/sgb/releases/tag/2025-12-28>; with the grace of Donald Knuth, see <https://www-cs-faculty.stanford.edu/~knuth/sgb.html>) and now I tried to compile the four SGB example codes `girth.cpp`, `miles_span.cpp`, `roget_components.cpp`, and `topo-sort-with-sgb.cpp` with g++ 13.3.0 on Kubuntu 24.04LTS.

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->
```shell
andreas@TravelMate .../Extern/graph/example develop
$ g++  miles_span.cpp -I /usr/include/sgb -L /usr/lib/x86_64-linux-gnu/sgb -lgb
andreas@TravelMate .../Extern/graph/example develop ?1
$ ./a.out 
The graph miles(100,0,0,0,0,10,0) has 405 edges,
  and its minimum spanning tree has length 14467.
andreas@TravelMate .../Extern/graph/example develop ?1
$ cat miles_span.expected 
The graph miles(100,0,0,0,0,10,0) has 405 edges,
  and its minimum spanning tree has length 14467
```

### Checklist

- [ ] Existing tests pass (`b2` in the `test/` directory).
- [ ] New behavior is covered by a test, or this is a docs / build / refactor change.
- [ ] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.
