### PR TITLE
Clean up compiler warnings from Apple clang.

### DIFF
--- a/include/boost/graph/stanford_graph.hpp
+++ b/include/boost/graph/stanford_graph.hpp
@@ -50,6 +50,7 @@ extern "C"
 #include <gb_games.h> /* graphs based on football scores */
 #undef ap /* avoid name clash with BGL parameter */
     // ap ==> Vertex::u.I
+#undef MAX_N /* redefinition in gb_miles.h below; unused */
 #include <gb_gates.h> /* graphs based on logic circuits */
 #undef val /* avoid name clash with g++ headerfile stl_tempbuf.h */
     // val ==> Vertex::x.I
@@ -401,26 +402,26 @@ public:
 
 template < class Tag >
 inline sgb_vertex_util_map< Tag, const typename Tag::type& > get_property_map(
-    Tag, const sgb_graph_ptr& g, vertex_property_tag)
+    Tag, const sgb_graph_ptr&, vertex_property_tag)
 {
     return sgb_vertex_util_map< Tag, const typename Tag::type& >();
 }
 template < class Tag >
 inline sgb_vertex_util_map< Tag, typename Tag::type& > get_property_map(
-    Tag, sgb_graph_ptr& g, vertex_property_tag)
+    Tag, sgb_graph_ptr&, vertex_property_tag)
 {
     return sgb_vertex_util_map< Tag, typename Tag::type& >();
 }
 
 template < class Tag >
 inline sgb_edge_util_map< Tag, const typename Tag::type& > get_property_map(
-    Tag, const sgb_graph_ptr& g, edge_property_tag)
+    Tag, const sgb_graph_ptr&, edge_property_tag)
 {
     return sgb_edge_util_map< Tag, const typename Tag::type& >();
 }
 template < class Tag >
 inline sgb_edge_util_map< Tag, typename Tag::type& > get_property_map(
-    Tag, sgb_graph_ptr& g, edge_property_tag)
+    Tag, sgb_graph_ptr&, edge_property_tag)
 {
     return sgb_edge_util_map< Tag, typename Tag::type& >();
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
        Might be of interest for issue #496.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [x] Bug fix
- [ ] New feature or API addition
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

<!-- A short summary of the change. -->
Fixes compiler warnings in `boost/stanford_graph.hpp` issued by **Apple clang version 21.0.0 (clang-2100.1.1.101)**.

In contrast to GCC 16, this compiler issues several warnings in <boost/stanford_graph.hpp>:

1.  Redefinition of preprocessor item `MAX_N` in `gb_games.h` (120) and `gb_miles.h` (128). Although neither of these values is actually used in the four SGB examples, we let the latter stand for `miles_span.cpp`.

2. In four templates, parameter `g` is not used.

### Motivation

<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->
Conventionally, I like to treat compiler warnings as bugs. :o)

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->

### Checklist

- [ ] Existing tests pass (`b2` in the `test/` directory).
- [ ] New behavior is covered by a test, or this is a docs / build / refactor change.
- [ ] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.
