### PR TITLE
refactor: drop Boost.Algorithm

### DIFF
--- a/include/boost/graph/bc_clustering.hpp
+++ b/include/boost/graph/bc_clustering.hpp
@@ -9,7 +9,6 @@
 #ifndef BOOST_GRAPH_BETWEENNESS_CENTRALITY_CLUSTERING_HPP
 #define BOOST_GRAPH_BETWEENNESS_CENTRALITY_CLUSTERING_HPP
 
-#include <boost/algorithm/minmax_element.hpp>
 #include <boost/graph/betweenness_centrality.hpp>
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/graph_utility.hpp>
@@ -132,8 +131,11 @@ void betweenness_centrality_clustering(MutableGraph& g, Done done,
             edge_centrality_map(edge_centrality)
                 .vertex_index_map(vertex_index));
         std::pair< edge_iterator, edge_iterator > edges_iters = edges(g);
-        edge_descriptor e
-            = *boost::first_max_element(edges_iters.first, edges_iters.second, cmp);
+        auto max_edge_it = edges_iters.first;
+        for (auto edge_it = edges_iters.first; edge_it != edges_iters.second; ++edge_it)
+            if (cmp(*max_edge_it, *edge_it))
+                max_edge_it = edge_it;
+        edge_descriptor e = *max_edge_it;
         is_done = done(get(edge_centrality, e), e, g);
         if (!is_done)
             remove_edge(e, g);

--- a/include/boost/graph/graphviz.hpp
+++ b/include/boost/graph/graphviz.hpp
@@ -32,7 +32,6 @@
 #include <boost/config/pragma_message.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/static_assert.hpp>
-#include <boost/algorithm/string/replace.hpp>
 
 namespace boost
 {
@@ -114,7 +113,10 @@ template < typename T > inline std::string escape_dot_string(const T& obj)
     }
     else
     {
-        boost::algorithm::replace_all(s, "\"", "\\\"");
+        for (auto pos = s.find('"'); pos != std::string::npos; pos = s.find('"', pos + 2))
+        {
+            s.insert(pos, 1, '\\');
+        }
         return "\"" + s + "\"";
     }
 }

--- a/include/boost/graph/howard_cycle_ratio.hpp
+++ b/include/boost/graph/howard_cycle_ratio.hpp
@@ -22,7 +22,6 @@
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/graph_concepts.hpp>
 #include <boost/concept/assert.hpp>
-#include <boost/algorithm/minmax_element.hpp>
 
 /** @file howard_cycle_ratio.hpp
  * @brief The implementation of the maximum/minimum cycle ratio/mean algorithm.
@@ -239,9 +238,10 @@ namespace detail
             for (boost::tie(vi, vie) = vertices(m_g); vi != vie; ++vi)
             {
                 boost::tie(oei, oeie) = out_edges(*vi, m_g);
-                auto mei = boost::first_max_element(oei, oeie,
-                    [this](const auto& first, const auto& second)
-                    { return m_cmp(m_ew1m[first], m_ew1m[second]); });
+                auto mei = oei;
+                for (auto edge_it = oei; edge_it != oeie; ++edge_it)
+                    if (m_cmp(m_ew1m[*mei], m_ew1m[*edge_it]))
+                        mei = edge_it;
                 if (mei == oeie)
                 {
                     if (m_sink == graph_traits< Graph >().null_vertex())

--- a/include/boost/graph/topology.hpp
+++ b/include/boost/graph/topology.hpp
@@ -10,7 +10,7 @@
 #ifndef BOOST_GRAPH_TOPOLOGY_HPP
 #define BOOST_GRAPH_TOPOLOGY_HPP
 
-#include <boost/algorithm/minmax.hpp>
+#include <algorithm>
 #include <boost/config.hpp> // For BOOST_STATIC_CONSTANT
 #include <boost/config/no_tr1/cmath.hpp>
 #include <cmath>

--- a/src/read_graphviz_new.cpp
+++ b/src/read_graphviz_new.cpp
@@ -32,8 +32,8 @@
 #include <boost/property_map/dynamic_property_map.hpp>
 #include <boost/graph/graph_traits.hpp>
 #include <boost/detail/workaround.hpp>
-#include <boost/algorithm/string/case_conv.hpp>
 #include <cstdlib>
+#include <cctype>
 #include <algorithm>
 #include <exception> // for std::exception
 #include <iostream>
@@ -260,7 +260,13 @@ namespace read_graphviz_detail
             if (found)
             {
                 std::string str = results[1].str();
-                std::string str_lower = boost::algorithm::to_lower_copy(str);
+                std::string str_lower = str;
+                std::transform(
+                    str_lower.begin(), 
+                    str_lower.end(),
+                    str_lower.begin(), 
+                    [](unsigned char c) { return static_cast< char >(std::tolower(c)); }
+                );
                 begin = results.suffix().first;
                 if (str_lower == "strict")
                 {

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -144,6 +144,7 @@ alias graph_test_regular :
     [ run mean_geodesic.cpp ]
     [ run eccentricity.cpp ]
     [ run clustering_coefficient.cpp ]
+    [ run bc_clustering_test.cpp ]
     [ run core_numbers_test.cpp ]
     [ run louvain_quality_function_test.cpp ]
     [ run louvain_clustering_test.cpp ]

--- a/test/all_planar_input_files_test.cpp
+++ b/test/all_planar_input_files_test.cpp
@@ -30,7 +30,6 @@ This test needs to be linked against Boost.Filesystem.
 #include <boost/lexical_cast.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/filesystem.hpp>
-#include <boost/algorithm/string.hpp>
 #include <boost/core/lightweight_test.hpp>
 
 #include <boost/graph/adjacency_list.hpp>
@@ -73,7 +72,14 @@ void read_dimacs(Graph& g, const std::string& filename)
             continue;
 
         std::vector< std::string > v;
-        split(v, buffer, is_any_of(" \t\n"));
+        for (std::string::size_type start = 0;;)
+        {
+            std::string::size_type pos = s.find_first_of(" \t\n", start);
+            v.push_back(s.substr(start, pos - start));
+            if (pos == std::string::npos)
+                break;
+            start = pos + 1;
+        }
 
         if (v[0] == "p")
         {

--- a/test/bc_clustering_test.cpp
+++ b/test/bc_clustering_test.cpp
@@ -1,0 +1,55 @@
+// Copyright (C) 2026 Arnaud Becheler
+//
+// Use, modification and distribution is subject to the Boost Software
+// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/graph/bc_clustering.hpp>
+#include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/connected_components.hpp>
+#include <boost/core/lightweight_test.hpp>
+#include <vector>
+
+struct EdgeCentrality
+{
+    double centrality;
+};
+
+using Graph = boost::adjacency_list< boost::vecS, boost::vecS,
+    boost::undirectedS, boost::no_property, EdgeCentrality >;
+
+struct stop_after_first_removal
+{
+    int calls = 0;
+    template < typename Edge, typename G >
+    bool operator()(double, Edge, const G&)
+    {
+        return calls++ > 0;
+    }
+};
+
+int main()
+{
+    Graph g(6);
+    boost::add_edge(0, 1, g);
+    boost::add_edge(1, 2, g);
+    boost::add_edge(0, 2, g);
+    boost::add_edge(3, 4, g);
+    boost::add_edge(4, 5, g);
+    boost::add_edge(3, 5, g);
+    boost::add_edge(2, 3, g);
+
+    auto done = stop_after_first_removal();
+    auto centrality_map = boost::get(&EdgeCentrality::centrality, g);
+    boost::betweenness_centrality_clustering(g, done, centrality_map);
+
+    auto bridge = boost::edge(2, 3, g);
+    BOOST_TEST(!bridge.second);
+    BOOST_TEST_EQ(boost::num_edges(g), 6u);
+
+    std::vector< int > component(boost::num_vertices(g));
+    auto component_map = &component[0];
+    BOOST_TEST_EQ(boost::connected_components(g, component_map), 2);
+
+    return boost::report_errors();
+}

--- a/test/parallel_edges_loops_test.cpp
+++ b/test/parallel_edges_loops_test.cpp
@@ -28,7 +28,6 @@ This test needs to be linked against Boost.Filesystem.
 #include <boost/lexical_cast.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/filesystem.hpp>
-#include <boost/algorithm/string.hpp>
 #include <boost/core/lightweight_test.hpp>
 
 #include <boost/graph/adjacency_list.hpp>
@@ -90,7 +89,14 @@ void read_dimacs(Graph& g, const std::string& filename)
             continue;
 
         std::vector< std::string > v;
-        split(v, buffer, is_any_of(" \t\n"));
+        for (std::string::size_type start = 0;;)
+        {
+            std::string::size_type pos = s.find_first_of(" \t\n", start);
+            v.push_back(s.substr(start, pos - start));
+            if (pos == std::string::npos)
+                break;
+            start = pos + 1;
+        }
 
         if (v[0] == "p")
         {


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [ ] Bug fix
- [ ] New feature or API addition
- [x] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

<!-- A short summary of the change. -->

- `topology.hpp`: replaced `algorithm/minmax.hpp` include with `<algorithm>`
- `howard_cycle_ratio.hpp` and `bc_clustering.hpp`: replaced `boost::first_max_element` with an explicit first-max loop
- `graphviz.hpp`: replaced `boost::algorithm::replace_all` with a quote-escape loop
- `read_graphviz_new.cpp`: replaced `boost::algorithm::to_lower_copy` with `std::transform`
- `parallel_edges_loops_test.cpp` and `all_planar_input_files_test.cpp`: replaced `boost::split` with a loop
- Added `test/bc_clustering_test.cpp`: guards the max-edge pick (bridge removed, graph splits into 2 components)

`std::max_element` is not usable here: it requires a ForwardIterator, and libc++ enforces that with a hard static_assert, but BGL's edge iterators declare a category that does not satisfy it. `boost::first_max_element` had no such check, so the replacement is a short explicit loop instead.

### Motivation

<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->

Boost.Algorithm adds 30 dependencies for something that STL and short loops can do easily.


### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->

### Checklist

- [x] Existing tests pass (`b2` in the `test/` directory).
- [x] New behavior is covered by a test, or this is a docs / build / refactor change.
- [x] Documentation was updated if user-facing behavior changed.
- [x] No new compiler warnings on the platforms I built against.
