### PR TITLE
refactor: align template and typedef types as per convention

### DIFF
--- a/doc/modules/ROOT/pages/algorithms/shortest_paths/r_c_shortest_paths.adoc
+++ b/doc/modules/ROOT/pages/algorithms/shortest_paths/r_c_shortest_paths.adoc
@@ -26,10 +26,10 @@ include::example$algorithms/shortest_paths/r_c_shortest.txt[]
 ----
 template <class Graph,
           class VertexIndexMap,
-          class Resource_Container,
-          class Resource_Extension_Function,
-          class Dominance_Function,
-          class Label_Allocator,
+          class ResourceContainer,
+          class ResourceExtensionFunction,
+          class DominanceFunction,
+          class LabelAllocator,
           class Visitor>
 void r_c_shortest_paths(
     const Graph& g,
@@ -37,11 +37,11 @@ void r_c_shortest_paths(
     typename graph_traits<Graph>::vertex_descriptor s,
     typename graph_traits<Graph>::vertex_descriptor t,
     std::vector<std::vector<typename graph_traits<Graph>::edge_descriptor>>& pareto_optimal_solutions,
-    std::vector<Resource_Container>& pareto_optimal_resource_containers,
-    const Resource_Container& rc,
-    const Resource_Extension_Function& ref,
-    const Dominance_Function& dominance,
-    Label_Allocator la,
+    std::vector<ResourceContainer>& pareto_optimal_resource_containers,
+    const ResourceContainer& rc,
+    const ResourceExtensionFunction& ref,
+    const DominanceFunction& dominance,
+    LabelAllocator la,
     Visitor vis)
 ----
 
@@ -52,10 +52,10 @@ Old interface, to be deprecated in future releases.
 template <class Graph,
       class VertexIndexMap,
       class EdgeIndexMap,
-      class Resource_Container,
-      class Resource_Extension_Function,
-      class Dominance_Function,
-      class Label_Allocator,
+      class ResourceContainer,
+      class ResourceExtensionFunction,
+      class DominanceFunction,
+      class LabelAllocator,
       class Visitor>
 void r_c_shortest_paths(
     const Graph& g,
@@ -64,11 +64,11 @@ void r_c_shortest_paths(
     typename graph_traits<Graph>::vertex_descriptor s,
     typename graph_traits<Graph>::vertex_descriptor t,
     std::vector<std::vector<typename graph_traits<Graph>::edge_descriptor>>& pareto_optimal_solutions,
-    std::vector<Resource_Container>& pareto_optimal_resource_containers,
-    const Resource_Container& rc,
-    const Resource_Extension_Function& ref,
-    const Dominance_Function& dominance,
-    Label_Allocator la,
+    std::vector<ResourceContainer>& pareto_optimal_resource_containers,
+    const ResourceContainer& rc,
+    const ResourceExtensionFunction& ref,
+    const DominanceFunction& dominance,
+    LabelAllocator la,
     Visitor vis)
 ----
 
@@ -108,32 +108,32 @@ void r_c_shortest_paths(
   (from `t` to `s`).
 
 | OUT
-| `std::vector<Resource_Container>& pareto_optimal_resource_containers`
+| `std::vector<ResourceContainer>& pareto_optimal_resource_containers`
 | A container for storing the Pareto-optimal resource containers
   corresponding to all Pareto-optimal solutions.
 
 | IN
-| `const Resource_Container& rc`
+| `const ResourceContainer& rc`
 | An object specifying the initial resource consumptions at vertex `s`.
-  The type `Resource_Container` must be a model of the ResourceContainer concept.
+  The type `ResourceContainer` must be a model of the ResourceContainer concept.
 
 | IN
-| `const Resource_Extension_Function& ref`
+| `const ResourceExtensionFunction& ref`
 | A function object, function pointer, or function specifying how a label is to
-  be extended along an arc. The type `Resource_Extension_Function` must be a model
+  be extended along an arc. The type `ResourceExtensionFunction` must be a model
   of the ResourceExtensionFunction concept.
 
 | IN
-| `const Dominance_Function& dominance`
+| `const DominanceFunction& dominance`
 | A function object, function pointer, or function specifying a dominance
-  relation between two labels. The type `Dominance_Function` must be a model of
+  relation between two labels. The type `DominanceFunction` must be a model of
   the DominanceFunction concept.
 
 | IN
-| `Label_Allocator la`
+| `LabelAllocator la`
 | An object specifying a strategy for the memory management of the labels.
   It must offer the same interface as
-  `std::allocator<r_c_shortest_paths_label<Graph, Resource_Container>>`.
+  `std::allocator<r_c_shortest_paths_label<Graph, ResourceContainer>>`.
   There is a default type `default_r_c_shortest_paths_allocator` for this
   parameter using the STL standard allocator. If one wants to use a specialized
   allocator, one can specify an arbitrary type as template parameter for
@@ -156,10 +156,10 @@ void r_c_shortest_paths(
 ----
 template <class Graph,
           class VertexIndexMap,
-          class Resource_Container,
-          class Resource_Extension_Function,
-          class Dominance_Function,
-          class Label_Allocator,
+          class ResourceContainer,
+          class ResourceExtensionFunction,
+          class DominanceFunction,
+          class LabelAllocator,
           class Visitor>
 void r_c_shortest_paths(
     const Graph& g,
@@ -167,11 +167,11 @@ void r_c_shortest_paths(
     typename graph_traits<Graph>::vertex_descriptor s,
     typename graph_traits<Graph>::vertex_descriptor t,
     std::vector<typename graph_traits<Graph>::edge_descriptor>& pareto_optimal_solution,
-    Resource_Container& pareto_optimal_resource_container,
-    const Resource_Container& rc,
-    const Resource_Extension_Function& ref,
-    const Dominance_Function& dominance,
-    Label_Allocator la,
+    ResourceContainer& pareto_optimal_resource_container,
+    const ResourceContainer& rc,
+    const ResourceExtensionFunction& ref,
+    const DominanceFunction& dominance,
+    LabelAllocator la,
     Visitor vis)
 ----
 
@@ -182,10 +182,10 @@ Old interface, to be deprecated in future releases.
 template <class Graph,
           class VertexIndexMap,
           class EdgeIndexMap,
-          class Resource_Container,
-          class Resource_Extension_Function,
-          class Dominance_Function,
-          class Label_Allocator,
+          class ResourceContainer,
+          class ResourceExtensionFunction,
+          class DominanceFunction,
+          class LabelAllocator,
           class Visitor>
 void r_c_shortest_paths(
     const Graph& g,
@@ -194,11 +194,11 @@ void r_c_shortest_paths(
     typename graph_traits<Graph>::vertex_descriptor s,
     typename graph_traits<Graph>::vertex_descriptor t,
     std::vector<typename graph_traits<Graph>::edge_descriptor>& pareto_optimal_solution,
-    Resource_Container& pareto_optimal_resource_container,
-    const Resource_Container& rc,
-    const Resource_Extension_Function& ref,
-    const Dominance_Function& dominance,
-    Label_Allocator la,
+    ResourceContainer& pareto_optimal_resource_container,
+    const ResourceContainer& rc,
+    const ResourceExtensionFunction& ref,
+    const DominanceFunction& dominance,
+    LabelAllocator la,
     Visitor vis)
 ----
 
@@ -238,33 +238,33 @@ void r_c_shortest_paths(
   (from `t` to `s`). This argument is not modified if there are no solutions.
 
 | OUT
-| `Resource_Container& pareto_optimal_resource_container`
-| A `Resource_Container` object for storing the Pareto-optimal resource
+| `ResourceContainer& pareto_optimal_resource_container`
+| A `ResourceContainer` object for storing the Pareto-optimal resource
   container corresponding to the first Pareto-optimal path. This argument
   is not modified if there are no solutions.
 
 | IN
-| `const Resource_Container& rc`
+| `const ResourceContainer& rc`
 | An object specifying the initial resource consumptions at vertex `s`.
-  The type `Resource_Container` must be a model of the ResourceContainer concept.
+  The type `ResourceContainer` must be a model of the ResourceContainer concept.
 
 | IN
-| `const Resource_Extension_Function& ref`
+| `const ResourceExtensionFunction& ref`
 | A function object, function pointer, or function specifying how a label is to
-  be extended along an arc. The type `Resource_Extension_Function` must be a model
+  be extended along an arc. The type `ResourceExtensionFunction` must be a model
   of the ResourceExtensionFunction concept.
 
 | IN
-| `const Dominance_Function& dominance`
+| `const DominanceFunction& dominance`
 | A function object, function pointer, or function specifying a dominance
-  relation between two labels. The type `Dominance_Function` must be a model of
+  relation between two labels. The type `DominanceFunction` must be a model of
   the DominanceFunction concept.
 
 | IN
-| `Label_Allocator la`
+| `LabelAllocator la`
 | An object specifying a strategy for the memory management of the labels.
   It must offer the same interface as
-  `std::allocator<r_c_shortest_paths_label<Graph, Resource_Container>>`.
+  `std::allocator<r_c_shortest_paths_label<Graph, ResourceContainer>>`.
   There is a default type `default_r_c_shortest_paths_allocator` for this
   parameter using the STL standard allocator.
 
@@ -285,19 +285,19 @@ void r_c_shortest_paths(
 ----
 template <class Graph,
           class VertexIndexMap,
-          class Resource_Container,
-          class Resource_Extension_Function,
-          class Dominance_Function>
+          class ResourceContainer,
+          class ResourceExtensionFunction,
+          class DominanceFunction>
 void r_c_shortest_paths(
     const Graph& g,
     const VertexIndexMap& vertex_index_map,
     typename graph_traits<Graph>::vertex_descriptor s,
     typename graph_traits<Graph>::vertex_descriptor t,
     std::vector<std::vector<typename graph_traits<Graph>::edge_descriptor>>& pareto_optimal_solutions,
-    std::vector<Resource_Container>& pareto_optimal_resource_containers,
-    const Resource_Container& rc,
-    const Resource_Extension_Function& ref,
-    const Dominance_Function& dominance)
+    std::vector<ResourceContainer>& pareto_optimal_resource_containers,
+    const ResourceContainer& rc,
+    const ResourceExtensionFunction& ref,
+    const DominanceFunction& dominance)
 ----
 
 Old interface, to be deprecated in future releases.
@@ -307,9 +307,9 @@ Old interface, to be deprecated in future releases.
 template <class Graph,
           class VertexIndexMap,
           class EdgeIndexMap,
-          class Resource_Container,
-          class Resource_Extension_Function,
-          class Dominance_Function>
+          class ResourceContainer,
+          class ResourceExtensionFunction,
+          class DominanceFunction>
 void r_c_shortest_paths(
     const Graph& g,
     const VertexIndexMap& vertex_index_map,
@@ -317,10 +317,10 @@ void r_c_shortest_paths(
     typename graph_traits<Graph>::vertex_descriptor s,
     typename graph_traits<Graph>::vertex_descriptor t,
     std::vector<std::vector<typename graph_traits<Graph>::edge_descriptor>>& pareto_optimal_solutions,
-    std::vector<Resource_Container>& pareto_optimal_resource_containers,
-    const Resource_Container& rc,
-    const Resource_Extension_Function& ref,
-    const Dominance_Function& dominance)
+    std::vector<ResourceContainer>& pareto_optimal_resource_containers,
+    const ResourceContainer& rc,
+    const ResourceExtensionFunction& ref,
+    const DominanceFunction& dominance)
 ----
 
 [%autowrap, cols="1,2,5"]
@@ -359,25 +359,25 @@ void r_c_shortest_paths(
   (from `t` to `s`).
 
 | OUT
-| `std::vector<Resource_Container>& pareto_optimal_resource_containers`
+| `std::vector<ResourceContainer>& pareto_optimal_resource_containers`
 | A container for storing the Pareto-optimal resource containers
   corresponding to all Pareto-optimal solutions.
 
 | IN
-| `const Resource_Container& rc`
+| `const ResourceContainer& rc`
 | An object specifying the initial resource consumptions at vertex `s`.
-  The type `Resource_Container` must be a model of the ResourceContainer concept.
+  The type `ResourceContainer` must be a model of the ResourceContainer concept.
 
 | IN
-| `const Resource_Extension_Function& ref`
+| `const ResourceExtensionFunction& ref`
 | A function object, function pointer, or function specifying how a label is to
-  be extended along an arc. The type `Resource_Extension_Function` must be a model
+  be extended along an arc. The type `ResourceExtensionFunction` must be a model
   of the ResourceExtensionFunction concept.
 
 | IN
-| `const Dominance_Function& dominance`
+| `const DominanceFunction& dominance`
 | A function object, function pointer, or function specifying a dominance
-  relation between two labels. The type `Dominance_Function` must be a model of
+  relation between two labels. The type `DominanceFunction` must be a model of
   the DominanceFunction concept.
 |===
 
@@ -390,9 +390,9 @@ void r_c_shortest_paths(
 template <class Graph,
           class VertexIndexMap,
           class EdgeIndexMap,
-          class Resource_Container,
-          class Resource_Extension_Function,
-          class Dominance_Function>
+          class ResourceContainer,
+          class ResourceExtensionFunction,
+          class DominanceFunction>
 void r_c_shortest_paths(
     const Graph& g,
     const VertexIndexMap& vertex_index_map,
@@ -400,10 +400,10 @@ void r_c_shortest_paths(
     typename graph_traits<Graph>::vertex_descriptor s,
     typename graph_traits<Graph>::vertex_descriptor t,
     std::vector<typename graph_traits<Graph>::edge_descriptor>& pareto_optimal_solution,
-    Resource_Container& pareto_optimal_resource_container,
-    const Resource_Container& rc,
-    const Resource_Extension_Function& ref,
-    const Dominance_Function& dominance)
+    ResourceContainer& pareto_optimal_resource_container,
+    const ResourceContainer& rc,
+    const ResourceExtensionFunction& ref,
+    const DominanceFunction& dominance)
 ----
 
 Old interface, to be deprecated in future releases.
@@ -412,19 +412,19 @@ Old interface, to be deprecated in future releases.
 ----
 template <class Graph,
           class VertexIndexMap,
-          class Resource_Container,
-          class Resource_Extension_Function,
-          class Dominance_Function>
+          class ResourceContainer,
+          class ResourceExtensionFunction,
+          class DominanceFunction>
 void r_c_shortest_paths(
     const Graph& g,
     const VertexIndexMap& vertex_index_map,
     typename graph_traits<Graph>::vertex_descriptor s,
     typename graph_traits<Graph>::vertex_descriptor t,
     std::vector<typename graph_traits<Graph>::edge_descriptor>& pareto_optimal_solution,
-    Resource_Container& pareto_optimal_resource_container,
-    const Resource_Container& rc,
-    const Resource_Extension_Function& ref,
-    const Dominance_Function& dominance)
+    ResourceContainer& pareto_optimal_resource_container,
+    const ResourceContainer& rc,
+    const ResourceExtensionFunction& ref,
+    const DominanceFunction& dominance)
 ----
 
 [cols="1,2,5"]
@@ -463,26 +463,26 @@ void r_c_shortest_paths(
   (from `t` to `s`). This argument is not modified if there are no solutions.
 
 | OUT
-| `Resource_Container& pareto_optimal_resource_container`
-| A `Resource_Container` object for storing the Pareto-optimal resource
+| `ResourceContainer& pareto_optimal_resource_container`
+| A `ResourceContainer` object for storing the Pareto-optimal resource
   container corresponding to the first Pareto-optimal path. This argument
   is not modified if there are no solutions.
 
 | IN
-| `const Resource_Container& rc`
+| `const ResourceContainer& rc`
 | An object specifying the initial resource consumptions at vertex `s`.
-  The type `Resource_Container` must be a model of the ResourceContainer concept.
+  The type `ResourceContainer` must be a model of the ResourceContainer concept.
 
 | IN
-| `const Resource_Extension_Function& ref`
+| `const ResourceExtensionFunction& ref`
 | A function object, function pointer, or function specifying how a label is to
-  be extended along an arc. The type `Resource_Extension_Function` must be a model
+  be extended along an arc. The type `ResourceExtensionFunction` must be a model
   of the ResourceExtensionFunction concept.
 
 | IN
-| `const Dominance_Function& dominance`
+| `const DominanceFunction& dominance`
 | A function object, function pointer, or function specifying a dominance
-  relation between two labels. The type `Dominance_Function` must be a model of
+  relation between two labels. The type `DominanceFunction` must be a model of
   the DominanceFunction concept.
 |===
 
@@ -540,7 +540,7 @@ See <<ResourceExtensionFunction,ResourceExtensionFunction>> concept.
 [#Label]
 == Label
 
-This concept defines the interface for a label in the `r_c_shortest_paths` functions. It is a design decision not to parameterize the functions on the type of label. The type `template<class Graph, class Resource_Container> struct r_c_shortest_paths_label` is used to model this concept.
+This concept defines the interface for a label in the `r_c_shortest_paths` functions. It is a design decision not to parameterize the functions on the type of label. The type `template<class Graph, class ResourceContainer> struct r_c_shortest_paths_label` is used to model this concept.
 
 *Valid Expressions* +
 If `label` is an object of type `r_c_shortest_paths_label`, the following expressions are valid:
@@ -577,7 +577,7 @@ Every `r_c_shortest_paths_label` object, except for the first label, has a valid
 A model of the ResourceExtensionFunction concept is used to specify how a label is to be extended along an arc.
 
 *Valid Expressions* +
-If `ref` models the ResourceExtensionFunction concept, and if the type `Resource_Container` models the ResourceContainer concept, the following expression is valid:
+If `ref` models the ResourceExtensionFunction concept, and if the type `ResourceContainer` models the ResourceContainer concept, the following expression is valid:
 
 [cols="1,1"]
 |===
@@ -585,8 +585,8 @@ a|
 [source,cpp]
 ----
 bool b = ref( const Graph& g,
-              Resource_Container& new_cont,
-              const Resource_Container& old_cont,
+              ResourceContainer& new_cont,
+              const ResourceContainer& old_cont,
               graph_traits<Graph>::edge_descriptor ed )
 ----
 
@@ -598,13 +598,13 @@ Moreover, a reference to a type modelling the ResourceExtensionFunction concept 
 Hence, a type modelling the ResourceExtensionFunction concept is likely to be a function or a http://www.boost.org/sgi/stl/functors.html[function object].
 
 *Invariants* +
-If `ref` models the ResourceExtensionFunction concept, and if the type `Resource_Container` models the ResourceContainer concept, after the call
+If `ref` models the ResourceExtensionFunction concept, and if the type `ResourceContainer` models the ResourceContainer concept, after the call
 
 [source,cpp]
 ----
 ref( const Graph& g,
-     Resource_Container& new_cont,
-     const Resource_Container& old_cont,
+     ResourceContainer& new_cont,
+     const ResourceContainer& old_cont,
      graph_traits<Graph>::edge_descriptor )
 ----
 
@@ -619,13 +619,13 @@ A model of DominanceFunction is used to specify a dominance relation between two
 http://www.boost.org/sgi/stl/BinaryPredicate.html[BinaryPredicate]
 
 *Valid Expressions* +
-If `dominance` models the DominanceFunction concept, and if the type `Resource_Container` models the ResourceContainer concept, the following expression is valid:
+If `dominance` models the DominanceFunction concept, and if the type `ResourceContainer` models the ResourceContainer concept, the following expression is valid:
 
 [cols="1,1"]
 |===
 a|
 ....
-bool b = dominance(const Resource_Container& rc1, const Resource_Container& rc2)
+bool b = dominance(const ResourceContainer& rc1, const ResourceContainer& rc2)
 ....
 
 | `dominance` must return `true` if and only if `rc1` dominates `rc2`.
@@ -715,7 +715,7 @@ r_c_shortest_paths( g,
 === Preconditions
 
 * `s` and `t` are valid vertex descriptors for `g`.
-* `rc` is within the resource windows at `s`, i.e., it constitutes a feasible `Resource_Container` object at `s` (see <<Discussion,discussion>>).
+* `rc` is within the resource windows at `s`, i.e., it constitutes a feasible `ResourceContainer` object at `s` (see <<Discussion,discussion>>).
 
 == Throws
 
@@ -737,7 +737,7 @@ Experience shows that for 'small' resource containers, it may be useful to try a
 
 === Allocator and Visitor Defaults
 
-If the third or the fourth overload of the function is used, objects of type `default_r_c_shortest_paths_allocator` and `default_r_c_shortest_paths_visitor` are used as the `Label_Allocator` and `Visitor` parameters respectively. If the first or the second overload is used, one must specify both a `Label_Allocator` and a `Visitor` parameter. If one wants to develop a user-defined type only for `Visitor`, one can use `default_r_c_shortest_paths_allocator` as `Label_Allocator` parameter. If one wants to use only a specialized allocator, one can use `default_r_c_shortest_paths_visitor` as `Visitor` parameter.
+If the third or the fourth overload of the function is used, objects of type `default_r_c_shortest_paths_allocator` and `default_r_c_shortest_paths_visitor` are used as the `LabelAllocator` and `Visitor` parameters respectively. If the first or the second overload is used, one must specify both a `LabelAllocator` and a `Visitor` parameter. If one wants to develop a user-defined type only for `Visitor`, one can use `default_r_c_shortest_paths_allocator` as `LabelAllocator` parameter. If one wants to use only a specialized allocator, one can use `default_r_c_shortest_paths_visitor` as `Visitor` parameter.
 
 === Utility Function: check_r_c_path
 
@@ -746,16 +746,16 @@ There is a utility function called `check_r_c_path` that can be used for debuggi
 [source,cpp]
 ----
 template <class Graph,
-          class Resource_Container,
-          class Resource_Extension_Function>
+          class ResourceContainer,
+          class ResourceExtensionFunction>
 void check_r_c_path(
     const Graph& g,
     const std::vector<typename graph_traits<Graph>::edge_descriptor>& ed_vec_path,
-    const Resource_Container& initial_resource_levels,
+    const ResourceContainer& initial_resource_levels,
     bool b_result_must_be_equal_to_desired_final_resource_levels,
-    const Resource_Container& desired_final_resource_levels,
-    Resource_Container& actual_final_resource_levels,
-    const Resource_Extension_Function& ref,
+    const ResourceContainer& desired_final_resource_levels,
+    ResourceContainer& actual_final_resource_levels,
+    const ResourceExtensionFunction& ref,
     bool& b_is_a_path_at_all,
     bool& b_feasible,
     bool& b_correctly_extended,

--- a/include/boost/graph/r_c_shortest_paths.hpp
+++ b/include/boost/graph/r_c_shortest_paths.hpp
@@ -22,16 +22,16 @@ namespace boost
 {
 
 // r_c_shortest_paths_label struct
-template < class Graph, class Resource_Container >
+template < class Graph, class ResourceContainer >
 struct r_c_shortest_paths_label
 {
     r_c_shortest_paths_label(const unsigned long n,
-        const Resource_Container& rc = Resource_Container(),
+        const ResourceContainer& rc = ResourceContainer(),
         const std::shared_ptr<
-            r_c_shortest_paths_label< Graph, Resource_Container > >
+            r_c_shortest_paths_label< Graph, ResourceContainer > >
             pl
         = std::shared_ptr<
-            r_c_shortest_paths_label< Graph, Resource_Container > >(),
+            r_c_shortest_paths_label< Graph, ResourceContainer > >(),
         const typename graph_traits< Graph >::edge_descriptor& ed
         = graph_traits< Graph >::edge_descriptor(),
         const typename graph_traits< Graph >::vertex_descriptor& vd
@@ -55,9 +55,9 @@ struct r_c_shortest_paths_label
         return *this;
     }
     const unsigned long num;
-    Resource_Container cumulated_resource_consumption;
+    ResourceContainer cumulated_resource_consumption;
     const std::shared_ptr<
-        r_c_shortest_paths_label< Graph, Resource_Container > >
+        r_c_shortest_paths_label< Graph, ResourceContainer > >
         p_pred_label;
     const typename graph_traits< Graph >::edge_descriptor pred_edge;
     const typename graph_traits< Graph >::vertex_descriptor resident_vertex;
@@ -65,53 +65,53 @@ struct r_c_shortest_paths_label
     bool b_is_processed;
 }; // r_c_shortest_paths_label
 
-template < class Graph, class Resource_Container >
+template < class Graph, class ResourceContainer >
 inline bool operator==(
-    const r_c_shortest_paths_label< Graph, Resource_Container >& l1,
-    const r_c_shortest_paths_label< Graph, Resource_Container >& l2)
+    const r_c_shortest_paths_label< Graph, ResourceContainer >& l1,
+    const r_c_shortest_paths_label< Graph, ResourceContainer >& l2)
 {
     return l1.cumulated_resource_consumption
         == l2.cumulated_resource_consumption;
 }
 
-template < class Graph, class Resource_Container >
+template < class Graph, class ResourceContainer >
 inline bool operator!=(
-    const r_c_shortest_paths_label< Graph, Resource_Container >& l1,
-    const r_c_shortest_paths_label< Graph, Resource_Container >& l2)
+    const r_c_shortest_paths_label< Graph, ResourceContainer >& l1,
+    const r_c_shortest_paths_label< Graph, ResourceContainer >& l2)
 {
     return !(l1 == l2);
 }
 
-template < class Graph, class Resource_Container >
+template < class Graph, class ResourceContainer >
 inline bool operator<(
-    const r_c_shortest_paths_label< Graph, Resource_Container >& l1,
-    const r_c_shortest_paths_label< Graph, Resource_Container >& l2)
+    const r_c_shortest_paths_label< Graph, ResourceContainer >& l1,
+    const r_c_shortest_paths_label< Graph, ResourceContainer >& l2)
 {
     return l1.cumulated_resource_consumption
         < l2.cumulated_resource_consumption;
 }
 
-template < class Graph, class Resource_Container >
+template < class Graph, class ResourceContainer >
 inline bool operator>(
-    const r_c_shortest_paths_label< Graph, Resource_Container >& l1,
-    const r_c_shortest_paths_label< Graph, Resource_Container >& l2)
+    const r_c_shortest_paths_label< Graph, ResourceContainer >& l1,
+    const r_c_shortest_paths_label< Graph, ResourceContainer >& l2)
 {
     return l2.cumulated_resource_consumption
         < l1.cumulated_resource_consumption;
 }
 
-template < class Graph, class Resource_Container >
+template < class Graph, class ResourceContainer >
 inline bool operator<=(
-    const r_c_shortest_paths_label< Graph, Resource_Container >& l1,
-    const r_c_shortest_paths_label< Graph, Resource_Container >& l2)
+    const r_c_shortest_paths_label< Graph, ResourceContainer >& l1,
+    const r_c_shortest_paths_label< Graph, ResourceContainer >& l2)
 {
     return l1 < l2 || l1 == l2;
 }
 
-template < class Graph, class Resource_Container >
+template < class Graph, class ResourceContainer >
 inline bool operator>=(
-    const r_c_shortest_paths_label< Graph, Resource_Container >& l1,
-    const r_c_shortest_paths_label< Graph, Resource_Container >& l2)
+    const r_c_shortest_paths_label< Graph, ResourceContainer >& l1,
+    const r_c_shortest_paths_label< Graph, ResourceContainer >& l2)
 {
     return l2 < l1 || l1 == l2;
 }
@@ -131,8 +131,8 @@ namespace detail
 
     // r_c_shortest_paths_dispatch function (body/implementation)
     template < class Graph, class VertexIndexMap,
-        class Resource_Container, class Resource_Extension_Function,
-        class Dominance_Function, class Label_Allocator, class Visitor >
+        class ResourceContainer, class ResourceExtensionFunction,
+        class DominanceFunction, class LabelAllocator, class Visitor >
     void r_c_shortest_paths_dispatch(const Graph& g,
         const VertexIndexMap& vertex_index_map,
         typename graph_traits< Graph >::vertex_descriptor s,
@@ -141,54 +141,54 @@ namespace detail
         std::vector<
             std::vector< typename graph_traits< Graph >::edge_descriptor > >&
             pareto_optimal_solutions,
-        std::vector< Resource_Container >& pareto_optimal_resource_containers,
+        std::vector< ResourceContainer >& pareto_optimal_resource_containers,
         bool b_all_pareto_optimal_solutions,
         // to initialize the first label/resource container
         // and to carry the type information
-        const Resource_Container& rc, Resource_Extension_Function& ref,
-        Dominance_Function& dominance,
+        const ResourceContainer& rc, ResourceExtensionFunction& ref,
+        DominanceFunction& dominance,
         // to specify the memory management strategy for the labels
-        Label_Allocator /*la*/, Visitor vis)
+        LabelAllocator /*la*/, Visitor vis)
     {
         pareto_optimal_resource_containers.clear();
         pareto_optimal_solutions.clear();
 
         size_t i_label_num = 0;
 #if defined(BOOST_NO_CXX11_ALLOCATOR)
-        typedef typename Label_Allocator::template rebind<
-            r_c_shortest_paths_label< Graph, Resource_Container > >::other
+        typedef typename LabelAllocator::template rebind<
+            r_c_shortest_paths_label< Graph, ResourceContainer > >::other
             LAlloc;
 #else
-        typedef typename std::allocator_traits< Label_Allocator >::
+        typedef typename std::allocator_traits< LabelAllocator >::
             template rebind_alloc<
-                r_c_shortest_paths_label< Graph, Resource_Container > >
-                LAlloc;
+                r_c_shortest_paths_label< Graph, ResourceContainer > >
+                label_allocator_type;
 #endif
-        LAlloc l_alloc;
+        label_allocator_type l_alloc;
         typedef std::shared_ptr<
-            r_c_shortest_paths_label< Graph, Resource_Container > >
-            Splabel;
-        std::priority_queue< Splabel, std::vector< Splabel >,
-            deref_greater< Splabel > >
+            r_c_shortest_paths_label< Graph, ResourceContainer > >
+            sp_label_type;
+        std::priority_queue< sp_label_type, std::vector< sp_label_type >,
+            deref_greater< sp_label_type > >
             unprocessed_labels;
 
         bool b_feasible = true;
-        Splabel splabel_first_label = std::allocate_shared<
-            r_c_shortest_paths_label< Graph, Resource_Container > >(l_alloc,
+        sp_label_type splabel_first_label = std::allocate_shared<
+            r_c_shortest_paths_label< Graph, ResourceContainer > >(l_alloc,
             i_label_num++, rc,
             std::shared_ptr<
-                r_c_shortest_paths_label< Graph, Resource_Container > >(),
+                r_c_shortest_paths_label< Graph, ResourceContainer > >(),
             typename graph_traits< Graph >::edge_descriptor(), s);
 
         unprocessed_labels.push(splabel_first_label);
-        std::vector< std::list< Splabel > > vec_vertex_labels_data(
+        std::vector< std::list< sp_label_type > > vec_vertex_labels_data(
             num_vertices(g));
         iterator_property_map<
-            typename std::vector< std::list< Splabel > >::iterator,
+            typename std::vector< std::list< sp_label_type > >::iterator,
             VertexIndexMap >
             vec_vertex_labels(vec_vertex_labels_data.begin(), vertex_index_map);
         vec_vertex_labels[s].push_back(splabel_first_label);
-        typedef std::vector< typename std::list< Splabel >::iterator >
+        typedef std::vector< typename std::list< sp_label_type >::iterator >
             vec_last_valid_positions_for_dominance_data_type;
         vec_last_valid_positions_for_dominance_data_type
             vec_last_valid_positions_for_dominance_data(num_vertices(g));
@@ -219,7 +219,7 @@ namespace detail
         while (!unprocessed_labels.empty()
             && vis.on_enter_loop(unprocessed_labels, g))
         {
-            Splabel cur_label = unprocessed_labels.top();
+            sp_label_type cur_label = unprocessed_labels.top();
             unprocessed_labels.pop();
             vis.on_label_popped(*cur_label, g);
             // an Splabel object in unprocessed_labels and the respective
@@ -239,20 +239,20 @@ namespace detail
                 typename boost::graph_traits< Graph >::vertex_descriptor
                     i_cur_resident_vertex
                     = cur_label->resident_vertex;
-                std::list< Splabel >& list_labels_cur_vertex
+                std::list< sp_label_type >& list_labels_cur_vertex
                     = get(vec_vertex_labels, i_cur_resident_vertex);
                 if (list_labels_cur_vertex.size() >= 2
                     && vec_last_valid_index_for_dominance[i_cur_resident_vertex]
                         < list_labels_cur_vertex.size())
                 {
-                    typename std::list< Splabel >::iterator outer_iter
+                    typename std::list< sp_label_type >::iterator outer_iter
                         = list_labels_cur_vertex.begin();
                     bool b_outer_iter_at_or_beyond_last_valid_pos_for_dominance
                         = false;
                     while (outer_iter != list_labels_cur_vertex.end())
                     {
-                        Splabel cur_outer_splabel = *outer_iter;
-                        typename std::list< Splabel >::iterator inner_iter
+                        sp_label_type cur_outer_splabel = *outer_iter;
+                        typename std::list< sp_label_type >::iterator inner_iter
                             = outer_iter;
                         if (!b_outer_iter_at_or_beyond_last_valid_pos_for_dominance
                             && outer_iter
@@ -276,13 +276,13 @@ namespace detail
                         bool b_outer_iter_erased = false;
                         while (inner_iter != list_labels_cur_vertex.end())
                         {
-                            Splabel cur_inner_splabel = *inner_iter;
+                            sp_label_type cur_inner_splabel = *inner_iter;
                             if (dominance(cur_outer_splabel
                                               ->cumulated_resource_consumption,
                                     cur_inner_splabel
                                         ->cumulated_resource_consumption))
                             {
-                                typename std::list< Splabel >::iterator buf
+                                typename std::list< sp_label_type >::iterator buf
                                     = inner_iter;
                                 ++inner_iter;
                                 list_labels_cur_vertex.erase(buf);
@@ -301,7 +301,7 @@ namespace detail
                                     cur_outer_splabel
                                         ->cumulated_resource_consumption))
                             {
-                                typename std::list< Splabel >::iterator buf
+                                typename std::list< sp_label_type >::iterator buf
                                     = outer_iter;
                                 ++outer_iter;
                                 list_labels_cur_vertex.erase(buf);
@@ -343,7 +343,7 @@ namespace detail
                 }
                 while (unprocessed_labels.size())
                 {
-                    Splabel l = unprocessed_labels.top();
+                    sp_label_type l = unprocessed_labels.top();
                     unprocessed_labels.pop();
                     // delete only dominated labels, because nondominated labels
                     // are deleted at the end of the function
@@ -365,8 +365,8 @@ namespace detail
                      oei != oei_end; ++oei)
                 {
                     b_feasible = true;
-                    Splabel new_label = std::allocate_shared<
-                        r_c_shortest_paths_label< Graph, Resource_Container > >(
+                    sp_label_type new_label = std::allocate_shared<
+                        r_c_shortest_paths_label< Graph, ResourceContainer > >(
                         l_alloc, i_label_num++,
                         cur_label->cumulated_resource_consumption, cur_label,
                         *oei, target(*oei, g));
@@ -395,14 +395,14 @@ namespace detail
                 cur_label.reset();
             }
         }
-        std::list< Splabel > dsplabels = get(vec_vertex_labels, t);
+        std::list< sp_label_type > dsplabels = get(vec_vertex_labels, t);
         if(!b_all_pareto_optimal_solutions)
         {
-            dsplabels.sort([](const Splabel& a, const Splabel& b)
+            dsplabels.sort([](const sp_label_type& a, const sp_label_type& b)
                 { return *a < *b; });
         }
-        typename std::list< Splabel >::const_iterator csi = dsplabels.begin();
-        typename std::list< Splabel >::const_iterator csi_end = dsplabels.end();
+        typename std::list< sp_label_type >::const_iterator csi = dsplabels.begin();
+        typename std::list< sp_label_type >::const_iterator csi_end = dsplabels.end();
         // if d could be reached from o
         if (!dsplabels.empty())
         {
@@ -411,7 +411,7 @@ namespace detail
                 std::vector< typename graph_traits< Graph >::edge_descriptor >
                     cur_pareto_optimal_path;
                 std::shared_ptr<
-                    r_c_shortest_paths_label< Graph, Resource_Container > >
+                    r_c_shortest_paths_label< Graph, ResourceContainer > >
                     p_cur_label = *csi;
                 pareto_optimal_resource_containers.push_back(
                     p_cur_label->cumulated_resource_consumption);
@@ -446,10 +446,10 @@ namespace detail
 
         BGL_FORALL_VERTICES_T(i, g, Graph)
         {
-            std::list< Splabel >& list_labels_cur_vertex = vec_vertex_labels[i];
-            typename std::list< Splabel >::iterator si
+            std::list< sp_label_type >& list_labels_cur_vertex = vec_vertex_labels[i];
+            typename std::list< sp_label_type >::iterator si
                 = list_labels_cur_vertex.begin();
-            const typename std::list< Splabel >::iterator si_end
+            const typename std::list< sp_label_type >::iterator si_end
                 = list_labels_cur_vertex.end();
             for (; si != si_end; ++si)
             {
@@ -500,10 +500,10 @@ typedef std::allocator< int > default_r_c_shortest_paths_allocator;
 // New r_c_shortest_paths functions (handle/interface)
 // first overload:
 // - return all pareto-optimal solutions
-// - specify Label_Allocator and Visitor arguments
+// - specify LabelAllocator and Visitor arguments
 template < class Graph, class VertexIndexMap,
-    class Resource_Container, class Resource_Extension_Function,
-    class Dominance_Function, class Label_Allocator, class Visitor >
+    class ResourceContainer, class ResourceExtensionFunction,
+    class DominanceFunction, class LabelAllocator, class Visitor >
 void r_c_shortest_paths(const Graph& g, const VertexIndexMap& vertex_index_map,
     typename graph_traits< Graph >::vertex_descriptor s,
     typename graph_traits< Graph >::vertex_descriptor t,
@@ -511,13 +511,13 @@ void r_c_shortest_paths(const Graph& g, const VertexIndexMap& vertex_index_map,
     std::vector<
         std::vector< typename graph_traits< Graph >::edge_descriptor > >&
         pareto_optimal_solutions,
-    std::vector< Resource_Container >& pareto_optimal_resource_containers,
+    std::vector< ResourceContainer >& pareto_optimal_resource_containers,
     // to initialize the first label/resource container
     // and to carry the type information
-    const Resource_Container& rc, const Resource_Extension_Function& ref,
-    const Dominance_Function& dominance,
+    const ResourceContainer& rc, const ResourceExtensionFunction& ref,
+    const DominanceFunction& dominance,
     // to specify the memory management strategy for the labels
-    Label_Allocator la, Visitor vis)
+    LabelAllocator la, Visitor vis)
 {
     r_c_shortest_paths_dispatch(g, vertex_index_map, s, t,
         pareto_optimal_solutions, pareto_optimal_resource_containers, true, rc,
@@ -527,28 +527,28 @@ void r_c_shortest_paths(const Graph& g, const VertexIndexMap& vertex_index_map,
 
 // second overload:
 // - return only one pareto-optimal solution
-// - specify Label_Allocator and Visitor arguments
+// - specify LabelAllocator and Visitor arguments
 template < class Graph, class VertexIndexMap,
-    class Resource_Container, class Resource_Extension_Function,
-    class Dominance_Function, class Label_Allocator, class Visitor >
+    class ResourceContainer, class ResourceExtensionFunction,
+    class DominanceFunction, class LabelAllocator, class Visitor >
 void r_c_shortest_paths(const Graph& g, const VertexIndexMap& vertex_index_map,
     typename graph_traits< Graph >::vertex_descriptor s,
     typename graph_traits< Graph >::vertex_descriptor t,
     std::vector< typename graph_traits< Graph >::edge_descriptor >&
         pareto_optimal_solution,
-    Resource_Container& pareto_optimal_resource_container,
+    ResourceContainer& pareto_optimal_resource_container,
     // to initialize the first label/resource container
     // and to carry the type information
-    const Resource_Container& rc, const Resource_Extension_Function& ref,
-    const Dominance_Function& dominance,
+    const ResourceContainer& rc, const ResourceExtensionFunction& ref,
+    const DominanceFunction& dominance,
     // to specify the memory management strategy for the labels
-    Label_Allocator la, Visitor vis)
+    LabelAllocator la, Visitor vis)
 {
     // each inner vector corresponds to a pareto-optimal path
     std::vector<
         std::vector< typename graph_traits< Graph >::edge_descriptor > >
         pareto_optimal_solutions;
-    std::vector< Resource_Container > pareto_optimal_resource_containers;
+    std::vector< ResourceContainer > pareto_optimal_resource_containers;
     r_c_shortest_paths_dispatch(g, vertex_index_map, s, t,
         pareto_optimal_solutions, pareto_optimal_resource_containers, false, rc,
         ref, dominance, la, vis);
@@ -562,10 +562,10 @@ void r_c_shortest_paths(const Graph& g, const VertexIndexMap& vertex_index_map,
 
 // third overload:
 // - return all pareto-optimal solutions
-// - use default Label_Allocator and Visitor
+// - use default LabelAllocator and Visitor
 template < class Graph, class VertexIndexMap,
-    class Resource_Container, class Resource_Extension_Function,
-    class Dominance_Function >
+    class ResourceContainer, class ResourceExtensionFunction,
+    class DominanceFunction >
 void r_c_shortest_paths(const Graph& g, const VertexIndexMap& vertex_index_map,
     typename graph_traits< Graph >::vertex_descriptor s,
     typename graph_traits< Graph >::vertex_descriptor t,
@@ -573,11 +573,11 @@ void r_c_shortest_paths(const Graph& g, const VertexIndexMap& vertex_index_map,
     std::vector<
         std::vector< typename graph_traits< Graph >::edge_descriptor > >&
         pareto_optimal_solutions,
-    std::vector< Resource_Container >& pareto_optimal_resource_containers,
+    std::vector< ResourceContainer >& pareto_optimal_resource_containers,
     // to initialize the first label/resource container
     // and to carry the type information
-    const Resource_Container& rc, const Resource_Extension_Function& ref,
-    const Dominance_Function& dominance)
+    const ResourceContainer& rc, const ResourceExtensionFunction& ref,
+    const DominanceFunction& dominance)
 {
     r_c_shortest_paths_dispatch(g, vertex_index_map, s, t,
         pareto_optimal_solutions, pareto_optimal_resource_containers, true, rc,
@@ -588,26 +588,26 @@ void r_c_shortest_paths(const Graph& g, const VertexIndexMap& vertex_index_map,
 
 // fourth overload:
 // - return only one pareto-optimal solution
-// - use default Label_Allocator and Visitor
+// - use default LabelAllocator and Visitor
 template < class Graph, class VertexIndexMap,
-    class Resource_Container, class Resource_Extension_Function,
-    class Dominance_Function >
+    class ResourceContainer, class ResourceExtensionFunction,
+    class DominanceFunction >
 void r_c_shortest_paths(const Graph& g, const VertexIndexMap& vertex_index_map,
     typename graph_traits< Graph >::vertex_descriptor s,
     typename graph_traits< Graph >::vertex_descriptor t,
     std::vector< typename graph_traits< Graph >::edge_descriptor >&
         pareto_optimal_solution,
-    Resource_Container& pareto_optimal_resource_container,
+    ResourceContainer& pareto_optimal_resource_container,
     // to initialize the first label/resource container
     // and to carry the type information
-    const Resource_Container& rc, const Resource_Extension_Function& ref,
-    const Dominance_Function& dominance)
+    const ResourceContainer& rc, const ResourceExtensionFunction& ref,
+    const DominanceFunction& dominance)
 {
     // each inner vector corresponds to a pareto-optimal path
     std::vector<
         std::vector< typename graph_traits< Graph >::edge_descriptor > >
         pareto_optimal_solutions;
-    std::vector< Resource_Container > pareto_optimal_resource_containers;
+    std::vector< ResourceContainer > pareto_optimal_resource_containers;
     r_c_shortest_paths_dispatch(g, vertex_index_map, s, t,
         pareto_optimal_solutions, pareto_optimal_resource_containers, false, rc,
         ref, dominance, default_r_c_shortest_paths_allocator(),
@@ -626,10 +626,10 @@ void r_c_shortest_paths(const Graph& g, const VertexIndexMap& vertex_index_map,
 
 // first overload:
 // - return all pareto-optimal solutions
-// - specify Label_Allocator and Visitor arguments
+// - specify LabelAllocator and Visitor arguments
 template < class Graph, class VertexIndexMap, class EdgeIndexMap,
-    class Resource_Container, class Resource_Extension_Function,
-    class Dominance_Function, class Label_Allocator, class Visitor >
+    class ResourceContainer, class ResourceExtensionFunction,
+    class DominanceFunction, class LabelAllocator, class Visitor >
 BOOST_DEPRECATED("edge_index_map is unused; drop it and call the 5-argument r_c_shortest_paths overload. Removal planned for Boost 1.95.")
 void r_c_shortest_paths(const Graph& g, const VertexIndexMap& vertex_index_map,
     const EdgeIndexMap& edge_index_map,
@@ -639,13 +639,13 @@ void r_c_shortest_paths(const Graph& g, const VertexIndexMap& vertex_index_map,
     std::vector<
         std::vector< typename graph_traits< Graph >::edge_descriptor > >&
         pareto_optimal_solutions,
-    std::vector< Resource_Container >& pareto_optimal_resource_containers,
+    std::vector< ResourceContainer >& pareto_optimal_resource_containers,
     // to initialize the first label/resource container
     // and to carry the type information
-    const Resource_Container& rc, const Resource_Extension_Function& ref,
-    const Dominance_Function& dominance,
+    const ResourceContainer& rc, const ResourceExtensionFunction& ref,
+    const DominanceFunction& dominance,
     // to specify the memory management strategy for the labels
-    Label_Allocator la, Visitor vis)
+    LabelAllocator la, Visitor vis)
 {
     r_c_shortest_paths(g, vertex_index_map, s, t,
         pareto_optimal_solutions, pareto_optimal_resource_containers, rc,
@@ -654,10 +654,10 @@ void r_c_shortest_paths(const Graph& g, const VertexIndexMap& vertex_index_map,
 
 // second overload:
 // - return only one pareto-optimal solution
-// - specify Label_Allocator and Visitor arguments
+// - specify LabelAllocator and Visitor arguments
 template < class Graph, class VertexIndexMap, class EdgeIndexMap,
-    class Resource_Container, class Resource_Extension_Function,
-    class Dominance_Function, class Label_Allocator, class Visitor >
+    class ResourceContainer, class ResourceExtensionFunction,
+    class DominanceFunction, class LabelAllocator, class Visitor >
 BOOST_DEPRECATED("edge_index_map is unused; drop it and call the 5-argument r_c_shortest_paths overload. Removal planned for Boost 1.95.")
 void r_c_shortest_paths(const Graph& g, const VertexIndexMap& vertex_index_map,
     const EdgeIndexMap& edge_index_map,
@@ -665,23 +665,23 @@ void r_c_shortest_paths(const Graph& g, const VertexIndexMap& vertex_index_map,
     typename graph_traits< Graph >::vertex_descriptor t,
     std::vector< typename graph_traits< Graph >::edge_descriptor >&
         pareto_optimal_solution,
-    Resource_Container& pareto_optimal_resource_container,
+    ResourceContainer& pareto_optimal_resource_container,
     // to initialize the first label/resource container
     // and to carry the type information
-    const Resource_Container& rc, const Resource_Extension_Function& ref,
-    const Dominance_Function& dominance,
+    const ResourceContainer& rc, const ResourceExtensionFunction& ref,
+    const DominanceFunction& dominance,
     // to specify the memory management strategy for the labels
-    Label_Allocator la, Visitor vis)
+    LabelAllocator la, Visitor vis)
 {
     r_c_shortest_paths(g, vertex_index_map, s, t, pareto_optimal_solution, pareto_optimal_resource_container, rc, ref, dominance, la, vis);
 }
 
 // third overload:
 // - return all pareto-optimal solutions
-// - use default Label_Allocator and Visitor
+// - use default LabelAllocator and Visitor
 template < class Graph, class VertexIndexMap, class EdgeIndexMap,
-    class Resource_Container, class Resource_Extension_Function,
-    class Dominance_Function >
+    class ResourceContainer, class ResourceExtensionFunction,
+    class DominanceFunction >
 BOOST_DEPRECATED("edge_index_map is unused; drop it and call the 5-argument r_c_shortest_paths overload. Removal planned for Boost 1.95.")
 void r_c_shortest_paths(const Graph& g, const VertexIndexMap& vertex_index_map,
     const EdgeIndexMap& edge_index_map,
@@ -691,11 +691,11 @@ void r_c_shortest_paths(const Graph& g, const VertexIndexMap& vertex_index_map,
     std::vector<
         std::vector< typename graph_traits< Graph >::edge_descriptor > >&
         pareto_optimal_solutions,
-    std::vector< Resource_Container >& pareto_optimal_resource_containers,
+    std::vector< ResourceContainer >& pareto_optimal_resource_containers,
     // to initialize the first label/resource container
     // and to carry the type information
-    const Resource_Container& rc, const Resource_Extension_Function& ref,
-    const Dominance_Function& dominance)
+    const ResourceContainer& rc, const ResourceExtensionFunction& ref,
+    const DominanceFunction& dominance)
 {
     r_c_shortest_paths(g, vertex_index_map, s, t,
         pareto_optimal_solutions, pareto_optimal_resource_containers, rc,
@@ -705,10 +705,10 @@ void r_c_shortest_paths(const Graph& g, const VertexIndexMap& vertex_index_map,
 
 // fourth overload:
 // - return only one pareto-optimal solution
-// - use default Label_Allocator and Visitor
+// - use default LabelAllocator and Visitor
 template < class Graph, class VertexIndexMap, class EdgeIndexMap,
-    class Resource_Container, class Resource_Extension_Function,
-    class Dominance_Function >
+    class ResourceContainer, class ResourceExtensionFunction,
+    class DominanceFunction >
 BOOST_DEPRECATED("edge_index_map is unused; drop it and call the 5-argument r_c_shortest_paths overload. Removal planned for Boost 1.95.")
 void r_c_shortest_paths(const Graph& g, const VertexIndexMap& vertex_index_map,
     const EdgeIndexMap& edge_index_map,
@@ -716,11 +716,11 @@ void r_c_shortest_paths(const Graph& g, const VertexIndexMap& vertex_index_map,
     typename graph_traits< Graph >::vertex_descriptor t,
     std::vector< typename graph_traits< Graph >::edge_descriptor >&
         pareto_optimal_solution,
-    Resource_Container& pareto_optimal_resource_container,
+    ResourceContainer& pareto_optimal_resource_container,
     // to initialize the first label/resource container
     // and to carry the type information
-    const Resource_Container& rc, const Resource_Extension_Function& ref,
-    const Dominance_Function& dominance)
+    const ResourceContainer& rc, const ResourceExtensionFunction& ref,
+    const DominanceFunction& dominance)
 {
     r_c_shortest_paths(g, vertex_index_map, s, t, pareto_optimal_solution, pareto_optimal_resource_container, rc, ref, dominance);
 }
@@ -730,20 +730,20 @@ void r_c_shortest_paths(const Graph& g, const VertexIndexMap& vertex_index_map,
 
 
 // check_r_c_path function
-template < class Graph, class Resource_Container,
-    class Resource_Extension_Function >
+template < class Graph, class ResourceContainer,
+    class ResourceExtensionFunction >
 void check_r_c_path(const Graph& g,
     const std::vector< typename graph_traits< Graph >::edge_descriptor >&
         ed_vec_path,
-    const Resource_Container& initial_resource_levels,
+    const ResourceContainer& initial_resource_levels,
     // if true, computed accumulated final resource levels must
     // be equal to desired_final_resource_levels
     // if false, computed accumulated final resource levels must
     // be less than or equal to desired_final_resource_levels
     bool b_result_must_be_equal_to_desired_final_resource_levels,
-    const Resource_Container& desired_final_resource_levels,
-    Resource_Container& actual_final_resource_levels,
-    const Resource_Extension_Function& ref, bool& b_is_a_path_at_all,
+    const ResourceContainer& desired_final_resource_levels,
+    ResourceContainer& actual_final_resource_levels,
+    const ResourceExtensionFunction& ref, bool& b_is_a_path_at_all,
     bool& b_feasible, bool& b_correctly_extended,
     typename graph_traits< Graph >::edge_descriptor& ed_last_extended_arc)
 {
@@ -773,7 +773,7 @@ void check_r_c_path(const Graph& g,
     b_is_a_path_at_all = true;
     b_feasible = true;
     b_correctly_extended = false;
-    Resource_Container current_resource_levels = initial_resource_levels;
+    ResourceContainer current_resource_levels = initial_resource_levels;
     actual_final_resource_levels = current_resource_levels;
     for (size_t i = 0; i < i_size_ed_vec_path; ++i)
     {


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [ ] Bug fix
- [ ] New feature or API addition
- [x] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

* rename template parameter types as pascal case
* rename some typedef types as snake case.
* update docs
* NO logic changes, pure renaming

### Motivation

I would like to help modernizing the RCSP code, and I noticed that the naming does not match the convention. It is a small first step in make the code easier to read and more modern.

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->

### Checklist

- [x] Existing tests pass (`b2` in the `test/` directory).
- [ ] New behavior is covered by a test, or this is a docs / build / refactor change.
- [x] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.
