### PR TITLE
fix: remove Boost.Range dead weight

### DIFF
--- a/include/boost/graph/louvain_clustering.hpp
+++ b/include/boost/graph/louvain_clustering.hpp
@@ -16,7 +16,6 @@
 
 #include <boost/property_map/property_map.hpp>
 #include <boost/property_map/vector_property_map.hpp>
-#include <boost/range/iterator_range.hpp>
 
 #include <boost/assert.hpp>
 #include <boost/static_assert.hpp>

--- a/include/boost/graph/vector_as_graph.hpp
+++ b/include/boost/graph/vector_as_graph.hpp
@@ -20,7 +20,6 @@
 #include <cstddef>
 #include <iterator>
 #include <boost/iterator/counting_iterator.hpp>
-#include <boost/range/irange.hpp>
 #include <boost/graph/graph_traits.hpp>
 #include <boost/property_map/property_map.hpp>
 #include <boost/graph/properties.hpp>

--- a/test/louvain_clustering_test.cpp
+++ b/test/louvain_clustering_test.cpp
@@ -10,6 +10,7 @@
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/louvain_clustering.hpp>
 #include <boost/graph/louvain_quality_functions.hpp>
+#include <boost/range/iterator_range.hpp>
 #include <boost/core/lightweight_test.hpp>
 #include <boost/unordered/unordered_flat_map.hpp>
 #include <cmath>


### PR DESCRIPTION
<!--
Thanks for contributing to Boost.Graph! A few notes before you fill this in:

* Target the `develop` branch.
* New contributions must be licensed under the
  [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt).
* Please link any related issue with `Fixes #N` or `Refs #N`.
-->

### Before submitting

- [x] This PR targets the `develop` branch.
- [x] I searched for an existing PR or issue covering the same change.
- [x] My contribution is licensed under the Boost Software License 1.0.

### Type of change

- [ ] Bug fix
- [ ] New feature or API addition
- [x] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build, CI, or tooling
- [ ] Other (specify below)

### Does this PR introduce a breaking change?

- [ ] Yes (describe migration impact below)
- [x] No

### What this PR does

<!-- A short summary of the change. -->

Remove dead includes related to Boost.Range.

### Motivation

<!-- Why is this needed? Link related issue with `Fixes #N` or `Refs #N`. -->

Cleaning.

### Testing

<!--
How did you verify the change? Which compilers and standard libraries did
you build against? Were new tests added under `test/`?
-->

### Checklist

- [] Existing tests pass (`b2` in the `test/` directory).
- [x] New behavior is covered by a test, or this is a docs / build / refactor change.
- [x] Documentation was updated if user-facing behavior changed.
- [] No new compiler warnings on the platforms I built against.
