### PR TITLE
refactor: migrate stoer wagner symbols, deprecate old symbols

### DIFF
--- a/doc/modules/ROOT/examples/algorithms/network_flow/stoer_wagner.cpp
+++ b/doc/modules/ROOT/examples/algorithms/network_flow/stoer_wagner.cpp
@@ -5,20 +5,19 @@
 
 struct EdgeProps { int weight; };
 
-using namespace boost;
-
-using Graph = adjacency_list<vecS, vecS, undirectedS,
-    no_property, EdgeProps>;
+using Graph = boost::adjacency_list< boost::vecS, boost::vecS, boost::undirectedS,
+    boost::no_property, EdgeProps >;
 
 int main() {
     Graph g{4};
-    add_edge(0, 1, EdgeProps{2}, g);
-    add_edge(0, 2, EdgeProps{3}, g);
-    add_edge(1, 2, EdgeProps{3}, g);
-    add_edge(1, 3, EdgeProps{2}, g);
-    add_edge(2, 3, EdgeProps{4}, g);
+    boost::add_edge(0, 1, EdgeProps{2}, g);
+    boost::add_edge(0, 2, EdgeProps{3}, g);
+    boost::add_edge(1, 2, EdgeProps{3}, g);
+    boost::add_edge(1, 3, EdgeProps{2}, g);
+    boost::add_edge(2, 3, EdgeProps{4}, g);
 
     auto weight_map = get(&EdgeProps::weight, g);
-    int cut = stoer_wagner_min_cut(g, weight_map);
+    // only the min-cut weight is needed here, so discard the partition
+    int cut = boost::graph::stoer_wagner_min_cut(g, weight_map, boost::dummy_property_map());
     std::cout << "Stoer-Wagner min cut: " << cut << "\n";
 }

--- a/doc/modules/ROOT/pages/algorithms/network_flow/stoer_wagner_min_cut.adoc
+++ b/doc/modules/ROOT/pages/algorithms/network_flow/stoer_wagner_min_cut.adoc
@@ -6,7 +6,98 @@ Determines a min-cut and the min-cut weight of a connected, undirected graph.
 *Complexity:* _O_(_V_ * _E_ + _V_^2^ log _V_) +
 *Defined in:* `<boost/graph/stoer_wagner_min_cut.hpp>`
 
-== Example
+== Description
+
+A _cut_ of a graph _G_ is a partition of the vertices into two, non-empty sets. The _weight_ of such a partition is the number of edges between the two sets if _G_ is unweighted, or the sum of the weights of all edges between the two sets if _G_ is weighted. A _min-cut_ is a cut having the least weight.
+
+Sometimes a graph has multiple min-cuts, but all have the same weight. The `stoer_wagner_min_cut` function implements the
+https://en.wikipedia.org/wiki/Stoer%E2%80%93Wagner_algorithm[Stoer-Wagner algorithm] and determines exactly one of the min-cuts as well as its weight.
+
+.A min-cut of a weighted graph having min-cut weight 4
+image::stoer_wagner_imgs/stoer_wagner-example-min-cut.gif[A min-cut of a weighted graph having min-cut weight 4,width=376]
+
+[WARNING]
+====
+The `stoer_wagner_min_cut` function moved to `namespace boost::graph`. The
+`boost::` overloads, both positional and named parameter, are kept for backward
+compatibility but are deprecated. Removal planned for Boost 1.95.
+====
+
+== Overloads
+
+=== (1) Fully Positional
+
+[source,cpp]
+----
+namespace boost::graph {
+template <class UndirectedGraph, class WeightMap, class ParityMap,
+          class VertexAssignmentMap, class KeyedUpdatablePriorityQueue,
+          class IndexMap>
+typename property_traits<WeightMap>::value_type
+stoer_wagner_min_cut(
+    const UndirectedGraph& g, WeightMap weights,
+    ParityMap parities, VertexAssignmentMap assignments,
+    KeyedUpdatablePriorityQueue& pq, IndexMap index_map);
+}
+----
+
+[cols="1,2,5"]
+|===
+| Direction | Parameter | Description
+
+| IN
+| `const UndirectedGraph& g`
+| A connected, undirected graph. The graph type must be a model of
+  xref:concepts/VertexListGraph.adoc[Vertex List Graph]
+  and xref:concepts/IncidenceGraph.adoc[Incidence Graph].
+
+| IN
+| `WeightMap weights`
+| The weight or length of each edge in the graph. The `WeightMap` type
+  must be a model of
+  link:../../property_map/doc/ReadablePropertyMap.html[Readable Property Map]
+  and its value type must be
+  http://www.boost.org/sgi/stl/LessThanComparable.html[Less Than Comparable]
+  and summable. The key type of this map needs to be the graph's edge
+  descriptor type.
+
+| OUT
+| `ParityMap parities`
+| Records which of the two min-cut sets each vertex belongs to, by setting the
+  parity to `true` (one set) or `false` (the other). `ParityMap` must be a
+  model of a
+  link:../../property_map/doc/WritablePropertyMap.html[Writable Property Map]
+  and its value type should be a bool type. The key type must be the graph's
+  vertex descriptor type. Pass `boost::dummy_property_map()` when only the
+  min-cut weight is needed.
+
+| UTIL
+| `VertexAssignmentMap assignments`
+| Work space mapping each vertex to the vertex it is assigned to. Must be a
+  model of
+  link:../../property_map/doc/ReadWritePropertyMap.html[Read/Write Property Map].
+  The key and value types must be the graph's vertex descriptor type. No
+  particular meaning should be derived from its values after completion.
+
+| UTIL
+| `KeyedUpdatablePriorityQueue& pq`
+| A max priority queue keyed on the reach counts. It must be a model of
+  xref:concepts/property_types/KeyedUpdatableQueue.adoc[Keyed Updatable Queue] and a
+  max-xref:concepts/property_types/UpdatableQueue.adoc[Updatable Priority Queue].
+  The value type must be the graph's vertex descriptor and the key type
+  must be the weight type. It must be empty when passed in.
+
+| IN
+| `IndexMap index_map`
+| Maps each vertex to an integer in the range `[0, num_vertices(g))`.
+  `IndexMap` must be a model of
+  link:../../property_map/doc/ReadablePropertyMap.html[Readable Property Map].
+  The value type must be an integer type and the key type the graph's vertex
+  descriptor type.
+
+|===
+
+==== Example
 
 [source,cpp]
 ----
@@ -20,10 +111,75 @@ include::example$algorithms/network_flow/stoer_wagner.txt[]
 
 '''
 
-=== (1) Named parameter version
+=== (2) Five arguments overload
 
-.A min-cut of a weighted graph having min-cut weight 4
-image::stoer_wagner_imgs/stoer_wagner-example-min-cut.gif[A min-cut of a weighted graph having min-cut weight 4,width=376]
+The index map is the least interesting argument, so this form defaults it to `get(vertex_index, g)`. Requires the graph to have an interior `vertex_index_t` property.
+
+[source,cpp]
+----
+namespace boost::graph {
+template <class UndirectedGraph, class WeightMap, class ParityMap,
+          class VertexAssignmentMap, class KeyedUpdatablePriorityQueue>
+typename property_traits<WeightMap>::value_type
+stoer_wagner_min_cut(
+    const UndirectedGraph& g, WeightMap weights,
+    ParityMap parities, VertexAssignmentMap assignments,
+    KeyedUpdatablePriorityQueue& pq);
+}
+----
+
+'''
+
+=== (3) Three arguments overload
+
+Building the assignment map and the priority queue is the cumbersome part, so this form defaults them along with the index map. Pass `boost::dummy_property_map()` for `parities` when only the min-cut weight is needed.
+
+[source,cpp]
+----
+namespace boost::graph {
+template <class UndirectedGraph, class WeightMap, class ParityMap>
+typename property_traits<WeightMap>::value_type
+stoer_wagner_min_cut(const UndirectedGraph& g, WeightMap weights, ParityMap parities);
+}
+----
+
+'''
+
+=== (4) Six arguments overload (deprecated)
+
+[WARNING]
+====
+Deprecated: this overload moved to `namespace boost::graph`. Use the positional
+`boost::graph::stoer_wagner_min_cut` overloads instead. Removal planned for
+Boost 1.95.
+====
+
+[source,cpp]
+----
+namespace boost {
+template <class UndirectedGraph, class WeightMap, class ParityMap,
+          class VertexAssignmentMap, class KeyedUpdatablePriorityQueue,
+          class IndexMap>
+typename property_traits<WeightMap>::value_type
+stoer_wagner_min_cut(
+    const UndirectedGraph& g, WeightMap weights,
+    ParityMap parities, VertexAssignmentMap assignments,
+    KeyedUpdatablePriorityQueue& pq, IndexMap index_map);
+}
+----
+
+Identical to overload (1) except for its namespace. Kept in `boost::` for backward compatibility.
+
+'''
+
+=== (5) Named parameter version (deprecated)
+
+[WARNING]
+====
+Deprecated: the named parameter interface is deprecated. Use the positional
+`boost::graph::stoer_wagner_min_cut` overloads instead. Removal planned for
+Boost 1.95.
+====
 
 [source,cpp]
 ----
@@ -128,48 +284,6 @@ weight_type stoer_wagner_min_cut(
 
 |===
 
-'''
-
-=== (2) Positional version (explicit index map)
-
-[source,cpp]
-----
-template <class UndirectedGraph, class WeightMap, class ParityMap,
-          class VertexAssignmentMap, class KeyedUpdatablePriorityQueue,
-          class IndexMap>
-typename property_traits<WeightMap>::value_type
-stoer_wagner_min_cut(
-    const UndirectedGraph& g, WeightMap weights,
-    ParityMap parities, VertexAssignmentMap assignments,
-    KeyedUpdatablePriorityQueue& pq, IndexMap index_map);
-----
-
-Explicit positional form with every working map supplied by the caller. Prefer overload (1) unless you have a reason to pre-allocate the work maps and priority queue.
-
-'''
-
-=== (3) Positional version (default index map)
-
-[source,cpp]
-----
-template <class UndirectedGraph, class WeightMap, class ParityMap,
-          class VertexAssignmentMap, class KeyedUpdatablePriorityQueue>
-typename property_traits<WeightMap>::value_type
-stoer_wagner_min_cut(
-    const UndirectedGraph& g, WeightMap weights,
-    ParityMap parities, VertexAssignmentMap assignments,
-    KeyedUpdatablePriorityQueue& pq);
-----
-
-Lives in namespace `boost::graph`. Same as (2) with `index_map = get(vertex_index, g)`; requires the graph to have an interior `vertex_index_t` property.
-
-== Description
-
-A _cut_ of a graph _G_ is a partition of the vertices into two, non-empty sets. The _weight_ of such a partition is the number of edges between the two sets if _G_ is unweighted, or the sum of the weights of all edges between the two sets if _G_ is weighted. A _min-cut_ is a cut having the least weight.
-
-Sometimes a graph has multiple min-cuts, but all have the same weight. The `stoer_wagner_min_cut` function implements the
-https://en.wikipedia.org/wiki/Stoer%E2%80%93Wagner_algorithm[Stoer-Wagner algorithm] and determines exactly one of the min-cuts as well as its weight.
-
 == Returns
 
 The weight of the min-cut.
@@ -179,13 +293,8 @@ The weight of the min-cut.
 `bad_graph`:: If `num_vertices(g)` is less than 2.
 `std::invalid_argument`:: If a max-priority queue is given as an argument and it is not empty.
 
-== Example
-
-The file link:../example/stoer_wagner.cpp[`examples/stoer_wagner.cpp`] contains an example of calculating a min-cut of a weighted, undirected graph and its min-cut weight.
-
 == References
 
 * xref:about/bibliography.adoc#mehlhorn-uhrig95[[74\]] Mehlhorn, Kurt and Christian Uhrig (1995). _The minimum cut algorithm of Stoer and Wagner_.
 * xref:about/bibliography.adoc#stoer-wagner97[[75\]] Stoer, Mechthild and Frank Wagner (1997). _A simple min-cut algorithm_. Journal of the ACM 44 (4), 585-591.
 * xref:about/bibliography.adoc#zwick08[[76\]] Zwick, Uri (2008). _Global minimum cuts_.
-

--- a/example/stoer_wagner.cpp
+++ b/example/stoer_wagner.cpp
@@ -56,8 +56,8 @@ int main()
 
     // run the Stoer-Wagner algorithm to obtain the min-cut weight. `parities`
     // is also filled in.
-    int w = boost::stoer_wagner_min_cut(
-        g, get(boost::edge_weight, g), boost::parity_map(parities));
+    int w = boost::graph::stoer_wagner_min_cut(
+        g, get(boost::edge_weight, g), parities);
 
     cout << "The min-cut weight of G is " << w << ".\n" << endl;
     assert(w == 7);

--- a/include/boost/graph/stoer_wagner_min_cut.hpp
+++ b/include/boost/graph/stoer_wagner_min_cut.hpp
@@ -20,19 +20,19 @@
 #include <boost/graph/one_bit_color_map.hpp>
 #include <boost/graph/detail/d_ary_heap.hpp>
 #include <boost/property_map/property_map.hpp>
+#include <boost/property_map/shared_array_property_map.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/utility/result_of.hpp>
 #include <boost/graph/iteration_macros.hpp>
+
+#include <functional>
 
 namespace boost
 {
 
 namespace detail
 {
-    // Captures the cut of the phase from a maximum adjacency sweep: the last
-    // two vertices visited and the reach count of the last one. mas_sweep fires
-    // start_vertex before popping each vertex, so its key at that moment is the
-    // reach count.
+    // Records the phase cut: the last two vertices swept and the reach count of the last.
     template < class UndirectedGraph, class KeyMap, class WeightType >
     struct mas_phase_recorder : public boost::graph::default_mas_visitor
     {
@@ -242,108 +242,40 @@ namespace detail
     }
 } // end `namespace detail` within `namespace boost`
 
-template < class UndirectedGraph, class WeightMap, class ParityMap,
-    class VertexAssignmentMap, class KeyedUpdatablePriorityQueue,
-    class IndexMap >
-typename boost::property_traits< WeightMap >::value_type stoer_wagner_min_cut(
-    const UndirectedGraph& g, WeightMap weights, ParityMap parities,
-    VertexAssignmentMap assignments, KeyedUpdatablePriorityQueue& pq,
-    IndexMap index_map)
-{
-    BOOST_CONCEPT_ASSERT((boost::IncidenceGraphConcept< UndirectedGraph >));
-    BOOST_CONCEPT_ASSERT((boost::VertexListGraphConcept< UndirectedGraph >));
-    typedef typename boost::graph_traits< UndirectedGraph >::vertex_descriptor
-        vertex_descriptor;
-    typedef typename boost::graph_traits< UndirectedGraph >::vertices_size_type
-        vertices_size_type;
-    typedef typename boost::graph_traits< UndirectedGraph >::edge_descriptor
-        edge_descriptor;
-    BOOST_CONCEPT_ASSERT((boost::Convertible<
-        typename boost::graph_traits< UndirectedGraph >::directed_category,
-        boost::undirected_tag >));
-    BOOST_CONCEPT_ASSERT(
-        (boost::ReadablePropertyMapConcept< WeightMap, edge_descriptor >));
-    // typedef typename boost::property_traits<WeightMap>::value_type
-    // weight_type;
-    BOOST_CONCEPT_ASSERT(
-        (boost::WritablePropertyMapConcept< ParityMap, vertex_descriptor >));
-    // typedef typename boost::property_traits<ParityMap>::value_type
-    // parity_type;
-    BOOST_CONCEPT_ASSERT(
-        (boost::ReadWritePropertyMapConcept< VertexAssignmentMap,
-            vertex_descriptor >));
-    BOOST_CONCEPT_ASSERT((boost::Convertible< vertex_descriptor,
-        typename boost::property_traits< VertexAssignmentMap >::value_type >));
-    BOOST_CONCEPT_ASSERT(
-        (boost::KeyedUpdatableQueueConcept< KeyedUpdatablePriorityQueue >));
-
-    vertices_size_type n = num_vertices(g);
-    if (n < 2)
-        throw boost::bad_graph(
-            "the input graph must have at least two vertices.");
-    else if (!pq.empty())
-        throw std::invalid_argument(
-            "the max-priority queue must be empty initially.");
-
-    return detail::stoer_wagner_min_cut(
-        g, weights, parities, assignments, pq, index_map);
-}
-
 namespace graph
 {
-    namespace detail
+    // Fully positional 6-args
+    template < class UndirectedGraph, class WeightMap, class ParityMap,
+        class VertexAssignmentMap, class KeyedUpdatablePriorityQueue,
+        class IndexMap >
+    typename boost::property_traits< WeightMap >::value_type
+    stoer_wagner_min_cut(const UndirectedGraph& g, WeightMap weights,
+        ParityMap parities, VertexAssignmentMap assignments,
+        KeyedUpdatablePriorityQueue& pq, IndexMap index_map)
     {
-        template < class UndirectedGraph, class WeightMap >
-        struct stoer_wagner_min_cut_impl
-        {
-            typedef typename boost::property_traits< WeightMap >::value_type
-                result_type;
-            template < typename ArgPack >
-            result_type operator()(const UndirectedGraph& g, WeightMap weights,
-                const ArgPack& arg_pack) const
-            {
-                using namespace boost::graph::keywords;
-                typedef typename boost::graph_traits<
-                    UndirectedGraph >::vertex_descriptor vertex_descriptor;
-                typedef typename boost::property_traits< WeightMap >::value_type
-                    weight_type;
+        using vertex_descriptor = typename boost::graph_traits< UndirectedGraph >::vertex_descriptor;
+        using vertices_size_type = typename boost::graph_traits< UndirectedGraph >::vertices_size_type;
+        using edge_descriptor = typename boost::graph_traits< UndirectedGraph >::edge_descriptor;
 
-                typedef boost::detail::make_priority_queue_from_arg_pack_gen<
-                    boost::graph::keywords::tag::max_priority_queue,
-                    weight_type, vertex_descriptor,
-                    std::greater< weight_type > >
-                    gen_type;
+        BOOST_CONCEPT_ASSERT((boost::IncidenceGraphConcept< UndirectedGraph >));
+        BOOST_CONCEPT_ASSERT((boost::VertexListGraphConcept< UndirectedGraph >));
+        BOOST_CONCEPT_ASSERT((boost::Convertible< typename boost::graph_traits< UndirectedGraph >::directed_category, boost::undirected_tag >));
+        BOOST_CONCEPT_ASSERT((boost::ReadablePropertyMapConcept< WeightMap, edge_descriptor >));
+        BOOST_CONCEPT_ASSERT((boost::WritablePropertyMapConcept< ParityMap, vertex_descriptor >));
+        BOOST_CONCEPT_ASSERT((boost::ReadWritePropertyMapConcept< VertexAssignmentMap, vertex_descriptor >));
+        BOOST_CONCEPT_ASSERT((boost::Convertible< vertex_descriptor, typename boost::property_traits< VertexAssignmentMap >::value_type >));
+        BOOST_CONCEPT_ASSERT((boost::KeyedUpdatableQueueConcept< KeyedUpdatablePriorityQueue >));
 
-                gen_type gen(
-                    choose_param(get_param(arg_pack, boost::distance_zero_t()),
-                        weight_type(0)));
+        const vertices_size_type n = num_vertices(g);
+        if (n < 2)
+            throw boost::bad_graph("the input graph must have at least two vertices.");
+        else if (!pq.empty())
+            throw std::invalid_argument("the max-priority queue must be empty initially.");
 
-                typename boost::result_of< gen_type(
-                    const UndirectedGraph&, const ArgPack&) >::type pq
-                    = gen(g, arg_pack);
-
-                boost::dummy_property_map dummy_prop;
-                return boost::stoer_wagner_min_cut(g, weights,
-                    arg_pack[_parity_map | dummy_prop],
-                    boost::detail::make_property_map_from_arg_pack_gen<
-                        tag::vertex_assignment_map, vertex_descriptor >(
-                        vertex_descriptor())(g, arg_pack),
-                    pq,
-                    boost::detail::override_const_property(
-                        arg_pack, _vertex_index_map, g, vertex_index));
-            }
-        };
+        return boost::detail::stoer_wagner_min_cut(g, weights, parities, assignments, pq, index_map);
     }
-    BOOST_GRAPH_MAKE_FORWARDING_FUNCTION(stoer_wagner_min_cut, 2, 4)
-}
 
-// Named parameter interface
-BOOST_GRAPH_MAKE_OLD_STYLE_PARAMETER_FUNCTION(stoer_wagner_min_cut, 2)
-namespace graph
-{
-    // version without IndexMap kept for backwards compatibility
-    // (but requires vertex_index_t to be defined in the graph)
-    // Place after the macro to avoid compilation errors
+    // Positional 5-args
     template < class UndirectedGraph, class WeightMap, class ParityMap,
         class VertexAssignmentMap, class KeyedUpdatablePriorityQueue >
     typename boost::property_traits< WeightMap >::value_type
@@ -351,11 +283,95 @@ namespace graph
         ParityMap parities, VertexAssignmentMap assignments,
         KeyedUpdatablePriorityQueue& pq)
     {
-
-        return stoer_wagner_min_cut(
-            g, weights, parities, assignments, pq, get(vertex_index, g));
+        return boost::graph::stoer_wagner_min_cut(g, weights, parities, assignments, pq, get(vertex_index, g));
     }
+
+    // Positional 3-args. 
+    template < class UndirectedGraph, class WeightMap, class ParityMap >
+    typename boost::property_traits< WeightMap >::value_type
+    stoer_wagner_min_cut(const UndirectedGraph& g, WeightMap weights, ParityMap parities)
+    {
+        using vertex_descriptor = typename boost::graph_traits< UndirectedGraph >::vertex_descriptor;
+        using weight_type = typename boost::property_traits< WeightMap >::value_type;
+        using vertex_index_map_type = typename boost::property_map< UndirectedGraph, boost::vertex_index_t >::const_type;
+        using distance_map_type = boost::shared_array_property_map< weight_type, vertex_index_map_type >;
+        using index_in_heap_type = typename std::vector< vertex_descriptor >::size_type;
+        using index_in_heap_map_type = boost::shared_array_property_map< index_in_heap_type, vertex_index_map_type >;
+        using priority_queue_type = boost::d_ary_heap_indirect< vertex_descriptor, 4, index_in_heap_map_type, distance_map_type, std::greater< weight_type > >;
+        using assignment_map_type = boost::shared_array_property_map< vertex_descriptor, vertex_index_map_type >;
+
+        const vertex_index_map_type vertex_index_map = get(boost::vertex_index, g);
+        distance_map_type distance_map = boost::make_shared_array_property_map(num_vertices(g), weight_type(0), vertex_index_map);
+        index_in_heap_map_type index_in_heap_map = boost::make_shared_array_property_map(num_vertices(g), index_in_heap_type(-1), vertex_index_map);
+        priority_queue_type pq(distance_map, index_in_heap_map);
+        assignment_map_type assignment_map = boost::make_shared_array_property_map(num_vertices(g), vertex_descriptor(), vertex_index_map);
+
+        return boost::graph::stoer_wagner_min_cut(g, weights, parities, assignment_map, pq, vertex_index_map);
+    }
+
+    namespace detail
+    {
+        template < class UndirectedGraph, class WeightMap >
+        struct stoer_wagner_min_cut_impl
+        {
+            using result_type = typename boost::property_traits< WeightMap >::value_type;
+            template < typename ArgPack >
+            result_type operator()(const UndirectedGraph& g, WeightMap weights, const ArgPack& arg_pack) const
+            {
+                using namespace boost::graph::keywords;
+                using vertex_descriptor = typename boost::graph_traits< UndirectedGraph >::vertex_descriptor;
+                using weight_type = typename boost::property_traits< WeightMap >::value_type;
+                using gen_type = boost::detail::make_priority_queue_from_arg_pack_gen< boost::graph::keywords::tag::max_priority_queue, weight_type, vertex_descriptor, std::greater< weight_type > >;
+
+                gen_type gen(choose_param(get_param(arg_pack, boost::distance_zero_t()), weight_type(0)));
+                typename boost::result_of< gen_type(const UndirectedGraph&, const ArgPack&) >::type pq = gen(g, arg_pack);
+
+                boost::dummy_property_map dummy_prop;
+                return boost::graph::stoer_wagner_min_cut(g, weights,
+                    arg_pack[_parity_map | dummy_prop],
+                    boost::detail::make_property_map_from_arg_pack_gen< tag::vertex_assignment_map, vertex_descriptor >(vertex_descriptor())(g, arg_pack),
+                    pq,
+                    boost::detail::override_const_property(arg_pack, _vertex_index_map, g, vertex_index));
+            }
+        };
+    }
+    // Generates the tagged-keyword Boost.Parameter overloads dispatching to stoer_wagner_min_cut_impl.
+    BOOST_GRAPH_MAKE_FORWARDING_FUNCTION(stoer_wagner_min_cut, 2, 4)
 } // end `namespace graph`
+
+// -- deprecated overloads --
+
+template < class UndirectedGraph, class WeightMap, class ParityMap,
+    class VertexAssignmentMap, class KeyedUpdatablePriorityQueue, class IndexMap >
+BOOST_DEPRECATED("use the positional boost::graph::stoer_wagner_min_cut. Removal planned for Boost 1.95.")
+typename boost::property_traits< WeightMap >::value_type
+stoer_wagner_min_cut(const UndirectedGraph& g, WeightMap weights, ParityMap parities,
+    VertexAssignmentMap assignments, KeyedUpdatablePriorityQueue& pq, IndexMap index_map)
+{
+    return graph::stoer_wagner_min_cut(g, weights, parities, assignments, pq, index_map);
+}
+
+// Named parameter interface
+template < class UndirectedGraph, class WeightMap, class P, class T, class R >
+BOOST_DEPRECATED("the named parameter interface is deprecated, use the positional boost::graph::stoer_wagner_min_cut. Removal planned for Boost 1.95.")
+typename boost::property_traits< WeightMap >::value_type
+stoer_wagner_min_cut(const UndirectedGraph& g, WeightMap weights, const bgl_named_params< P, T, R >& params)
+{
+    using params_type = bgl_named_params< P, T, R >;
+    // Converts the legacy bgl_named_params into the modern Boost.Parameter arg_pack the forwarding function expects.
+    BOOST_GRAPH_DECLARE_CONVERTED_PARAMETERS(params_type, params)
+    return graph::stoer_wagner_min_cut_with_named_params(g, weights, arg_pack);
+}
+
+template < class UndirectedGraph, class WeightMap >
+BOOST_DEPRECATED("the named parameter interface is deprecated, use the positional boost::graph::stoer_wagner_min_cut. Removal planned for Boost 1.95.")
+typename boost::property_traits< WeightMap >::value_type
+stoer_wagner_min_cut(const UndirectedGraph& g, WeightMap weights)
+{
+    // Converts the legacy bgl_named_params into the modern Boost.Parameter arg_pack the forwarding function expects.
+    BOOST_GRAPH_DECLARE_CONVERTED_PARAMETERS(boost::no_named_parameters, boost::no_named_parameters())
+    return graph::stoer_wagner_min_cut_with_named_params(g, weights, arg_pack);
+}
 } // end `namespace boost`
 
 #include <boost/graph/iteration_macros_undef.hpp>

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -164,6 +164,7 @@ alias graph_test_regular :
     [ run mas_test.cpp ]
     [ run mas_test_old.cpp : $(TEST_DIR) ]
     [ run stoer_wagner_test.cpp : $(TEST_DIR) ]
+    [ run stoer_wagner_test_old.cpp : $(TEST_DIR) ]
     [ compile filtered_graph_properties_dijkstra.cpp ]
     [ run vf2_sub_graph_iso_test.cpp ]
     [ run vf2_sub_graph_iso_test_2.cpp ]

--- a/test/stoer_wagner_test.cpp
+++ b/test/stoer_wagner_test.cpp
@@ -1,17 +1,18 @@
 //            Copyright Daniel Trebbien 2010.
+// Copyright Arnaud Becheler 2026.
 // Distributed under the Boost Software License, Version 1.0.
 //   (See accompanying file LICENSE_1_0.txt or the copy at
 //         http://www.boost.org/LICENSE_1_0.txt)
 
-#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
-#define _CRT_SECURE_NO_WARNINGS
-#endif
+// Exercises the positional boost::graph::stoer_wagner_min_cut interface.
+// The deprecated named parameter forms are covered in stoer_wagner_test_old.cpp.
 
 #include <fstream>
-#include <iostream>
+#include <functional>
 #include <map>
-#include <vector>
+#include <stdexcept>
 #include <string>
+#include <vector>
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/connected_components.hpp>
 #include <boost/graph/exception.hpp>
@@ -20,17 +21,18 @@
 #include <boost/graph/stoer_wagner_min_cut.hpp>
 #include <boost/graph/property_maps/constant_property_map.hpp>
 #include <boost/property_map/property_map.hpp>
+#include <boost/property_map/shared_array_property_map.hpp>
 #include <boost/core/lightweight_test.hpp>
-#include <boost/tuple/tuple.hpp>
 
 #include "mas_sw_maxflow_oracle.hpp"
 
 using mas_sw_oracle::undirected_graph;
 using mas_sw_oracle::weight_map_type;
 using mas_sw_oracle::weight_type;
+using mas_sw_oracle::vertex_descriptor;
+using mas_sw_oracle::edge_descriptor;
 
-typedef boost::adjacency_list< boost::vecS, boost::vecS, boost::undirectedS >
-    undirected_unweighted_graph;
+using undirected_unweighted_graph = boost::adjacency_list< boost::vecS, boost::vecS, boost::undirectedS >;
 
 std::string test_dir;
 
@@ -40,6 +42,31 @@ struct edge_t
     unsigned long second;
 };
 
+// Build the keyed max priority queue the Stoer-Wagner phases run on.
+template < class Graph >
+auto make_maxheap(const Graph& g)
+{
+    using vd = typename boost::graph_traits< Graph >::vertex_descriptor;
+    using index_map_type = typename boost::property_map< Graph, boost::vertex_index_t >::const_type;
+    using distances_type = boost::shared_array_property_map< weight_type, index_map_type >;
+    using index_in_heap_type = typename std::vector< vd >::size_type;
+    using indices_type = boost::shared_array_property_map< index_in_heap_type, index_map_type >;
+    using maxheap_type = boost::d_ary_heap_indirect< vd, 22, indices_type, distances_type, std::greater< weight_type > >;
+
+    const index_map_type index_map = get(boost::vertex_index, g);
+    distances_type distances_map = boost::make_shared_array_property_map(num_vertices(g), static_cast< weight_type >(0), index_map);
+    indices_type indices_map = boost::make_shared_array_property_map(num_vertices(g), static_cast< index_in_heap_type >(-1), index_map);
+    return maxheap_type(distances_map, indices_map);
+}
+
+// Assignment work map: each vertex maps to its supernode representative.
+template < class Graph >
+auto make_assignment_map(const Graph& g)
+{
+    using vd = typename boost::graph_traits< Graph >::vertex_descriptor;
+    return boost::make_shared_array_property_map(num_vertices(g), vd(), get(boost::vertex_index, g));
+}
+
 // Stoer Wagner global min cut on a curated set, checked against the known value.
 void test_curated_min_cuts()
 {
@@ -47,11 +74,12 @@ void test_curated_min_cuts()
     {
         const undirected_graph& g = cg.graph;
         BOOST_TEST(mas_sw_oracle::is_connected(g));
-        BOOST_TEST_EQ(boost::stoer_wagner_min_cut(g, get(boost::edge_weight, g)), cg.min_cut);
+        const weight_type w = boost::graph::stoer_wagner_min_cut(g, get(boost::edge_weight, g), boost::dummy_property_map());
+        BOOST_TEST_EQ(w, cg.min_cut);
     }
 }
 
-// the example from Stoer & Wagner (1997)
+// the example from Stoer & Wagner (1997), via the convenience overload
 void test0()
 {
     edge_t edges[] = { { 0, 1 }, { 1, 2 }, { 2, 3 }, { 0, 4 }, { 1, 4 },
@@ -60,10 +88,9 @@ void test0()
     undirected_graph g(edges, edges + 12, ws, 8, 12);
 
     weight_map_type weights = get(boost::edge_weight, g);
-    std::map< int, bool > parity;
-    boost::associative_property_map< std::map< int, bool > > parities(parity);
-    int w
-        = boost::stoer_wagner_min_cut(g, weights, boost::parity_map(parities));
+    std::map< vertex_descriptor, bool > parity;
+    boost::associative_property_map< std::map< vertex_descriptor, bool > > parities(parity);
+    const int w = boost::graph::stoer_wagner_min_cut(g, weights, parities);
     BOOST_TEST_EQ(w, 4);
     const bool parity0 = get(parities, 0);
     BOOST_TEST_EQ(parity0, get(parities, 1));
@@ -78,37 +105,42 @@ void test0()
 
 void test1()
 {
-    { // if only one vertex, can't run `boost::stoer_wagner_min_cut`
+    { // if only one vertex, can't run stoer_wagner_min_cut
         undirected_graph g;
         add_vertex(g);
-
         BOOST_TEST_THROWS(
-            boost::stoer_wagner_min_cut(g, get(boost::edge_weight, g)),
+            boost::graph::stoer_wagner_min_cut(g, get(boost::edge_weight, g), boost::dummy_property_map()),
             boost::bad_graph);
     }
     { // three vertices with one multi-edge
-        typedef boost::graph_traits< undirected_graph >::vertex_descriptor
-            vertex_descriptor;
-
         edge_t edges[] = { { 0, 1 }, { 1, 2 }, { 1, 2 }, { 2, 0 } };
         weight_type ws[] = { 3, 1, 1, 1 };
         undirected_graph g(edges, edges + 4, ws, 3, 4);
 
         weight_map_type weights = get(boost::edge_weight, g);
-        std::map< int, bool > parity;
-        boost::associative_property_map< std::map< int, bool > > parities(
-            parity);
-        std::map< vertex_descriptor, vertex_descriptor > assignment;
-        boost::associative_property_map<
-            std::map< vertex_descriptor, vertex_descriptor > >
-            assignments(assignment);
-        int w = boost::stoer_wagner_min_cut(g, weights,
-            boost::parity_map(parities).vertex_assignment_map(assignments));
+        std::map< vertex_descriptor, bool > parity;
+        boost::associative_property_map< std::map< vertex_descriptor, bool > > parities(parity);
+        const int w = boost::graph::stoer_wagner_min_cut(g, weights, parities);
         BOOST_TEST_EQ(w, 3);
         const bool parity2 = get(parities, 2), parity0 = get(parities, 0);
         BOOST_TEST_NE(parity2, parity0);
         BOOST_TEST_EQ(parity0, get(parities, 1));
     }
+}
+
+// a priority queue that is not empty on entry is rejected
+void test_nonempty_queue_throws()
+{
+    undirected_graph g = mas_sw_oracle::make_weighted_graph(4, { { 0, 1, 1 }, { 1, 2, 1 }, { 2, 3, 1 } });
+    weight_map_type weights = get(boost::edge_weight, g);
+    std::map< vertex_descriptor, bool > parity;
+    boost::associative_property_map< std::map< vertex_descriptor, bool > > parities(parity);
+    auto assignment_map = make_assignment_map(g);
+    auto pq = make_maxheap(g);
+    pq.push(0);
+    BOOST_TEST_THROWS(
+        boost::graph::stoer_wagner_min_cut(g, weights, parities, assignment_map, pq),
+        std::invalid_argument);
 }
 
 // example by Daniel Trebbien
@@ -119,10 +151,9 @@ void test2()
     weight_type ws[] = { 1, 3, 4, 6, 4, 1, 2, 5, 2 };
     undirected_graph g(edges, edges + 9, ws, 7, 9);
 
-    std::map< int, bool > parity;
-    boost::associative_property_map< std::map< int, bool > > parities(parity);
-    int w = boost::stoer_wagner_min_cut(
-        g, get(boost::edge_weight, g), boost::parity_map(parities));
+    std::map< vertex_descriptor, bool > parity;
+    boost::associative_property_map< std::map< vertex_descriptor, bool > > parities(parity);
+    const int w = boost::graph::stoer_wagner_min_cut(g, get(boost::edge_weight, g), parities);
     BOOST_TEST_EQ(w, 3);
     const bool parity2 = get(parities, 2);
     BOOST_TEST_EQ(parity2, get(parities, 4));
@@ -137,17 +168,18 @@ void test2()
 // example by Daniel Trebbien
 void test3()
 {
-    edge_t edges[] = { { 3, 4 }, { 3, 6 }, { 3, 5 }, { 0, 4 }, { 0, 1 },
+    edge_t edges[] = { 
+        { 3, 4 }, { 3, 6 }, { 3, 5 }, { 0, 4 }, { 0, 1 },
         { 0, 6 }, { 0, 7 }, { 0, 5 }, { 0, 2 }, { 4, 1 }, { 1, 6 }, { 1, 5 },
-        { 6, 7 }, { 7, 5 }, { 5, 2 }, { 3, 4 } };
+        { 6, 7 }, { 7, 5 }, { 5, 2 }, { 3, 4 }
+    };
     weight_type ws[] = { 0, 3, 1, 3, 1, 2, 6, 1, 8, 1, 1, 80, 2, 1, 1, 4 };
     undirected_graph g(edges, edges + 16, ws, 8, 16);
 
     weight_map_type weights = get(boost::edge_weight, g);
-    std::map< int, bool > parity;
-    boost::associative_property_map< std::map< int, bool > > parities(parity);
-    int w
-        = boost::stoer_wagner_min_cut(g, weights, boost::parity_map(parities));
+    std::map< vertex_descriptor, bool > parity;
+    boost::associative_property_map< std::map< vertex_descriptor, bool > > parities(parity);
+    const int w = boost::graph::stoer_wagner_min_cut(g, weights, parities);
     BOOST_TEST_EQ(w, 7);
     const bool parity1 = get(parities, 1);
     BOOST_TEST_EQ(parity1, get(parities, 5));
@@ -160,28 +192,21 @@ void test3()
     BOOST_TEST_EQ(parity0, get(parities, 7));
 }
 
+// unweighted graph with a constant weight map
 void test4()
 {
-    typedef boost::graph_traits<
-        undirected_unweighted_graph >::vertex_descriptor vertex_descriptor;
-    typedef boost::graph_traits< undirected_unweighted_graph >::edge_descriptor
-        edge_descriptor;
+    using vd = boost::graph_traits< undirected_unweighted_graph >::vertex_descriptor;
+    using ed = boost::graph_traits< undirected_unweighted_graph >::edge_descriptor;
 
     edge_t edges[] = { { 0, 1 }, { 1, 2 }, { 2, 3 }, { 0, 4 }, { 1, 4 },
         { 1, 5 }, { 2, 6 }, { 3, 6 }, { 3, 7 }, { 4, 5 }, { 5, 6 }, { 6, 7 },
         { 0, 4 }, { 6, 7 } };
     undirected_unweighted_graph g(edges, edges + 14, 8);
 
-    std::map< vertex_descriptor, bool > parity;
-    boost::associative_property_map< std::map< vertex_descriptor, bool > >
-        parities(parity);
-    std::map< vertex_descriptor, vertex_descriptor > assignment;
-    boost::associative_property_map<
-        std::map< vertex_descriptor, vertex_descriptor > >
-        assignments(assignment);
-    int w = boost::stoer_wagner_min_cut(g,
-        boost::make_constant_property< edge_descriptor >(weight_type(1)),
-        boost::vertex_assignment_map(assignments).parity_map(parities));
+    std::map< vd, bool > parity;
+    boost::associative_property_map< std::map< vd, bool > > parities(parity);
+    const int w = boost::graph::stoer_wagner_min_cut(g,
+        boost::make_constant_property< ed >(weight_type(1)), parities);
     BOOST_TEST_EQ(w, 2);
     const bool parity0 = get(parities, 0);
     BOOST_TEST_EQ(parity0, get(parities, 1));
@@ -204,10 +229,9 @@ void test5()
     undirected_graph g(edges, edges + 13, ws, 8, 13);
 
     weight_map_type weights = get(boost::edge_weight, g);
-    std::map< int, bool > parity;
-    boost::associative_property_map< std::map< int, bool > > parities(parity);
-    int w
-        = boost::stoer_wagner_min_cut(g, weights, boost::parity_map(parities));
+    std::map< vertex_descriptor, bool > parity;
+    boost::associative_property_map< std::map< vertex_descriptor, bool > > parities(parity);
+    const int w = boost::graph::stoer_wagner_min_cut(g, weights, parities);
     BOOST_TEST_EQ(w, 6);
     const bool parity0 = get(parities, 0);
     BOOST_TEST_EQ(parity0, get(parities, 1));
@@ -220,102 +244,62 @@ void test5()
     BOOST_TEST_EQ(parity4, get(parities, 7));
 }
 
-// The input for the `test_prgen` family of tests comes from a program, named
-// `prgen`, that comes with a package of min-cut solvers by Chandra Chekuri,
-// Andrew Goldberg, David Karger, Matthew Levine, and Cliff Stein. `prgen` was
+// The input for the test_prgen family of tests comes from a program named
+// prgen that comes with a package of min-cut solvers by Chandra Chekuri,
+// Andrew Goldberg, David Karger, Matthew Levine, and Cliff Stein. prgen was
 // used to generate input graphs and the solvers were used to verify the return
-// value of `boost::stoer_wagner_min_cut` on the input graphs.
+// value of stoer_wagner_min_cut on the input graphs.
 //
 // http://www.columbia.edu/~cs2035/code.html
 //
-// Note that it is somewhat more difficult to verify the parities because
-// "`prgen` graphs" often have several min-cuts. This is why only the cut
-// weight of the min-cut is verified.
+// Only the cut weight is verified because prgen graphs often have several
+// min-cuts.
 
-// 3 min-cuts
+// 3 min-cuts, via the fully positional overload with an explicit index map
 void test_prgen_20_70_2()
 {
-    typedef boost::graph_traits< undirected_graph >::vertex_descriptor
-        vertex_descriptor;
-
-    std::ifstream ifs(
-        (test_dir + "/prgen_input_graphs/prgen_20_70_2.net").c_str());
+    std::ifstream ifs((test_dir + "/prgen_input_graphs/prgen_20_70_2.net").c_str());
     undirected_graph g;
-    boost::read_dimacs_min_cut(
-        g, get(boost::edge_weight, g), boost::dummy_property_map(), ifs);
+    boost::read_dimacs_min_cut(g, get(boost::edge_weight, g), boost::dummy_property_map(), ifs);
 
     std::map< vertex_descriptor, std::size_t > component;
-    boost::associative_property_map<
-        std::map< vertex_descriptor, std::size_t > >
-        components(component);
-    BOOST_TEST_EQ(boost::connected_components(g, components),
-        1U); // verify the connectedness assumption
+    boost::associative_property_map< std::map< vertex_descriptor, std::size_t > > components(component);
+    BOOST_TEST_EQ(boost::connected_components(g, components), 1U);
 
-    typedef boost::shared_array_property_map< weight_type,
-        boost::property_map< undirected_graph,
-            boost::vertex_index_t >::const_type >
-        distances_type;
-    distances_type distances = boost::make_shared_array_property_map(
-        num_vertices(g), weight_type(0), get(boost::vertex_index, g));
-    typedef std::vector< vertex_descriptor >::size_type index_in_heap_type;
-    typedef boost::shared_array_property_map< index_in_heap_type,
-        boost::property_map< undirected_graph,
-            boost::vertex_index_t >::const_type >
-        indicesInHeap_type;
-    indicesInHeap_type indicesInHeap = boost::make_shared_array_property_map(
-        num_vertices(g), index_in_heap_type(-1), get(boost::vertex_index, g));
-    boost::d_ary_heap_indirect< vertex_descriptor, 22, indicesInHeap_type,
-        distances_type, std::greater< weight_type > >
-        pq(distances, indicesInHeap);
-
-    int w = boost::stoer_wagner_min_cut(
-        g, get(boost::edge_weight, g), boost::max_priority_queue(pq));
+    auto assignment_map = make_assignment_map(g);
+    auto pq = make_maxheap(g);
+    const int w = boost::graph::stoer_wagner_min_cut(g, get(boost::edge_weight, g),
+        boost::dummy_property_map(), assignment_map, pq, get(boost::vertex_index, g));
     BOOST_TEST_EQ(w, 3407);
 }
 
 // 7 min-cuts
 void test_prgen_50_40_2()
 {
-    typedef boost::graph_traits< undirected_graph >::vertex_descriptor
-        vertex_descriptor;
-
-    std::ifstream ifs(
-        (test_dir + "/prgen_input_graphs/prgen_50_40_2.net").c_str());
+    std::ifstream ifs((test_dir + "/prgen_input_graphs/prgen_50_40_2.net").c_str());
     undirected_graph g;
-    boost::read_dimacs_min_cut(
-        g, get(boost::edge_weight, g), boost::dummy_property_map(), ifs);
+    boost::read_dimacs_min_cut(g, get(boost::edge_weight, g), boost::dummy_property_map(), ifs);
 
     std::map< vertex_descriptor, std::size_t > component;
-    boost::associative_property_map<
-        std::map< vertex_descriptor, std::size_t > >
-        components(component);
-    BOOST_TEST_EQ(boost::connected_components(g, components),
-        1U); // verify the connectedness assumption
+    boost::associative_property_map< std::map< vertex_descriptor, std::size_t > > components(component);
+    BOOST_TEST_EQ(boost::connected_components(g, components), 1U);
 
-    int w = boost::stoer_wagner_min_cut(g, get(boost::edge_weight, g));
+    const int w = boost::graph::stoer_wagner_min_cut(g, get(boost::edge_weight, g), boost::dummy_property_map());
     BOOST_TEST_EQ(w, 10056);
 }
 
 // 6 min-cuts
 void test_prgen_50_70_2()
 {
-    typedef boost::graph_traits< undirected_graph >::vertex_descriptor
-        vertex_descriptor;
-
-    std::ifstream ifs(
-        (test_dir + "/prgen_input_graphs/prgen_50_70_2.net").c_str());
+    std::ifstream ifs((test_dir + "/prgen_input_graphs/prgen_50_70_2.net").c_str());
     undirected_graph g;
-    boost::read_dimacs_min_cut(
-        g, get(boost::edge_weight, g), boost::dummy_property_map(), ifs);
+    boost::read_dimacs_min_cut(g, get(boost::edge_weight, g), boost::dummy_property_map(), ifs);
 
     std::map< vertex_descriptor, std::size_t > component;
-    boost::associative_property_map<
-        std::map< vertex_descriptor, std::size_t > >
-        components(component);
-    BOOST_TEST_EQ(boost::connected_components(g, components),
-        1U); // verify the connectedness assumption
+    boost::associative_property_map< std::map< vertex_descriptor, std::size_t > > components(component);
+    BOOST_TEST_EQ(boost::connected_components(g, components), 1U);
 
-    int w = boost::stoer_wagner_min_cut(g, get(boost::edge_weight, g));
+    const int w = boost::graph::stoer_wagner_min_cut(g, get(boost::edge_weight, g), boost::dummy_property_map());
     BOOST_TEST_EQ(w, 21755);
 }
 
@@ -326,6 +310,7 @@ int main(int argc, char* argv[])
         test_dir = argv[1];
         test0();
         test1();
+        test_nonempty_queue_throws();
         test2();
         test3();
         test4();

--- a/test/stoer_wagner_test_old.cpp
+++ b/test/stoer_wagner_test_old.cpp
@@ -1,0 +1,344 @@
+//            Copyright Daniel Trebbien 2010.
+// Distributed under the Boost Software License, Version 1.0.
+//   (See accompanying file LICENSE_1_0.txt or the copy at
+//         http://www.boost.org/LICENSE_1_0.txt)
+
+// This test exercises the deprecated stoer_wagner_min_cut interfaces on purpose
+// (the named parameter and boost:: positional overloads that now live in
+// boost::graph), so silence the deprecation warnings.
+#define BOOST_ALLOW_DEPRECATED_SYMBOLS
+
+#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <vector>
+#include <string>
+#include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/connected_components.hpp>
+#include <boost/graph/exception.hpp>
+#include <boost/graph/graph_traits.hpp>
+#include <boost/graph/read_dimacs.hpp>
+#include <boost/graph/stoer_wagner_min_cut.hpp>
+#include <boost/graph/property_maps/constant_property_map.hpp>
+#include <boost/property_map/property_map.hpp>
+#include <boost/core/lightweight_test.hpp>
+#include <boost/tuple/tuple.hpp>
+
+#include "mas_sw_maxflow_oracle.hpp"
+
+using mas_sw_oracle::undirected_graph;
+using mas_sw_oracle::weight_map_type;
+using mas_sw_oracle::weight_type;
+
+typedef boost::adjacency_list< boost::vecS, boost::vecS, boost::undirectedS >
+    undirected_unweighted_graph;
+
+std::string test_dir;
+
+struct edge_t
+{
+    unsigned long first;
+    unsigned long second;
+};
+
+// Stoer Wagner global min cut on a curated set, checked against the known value.
+void test_curated_min_cuts()
+{
+    for (const mas_sw_oracle::curated_graph& cg : mas_sw_oracle::curated_graphs())
+    {
+        const undirected_graph& g = cg.graph;
+        BOOST_TEST(mas_sw_oracle::is_connected(g));
+        BOOST_TEST_EQ(boost::stoer_wagner_min_cut(g, get(boost::edge_weight, g)), cg.min_cut);
+    }
+}
+
+// the example from Stoer & Wagner (1997)
+void test0()
+{
+    edge_t edges[] = { { 0, 1 }, { 1, 2 }, { 2, 3 }, { 0, 4 }, { 1, 4 },
+        { 1, 5 }, { 2, 6 }, { 3, 6 }, { 3, 7 }, { 4, 5 }, { 5, 6 }, { 6, 7 } };
+    weight_type ws[] = { 2, 3, 4, 3, 2, 2, 2, 2, 2, 3, 1, 3 };
+    undirected_graph g(edges, edges + 12, ws, 8, 12);
+
+    weight_map_type weights = get(boost::edge_weight, g);
+    std::map< int, bool > parity;
+    boost::associative_property_map< std::map< int, bool > > parities(parity);
+    int w
+        = boost::stoer_wagner_min_cut(g, weights, boost::parity_map(parities));
+    BOOST_TEST_EQ(w, 4);
+    const bool parity0 = get(parities, 0);
+    BOOST_TEST_EQ(parity0, get(parities, 1));
+    BOOST_TEST_EQ(parity0, get(parities, 4));
+    BOOST_TEST_EQ(parity0, get(parities, 5));
+    const bool parity2 = get(parities, 2);
+    BOOST_TEST_NE(parity0, parity2);
+    BOOST_TEST_EQ(parity2, get(parities, 3));
+    BOOST_TEST_EQ(parity2, get(parities, 6));
+    BOOST_TEST_EQ(parity2, get(parities, 7));
+}
+
+void test1()
+{
+    { // if only one vertex, can't run `boost::stoer_wagner_min_cut`
+        undirected_graph g;
+        add_vertex(g);
+
+        BOOST_TEST_THROWS(
+            boost::stoer_wagner_min_cut(g, get(boost::edge_weight, g)),
+            boost::bad_graph);
+    }
+    { // three vertices with one multi-edge
+        typedef boost::graph_traits< undirected_graph >::vertex_descriptor
+            vertex_descriptor;
+
+        edge_t edges[] = { { 0, 1 }, { 1, 2 }, { 1, 2 }, { 2, 0 } };
+        weight_type ws[] = { 3, 1, 1, 1 };
+        undirected_graph g(edges, edges + 4, ws, 3, 4);
+
+        weight_map_type weights = get(boost::edge_weight, g);
+        std::map< int, bool > parity;
+        boost::associative_property_map< std::map< int, bool > > parities(
+            parity);
+        std::map< vertex_descriptor, vertex_descriptor > assignment;
+        boost::associative_property_map<
+            std::map< vertex_descriptor, vertex_descriptor > >
+            assignments(assignment);
+        int w = boost::stoer_wagner_min_cut(g, weights,
+            boost::parity_map(parities).vertex_assignment_map(assignments));
+        BOOST_TEST_EQ(w, 3);
+        const bool parity2 = get(parities, 2), parity0 = get(parities, 0);
+        BOOST_TEST_NE(parity2, parity0);
+        BOOST_TEST_EQ(parity0, get(parities, 1));
+    }
+}
+
+// example by Daniel Trebbien
+void test2()
+{
+    edge_t edges[] = { { 5, 2 }, { 0, 6 }, { 5, 6 }, { 3, 1 }, { 0, 1 },
+        { 6, 3 }, { 4, 6 }, { 2, 4 }, { 5, 3 } };
+    weight_type ws[] = { 1, 3, 4, 6, 4, 1, 2, 5, 2 };
+    undirected_graph g(edges, edges + 9, ws, 7, 9);
+
+    std::map< int, bool > parity;
+    boost::associative_property_map< std::map< int, bool > > parities(parity);
+    int w = boost::stoer_wagner_min_cut(
+        g, get(boost::edge_weight, g), boost::parity_map(parities));
+    BOOST_TEST_EQ(w, 3);
+    const bool parity2 = get(parities, 2);
+    BOOST_TEST_EQ(parity2, get(parities, 4));
+    const bool parity5 = get(parities, 5);
+    BOOST_TEST_NE(parity2, parity5);
+    BOOST_TEST_EQ(parity5, get(parities, 3));
+    BOOST_TEST_EQ(parity5, get(parities, 6));
+    BOOST_TEST_EQ(parity5, get(parities, 1));
+    BOOST_TEST_EQ(parity5, get(parities, 0));
+}
+
+// example by Daniel Trebbien
+void test3()
+{
+    edge_t edges[] = { { 3, 4 }, { 3, 6 }, { 3, 5 }, { 0, 4 }, { 0, 1 },
+        { 0, 6 }, { 0, 7 }, { 0, 5 }, { 0, 2 }, { 4, 1 }, { 1, 6 }, { 1, 5 },
+        { 6, 7 }, { 7, 5 }, { 5, 2 }, { 3, 4 } };
+    weight_type ws[] = { 0, 3, 1, 3, 1, 2, 6, 1, 8, 1, 1, 80, 2, 1, 1, 4 };
+    undirected_graph g(edges, edges + 16, ws, 8, 16);
+
+    weight_map_type weights = get(boost::edge_weight, g);
+    std::map< int, bool > parity;
+    boost::associative_property_map< std::map< int, bool > > parities(parity);
+    int w
+        = boost::stoer_wagner_min_cut(g, weights, boost::parity_map(parities));
+    BOOST_TEST_EQ(w, 7);
+    const bool parity1 = get(parities, 1);
+    BOOST_TEST_EQ(parity1, get(parities, 5));
+    const bool parity0 = get(parities, 0);
+    BOOST_TEST_NE(parity1, parity0);
+    BOOST_TEST_EQ(parity0, get(parities, 2));
+    BOOST_TEST_EQ(parity0, get(parities, 3));
+    BOOST_TEST_EQ(parity0, get(parities, 4));
+    BOOST_TEST_EQ(parity0, get(parities, 6));
+    BOOST_TEST_EQ(parity0, get(parities, 7));
+}
+
+void test4()
+{
+    typedef boost::graph_traits<
+        undirected_unweighted_graph >::vertex_descriptor vertex_descriptor;
+    typedef boost::graph_traits< undirected_unweighted_graph >::edge_descriptor
+        edge_descriptor;
+
+    edge_t edges[] = { { 0, 1 }, { 1, 2 }, { 2, 3 }, { 0, 4 }, { 1, 4 },
+        { 1, 5 }, { 2, 6 }, { 3, 6 }, { 3, 7 }, { 4, 5 }, { 5, 6 }, { 6, 7 },
+        { 0, 4 }, { 6, 7 } };
+    undirected_unweighted_graph g(edges, edges + 14, 8);
+
+    std::map< vertex_descriptor, bool > parity;
+    boost::associative_property_map< std::map< vertex_descriptor, bool > >
+        parities(parity);
+    std::map< vertex_descriptor, vertex_descriptor > assignment;
+    boost::associative_property_map<
+        std::map< vertex_descriptor, vertex_descriptor > >
+        assignments(assignment);
+    int w = boost::stoer_wagner_min_cut(g,
+        boost::make_constant_property< edge_descriptor >(weight_type(1)),
+        boost::vertex_assignment_map(assignments).parity_map(parities));
+    BOOST_TEST_EQ(w, 2);
+    const bool parity0 = get(parities, 0);
+    BOOST_TEST_EQ(parity0, get(parities, 1));
+    BOOST_TEST_EQ(parity0, get(parities, 4));
+    BOOST_TEST_EQ(parity0, get(parities, 5));
+    const bool parity2 = get(parities, 2);
+    BOOST_TEST_NE(parity0, parity2);
+    BOOST_TEST_EQ(parity2, get(parities, 3));
+    BOOST_TEST_EQ(parity2, get(parities, 6));
+    BOOST_TEST_EQ(parity2, get(parities, 7));
+}
+
+// Non regression test for github.com/boostorg/graph/issues/286
+void test5()
+{
+    edge_t edges[] = { { 0, 1 }, { 0, 2 }, { 0, 3 }, { 1, 2 }, { 1, 3 },
+        { 2, 3 }, { 4, 5 }, { 4, 6 }, { 4, 7 }, { 5, 6 }, { 5, 7 }, { 6, 7 },
+        { 0, 4 } };
+    weight_type ws[] = { 3, 3, 3, 2, 2, 2, 3, 3, 3, 2, 2, 2, 6 };
+    undirected_graph g(edges, edges + 13, ws, 8, 13);
+
+    weight_map_type weights = get(boost::edge_weight, g);
+    std::map< int, bool > parity;
+    boost::associative_property_map< std::map< int, bool > > parities(parity);
+    int w
+        = boost::stoer_wagner_min_cut(g, weights, boost::parity_map(parities));
+    BOOST_TEST_EQ(w, 6);
+    const bool parity0 = get(parities, 0);
+    BOOST_TEST_EQ(parity0, get(parities, 1));
+    BOOST_TEST_EQ(parity0, get(parities, 2));
+    BOOST_TEST_EQ(parity0, get(parities, 3));
+    const bool parity4 = get(parities, 4);
+    BOOST_TEST_NE(parity0, parity4);
+    BOOST_TEST_EQ(parity4, get(parities, 5));
+    BOOST_TEST_EQ(parity4, get(parities, 6));
+    BOOST_TEST_EQ(parity4, get(parities, 7));
+}
+
+// The input for the `test_prgen` family of tests comes from a program, named
+// `prgen`, that comes with a package of min-cut solvers by Chandra Chekuri,
+// Andrew Goldberg, David Karger, Matthew Levine, and Cliff Stein. `prgen` was
+// used to generate input graphs and the solvers were used to verify the return
+// value of `boost::stoer_wagner_min_cut` on the input graphs.
+//
+// http://www.columbia.edu/~cs2035/code.html
+//
+// Note that it is somewhat more difficult to verify the parities because
+// "`prgen` graphs" often have several min-cuts. This is why only the cut
+// weight of the min-cut is verified.
+
+// 3 min-cuts
+void test_prgen_20_70_2()
+{
+    typedef boost::graph_traits< undirected_graph >::vertex_descriptor
+        vertex_descriptor;
+
+    std::ifstream ifs(
+        (test_dir + "/prgen_input_graphs/prgen_20_70_2.net").c_str());
+    undirected_graph g;
+    boost::read_dimacs_min_cut(
+        g, get(boost::edge_weight, g), boost::dummy_property_map(), ifs);
+
+    std::map< vertex_descriptor, std::size_t > component;
+    boost::associative_property_map<
+        std::map< vertex_descriptor, std::size_t > >
+        components(component);
+    BOOST_TEST_EQ(boost::connected_components(g, components),
+        1U); // verify the connectedness assumption
+
+    typedef boost::shared_array_property_map< weight_type,
+        boost::property_map< undirected_graph,
+            boost::vertex_index_t >::const_type >
+        distances_type;
+    distances_type distances = boost::make_shared_array_property_map(
+        num_vertices(g), weight_type(0), get(boost::vertex_index, g));
+    typedef std::vector< vertex_descriptor >::size_type index_in_heap_type;
+    typedef boost::shared_array_property_map< index_in_heap_type,
+        boost::property_map< undirected_graph,
+            boost::vertex_index_t >::const_type >
+        indicesInHeap_type;
+    indicesInHeap_type indicesInHeap = boost::make_shared_array_property_map(
+        num_vertices(g), index_in_heap_type(-1), get(boost::vertex_index, g));
+    boost::d_ary_heap_indirect< vertex_descriptor, 22, indicesInHeap_type,
+        distances_type, std::greater< weight_type > >
+        pq(distances, indicesInHeap);
+
+    int w = boost::stoer_wagner_min_cut(
+        g, get(boost::edge_weight, g), boost::max_priority_queue(pq));
+    BOOST_TEST_EQ(w, 3407);
+}
+
+// 7 min-cuts
+void test_prgen_50_40_2()
+{
+    typedef boost::graph_traits< undirected_graph >::vertex_descriptor
+        vertex_descriptor;
+
+    std::ifstream ifs(
+        (test_dir + "/prgen_input_graphs/prgen_50_40_2.net").c_str());
+    undirected_graph g;
+    boost::read_dimacs_min_cut(
+        g, get(boost::edge_weight, g), boost::dummy_property_map(), ifs);
+
+    std::map< vertex_descriptor, std::size_t > component;
+    boost::associative_property_map<
+        std::map< vertex_descriptor, std::size_t > >
+        components(component);
+    BOOST_TEST_EQ(boost::connected_components(g, components),
+        1U); // verify the connectedness assumption
+
+    int w = boost::stoer_wagner_min_cut(g, get(boost::edge_weight, g));
+    BOOST_TEST_EQ(w, 10056);
+}
+
+// 6 min-cuts
+void test_prgen_50_70_2()
+{
+    typedef boost::graph_traits< undirected_graph >::vertex_descriptor
+        vertex_descriptor;
+
+    std::ifstream ifs(
+        (test_dir + "/prgen_input_graphs/prgen_50_70_2.net").c_str());
+    undirected_graph g;
+    boost::read_dimacs_min_cut(
+        g, get(boost::edge_weight, g), boost::dummy_property_map(), ifs);
+
+    std::map< vertex_descriptor, std::size_t > component;
+    boost::associative_property_map<
+        std::map< vertex_descriptor, std::size_t > >
+        components(component);
+    BOOST_TEST_EQ(boost::connected_components(g, components),
+        1U); // verify the connectedness assumption
+
+    int w = boost::stoer_wagner_min_cut(g, get(boost::edge_weight, g));
+    BOOST_TEST_EQ(w, 21755);
+}
+
+int main(int argc, char* argv[])
+{
+    if (BOOST_TEST(argc == 2))
+    {
+        test_dir = argv[1];
+        test0();
+        test1();
+        test2();
+        test3();
+        test4();
+        test5();
+        test_prgen_20_70_2();
+        test_prgen_50_40_2();
+        test_prgen_50_70_2();
+        test_curated_min_cuts();
+    }
+    return boost::report_errors();
+}


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [ ] Bug fix
- [ ] New feature or API addition
- [x] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

<!-- A short summary of the change. -->

- Moved `stoer_wagner_min_cut` from `boost` into `boost::graph` (positional: 6-arg, 5-arg, 3-arg convenience).
- Added `BOOST_DEPRECATED` `boost::` shims for positional 6-arg, named-param, 2-arg (nothing removed).
- Weight-only now takes `boost::dummy_property_map()` (we cant have bare 2-arg in `boost::graph`, this will have to wait 1.95 removal of the existing 2-arg overload).
- Renamed old tests as `stoer_wagner_test_old.cpp` (still covers deprecated forms, `BOOST_ALLOW_DEPRECATED_SYMBOLS` to reduce warnings); registered in `Jamfile.v2`, will be removed in 1.95
- Add modernized `stoer_wagner_test.cpp` to test the new positional interface.
- Updated `example/stoer_wagner.cpp` + doc example to  use`boost::graph::` namespaces.
- Rewrote the `.adoc` to imitate the style of MAS doc page.

### Motivation

<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->

Deprecating the named parameters signature once, then deprecating again for namespace migration will be painful for users. It's better to have them change the call site once for all.

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->

Both legacy (deprecated) interfaces and new interfaces are covered.

### Checklist

- [x] Existing tests pass (`b2` in the `test/` directory).
- [x] New behavior is covered by a test, or this is a docs / build / refactor change.
- [x] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.
