### PR TITLE
Fix signed/unsigned warning from g++.

### DIFF
--- a/example/roget_components.cpp
+++ b/example/roget_components.cpp
@@ -25,7 +25,8 @@ int main(int argc, char* argv[])
     unsigned long p = 0;
     long s = 0;
     char* filename = NULL;
-    int c, i;
+    int c;
+    unsigned int i;
 
     while (--argc)
     {


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

### Before submitting

- [x] This PR targets the `develop` branch.
- [ ] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [x] Bug fix
- [ ] New feature or API addition
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

<!-- A short summary of the change. -->
It fixes a signed/unsigned warning from g++.

### Motivation

<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->
I prefer to run the compiler with -Wall -Wextra and treat warnings as errors.

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->
```shell
/home/linuxbrew/.linuxbrew/bin/g++-16 --std=c++23 -Wall -Wextra \
    -I /usr/include/sgb -L /usr/lib/x86_64-linux-gnu/sgb -lgb \
    roget_components.cpp
```

### Checklist

- [ ] Existing tests pass (`b2` in the `test/` directory).
- [ ] New behavior is covered by a test, or this is a docs / build / refactor change.
- [ ] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.
